### PR TITLE
Contract test service.

### DIFF
--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const { Log } = require('./log');
+const { newSdkClientEntity, badCommandError } = require('./sdkClientEntity');
+
+const app = express();
+let server = null;
+
+const port = 8000;
+
+let clientCounter = 0;
+const clients = {};
+
+const mainLog = Log('service');
+
+app.use(bodyParser.json());
+
+app.get('/', (req, res) => {
+  res.header('Content-Type', 'application/json');
+  res.json({
+    capabilities: [
+      'server-side',
+      'all-flags-client-side-only',
+      'all-flags-details-only-for-tracked-flags',
+      'all-flags-with-reasons',
+      'tags',
+    ],
+  });
+});
+
+app.delete('/', (req, res) => {
+  mainLog.info('Test service has told us to exit');
+  res.status(204);
+  res.send();
+
+  // Defer the following actions till after the response has been sent
+  setTimeout(() => {
+    server.close(() => process.exit());
+    // We force-quit with process.exit because, even after closing the server, there could be some
+    // scheduled tasks lingering if an SDK instance didn't get cleaned up properly, and we don't want
+    // that to prevent us from quitting.
+  }, 1);
+});
+
+app.post('/', async (req, res) => {
+  const options = req.body;
+
+  clientCounter += 1;
+  const clientId = clientCounter.toString();
+  const resourceUrl = `/clients/${clientId}`;
+
+  try {
+    const client = await newSdkClientEntity(options);
+    clients[clientId] = client;
+
+    res.status(201);
+    res.set('Location', resourceUrl);
+  } catch (e) {
+    res.status(500);
+    const message = e.message || JSON.stringify(e);
+    mainLog.error('Error creating client: ' + message);
+    res.write(message);
+  }
+  res.send();
+});
+
+app.post('/clients/:id', async (req, res) => {
+  const client = clients[req.params.id];
+  if (!client) {
+    res.status(404);
+  } else {
+    try {
+      const respValue = await client.doCommand(req.body);
+      if (respValue) {
+        res.status(200);
+        res.write(JSON.stringify(respValue));
+      } else {
+        res.status(204);
+      }
+    } catch (e) {
+      const isBadRequest = e === badCommandError;
+      res.status(isBadRequest ? 400 : 500);
+      res.write(e.message || JSON.stringify(e));
+      if (!isBadRequest && e.stack) {
+        console.log(e.stack);
+      }
+    }
+  }
+  res.send();
+});
+
+app.delete('/clients/:id', async (req, res) => {
+  const client = clients[req.params.id];
+  if (!client) {
+    res.status(404);
+    res.send();
+  } else {
+    client.close();
+    delete clients[req.params.id];
+    res.status(204);
+    res.send();
+  }
+});
+
+server = app.listen(port, () => {
+  console.log('Listening on port %d', port);
+});

--- a/contract-tests/log.js
+++ b/contract-tests/log.js
@@ -1,0 +1,23 @@
+const ld = require('platform-node');
+
+function Log(tag) {
+  function doLog(level, message) {
+    console.log(new Date().toISOString() + ` [${tag}] ${level}: ${message}`);
+  }
+  return {
+    info: message => doLog('info', message),
+    error: message => doLog('error', message),
+  };
+}
+
+function sdkLogger(tag) {
+  return ld.basicLogger({
+    level: 'debug',
+    destination: line => {
+      console.log(new Date().toISOString() + ` [${tag}.sdk] ${line}`);
+    },
+  });
+}
+
+module.exports.Log = Log;
+module.exports.sdkLogger = sdkLogger;

