### PR TITLE
chore: Limit published files to dist for node server.

### DIFF
--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -5,6 +5,9 @@
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
+  "files": [
+    "/dist"
+  ],
   "keywords": [
     "launchdarkly",
     "analytics",


### PR DESCRIPTION
All I needed to do was add "files" other packages already had it.

Example of what the output will be:
![image](https://user-images.githubusercontent.com/4955475/225464650-eaf74ffc-7451-4453-96f3-49790c34bc9e.png)

This is the server shared package which works this way.

Basically it automatically includes package.json, README.md, and CONTRIBUTING.md. 