### PR TITLE
Add a simple test with order dependent operations to ensure the clause executes the matches with parameters in the correct order.

### DIFF
--- a/server-sdk-common/src/evaluation/matchClause.ts
+++ b/server-sdk-common/src/evaluation/matchClause.ts
@@ -34,7 +34,6 @@ export default function matchClauseWithoutSegmentOperations(
       clause,
       contextValue.some(
         (value) => matchAny(clause.op, value, clause.values),
-        // (value) => matchAny(clause.op, clause.values, value),
       ),
     );
   }


### PR DESCRIPTION
There was an issue in the rust SDK where the parameters were passed to an operation in the wrong order in a specific case. Where context values were an array. 

I tried transposing the parameters in a few places. If they were transposed in the operator, than many tests failed. If they were transposed in the clause matching logic, then no tests failed. This runs a series of order dependent clause operations with and without the clause value being an array.