--- a/contract-tests/package.json
+++ b/contract-tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "platform-node-sdk-contract-tests",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node --inspect index.js"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "platform-node": "file:../platform-node"
+  }
+}

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -1,0 +1,110 @@
+const ld = require('platform-node');
+
+const { Log, sdkLogger } = require('./log');
+
+const badCommandError = new Error('unsupported command');
+
+function makeSdkConfig(options, tag) {
+  const cf = {
+    logger: sdkLogger(tag),
+  };
+  const maybeTime = seconds => (seconds === undefined || seconds === null ? undefined : seconds / 1000);
+  if (options.streaming) {
+    cf.streamUri = options.streaming.baseUri;
+    cf.streamInitialReconnectDelay = maybeTime(options.streaming.initialRetryDelayMs);
+  }
+  if (options.events) {
+    cf.allAttributesPrivate = options.events.allAttributesPrivate;
+    cf.eventsUri = options.events.baseUri;
+    cf.capacity = options.events.capacity;
+    cf.diagnosticOptOut = !options.events.enableDiagnostics;
+    cf.flushInterval = maybeTime(options.events.flushIntervalMs);
+    cf.privateAttributes = options.events.globalPrivateAttributes;
+  }
+  if (options.tags) {
+    cf.application = {
+      id: options.tags.applicationId,
+      version: options.tags.applicationVersion,
+    };
+  }
+  return cf;
+}
+
+async function newSdkClientEntity(options) {
+  const c = {};
+  const log = Log(options.tag);
+
+  log.info('Creating client with configuration: ' + JSON.stringify(options.configuration));
+  const timeout =
+    options.configuration.startWaitTimeMs !== null && options.configuration.startWaitTimeMs !== undefined
+      ? options.configuration.startWaitTimeMs
+      : 5000;
+  const client = ld.init(
+    options.configuration.credential || 'unknown-sdk-key',
+    makeSdkConfig(options.configuration, options.tag)
+  );
+  try {
+    await Promise.race([client.waitForInitialization(), new Promise(resolve => setTimeout(resolve, timeout))]);
+  } catch (_) {
+    // if waitForInitialization() rejects, the client failed to initialize, see next line
+  }
+  if (!client.initialized() && !options.configuration.initCanFail) {
+    client.close();
+    throw new Error('client initialization failed');
+  }
+
+  c.close = () => {
+    client.close();
+    log.info('Test ended');
+  };
+
+  c.doCommand = async params => {
+    log.info('Received command: ' + params.command);
+    switch (params.command) {
+      case 'evaluate': {
+        const pe = params.evaluate;
+        if (pe.detail) {
+          return await client.variationDetail(pe.flagKey, pe.context, pe.defaultValue);
+        } else {
+          const value = await client.variation(pe.flagKey, pe.context, pe.defaultValue);
+          return { value };
+        }
+      }
+
+      case 'evaluateAll': {
+        const pea = params.evaluateAll;
+        const eao = {
+          clientSideOnly: pea.clientSideOnly,
+          detailsOnlyForTrackedFlags: pea.detailsOnlyForTrackedFlags,
+          withReasons: pea.withReasons,
+        };
+        return { state: await client.allFlagsState(pea.context, eao) };
+      }
+
+      case 'identifyEvent':
+        client.identify(params.identifyEvent.context);
+        return undefined;
+
+      case 'customEvent': {
+        const pce = params.customEvent;
+        client.track(pce.eventKey, pce.context, pce.data, pce.metricValue);
+        return undefined;
+      }
+
+      case 'flushEvents':
+        client.flush();
+        return undefined;
+
+      case 'getBigSegmentStoreStatus':
+        return undefined;
+
+      default:
+        throw badCommandError;
+    }
+  };
+
+  return c;
+}
+
+module.exports.newSdkClientEntity = newSdkClientEntity;
+module.exports.badCommandError = badCommandError;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
-    "coverage": "npm run test -- --coverage"
+    "coverage": "npm run test -- --coverage",
+    "contract-test-service": "npm --prefix contract-tests install && npm --prefix contract-tests start",
+    "contract-test-harness": "curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/master/downloader/run.sh \\ | VERSION=v1 PARAMS=\"-url http://localhost:8000 -debug -stop-service-at-end $TEST_HARNESS_PARAMS\" sh",
+    "contract-tests": "npm run contract-test-service & npm run contract-test-harness"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.22.0",

--- a/platform-node/src/LDClientNode.ts
+++ b/platform-node/src/LDClientNode.ts
@@ -13,7 +13,7 @@ class LDClientNode extends LDClientImpl {
   override bigSegmentStoreStatusProvider:
   InstanceType<typeof BigSegmentStoreStatusProviderNode>;
 
-  constructor(options: LDOptions) {
+  constructor(private sdkKey: string, options: LDOptions) {
     super(new NodePlatform(options));
     this.bigSegmentStoreStatusProvider = new BigSegmentStoreStatusProviderNode();
   }

--- a/platform-node/src/index.ts
+++ b/platform-node/src/index.ts
@@ -1,3 +1,7 @@
+import {
+  BasicLogger, BasicLoggerOptions, LDLogger, LDOptions, LDClient,
+} from '@launchdarkly/js-server-sdk-common';
+import { EventEmitter } from 'events';
 import LDClientImpl from './LDClientNode';
 import BigSegmentStoreStatusProviderNode from './BigSegmentsStoreStatusProviderNode';
 
@@ -8,3 +12,11 @@ export * from '@launchdarkly/js-server-sdk-common';
 
 export { LDClient } from './api';
 export { LDClientImpl, BigSegmentStoreStatusProviderNode };
+
+export function init(sdkKey: string, options: LDOptions): LDClient & EventEmitter {
+  return new LDClientImpl(sdkKey, options);
+}
+
+export function basicLogger(options: BasicLoggerOptions): LDLogger {
+  return new BasicLogger(options);
+}

--- a/server-sdk-common/src/index.ts
+++ b/server-sdk-common/src/index.ts
@@ -3,6 +3,8 @@ import BigSegmentStoreStatusProviderImpl from './BigSegmentStatusProviderImpl';
 
 export * as platform from './platform';
 export * from './api';
+export * from '@launchdarkly/js-sdk-common';
 
-export { LDClientImpl };
-export { BigSegmentStoreStatusProviderImpl };
+export {
+  LDClientImpl, BigSegmentStoreStatusProviderImpl,
+};


### PR DESCRIPTION
This is a direct copy of the contract test service from node. It has not been re-written as TS yet. Doing it this way gets something that can run right away, and also helps test out compatibility. Later it may be desirable to rewrite this in TS. There isn't much too it, so it should be straight forward.

Everything in `contract-tests` is unchanged aside from imports.

I also updated the code to support the init method, as that was not available yet.

This allows the service to run, but nothing will work/pass.

The changes to make the client more whole will be a different PR. I am trying to break these into somewhat understandable chunks.
