### PR TITLE
Remove unused interface fields for segments.

### DIFF
--- a/server-sdk-common/src/evaluation/data/Segment.ts
+++ b/server-sdk-common/src/evaluation/data/Segment.ts
@@ -13,8 +13,6 @@ export interface Segment extends Versioned {
   unbounded?: boolean;
   unboundedContextKind?: string;
   generation?: number;
-  bucketBy?: string;
-  rolloutContextKind?: string;
 
   // This field is not part of the schema, but it is populated during parsing.
   bucketByAttributeReference?: AttributeReference,


### PR DESCRIPTION
These were leftover from some iteration on the schema where they were in the wrong place. They are unused.