### PR TITLE
fix: semver util import error

### DIFF
--- a/packages/sdk/cloudflare/README.md
+++ b/packages/sdk/cloudflare/README.md
@@ -20,6 +20,13 @@ or yarn:
 yarn add -D @launchdarkly/cloudflare-server-sdk
 ```
 
+In `wrangler.toml` in your worker project turn on the Node.js compatibility flag.
+This allows the SDK to use `node:events`:
+
+```toml
+compatibility_flags = [ "nodejs_compat" ]
+```
+
 ## Quickstart
 
 Initialize the ldClient with the [Cloudflare KV namespace](https://developers.cloudflare.com/workers/runtime-apis/kv#kv-bindings) and your client side sdk key:

--- a/packages/sdk/cloudflare/README.md
+++ b/packages/sdk/cloudflare/README.md
@@ -17,7 +17,7 @@ npm i @launchdarkly/cloudflare-server-sdk
 or yarn:
 
 ```shell
-yarn add -D @launchdarkly/cloudflare-server-sdk
+yarn add @launchdarkly/cloudflare-server-sdk
 ```
 
 In `wrangler.toml` in your worker project turn on the Node.js compatibility flag.

--- a/packages/sdk/cloudflare/README.md
+++ b/packages/sdk/cloudflare/README.md
@@ -1,8 +1,8 @@
 # LaunchDarkly Cloudflare SDK
 
-[![NPM][sdk-server-cloudflare-npm-badge]][sdk-server-cloudflare-npm-link]
-[![Actions Status][sdk-server-cloudflare-ci-badge]][sdk-server-cloudflare-ci]
-[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/js-core/packages/sdk/server-cloudflare/docs/)
+[![NPM][sdk-cloudflare-npm-badge]][sdk-cloudflare-npm-link]
+[![Actions Status][sdk-cloudflare-ci-badge]][sdk-cloudflare-ci]
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/js-core/packages/sdk/cloudflare/docs/)
 
 This library supports using Cloudflare [Workers KV](https://developers.cloudflare.com/workers/learning/how-kv-works) to replace the default in-memory feature store of the [LaunchDarkly Node.js SDK](https://github.com/launchdarkly/cloudflare-server-sdk).
 
@@ -62,3 +62,8 @@ yarn test
   - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
   - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+[sdk-cloudflare-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/cloudflare.yml/badge.svg
+[sdk-cloudflare-ci]: https://github.com/launchdarkly/js-core/actions/workflows/cloudflare.yml
+[sdk-cloudflare-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/cloudflare-server-sdk.svg?style=flat-square
+[sdk-cloudflare-npm-link]: https://www.npmjs.com/package/@launchdarkly/cloudflare-server-sdk

--- a/packages/shared/sdk-server/package.json
+++ b/packages/shared/sdk-server/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@launchdarkly/js-sdk-common": "0.3.0",
-    "semver": "^7.3.8"
+    "semver": "7.4.0"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/packages/shared/sdk-server/package.json
+++ b/packages/shared/sdk-server/package.json
@@ -22,6 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@launchdarkly/js-sdk-common": "0.3.0",
+    "//": "Pinned because 7.5.0 introduced require('util') without the node: prefix",
     "semver": "7.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Semver [v7.5.0](https://github.com/npm/node-semver/compare/v7.4.0...v7.5.0#diff-7917f8ef42ff71df5bde71c259d15feab8b147e3e6c2fde11b56cbf42cadea16R19) adds a version check on the node util class with a `require('util')` statement which breaks nodejs compatibility in a worker environment. This should have been `require('node:util')`. The workaround is for our customers to use a bundler for the application, but that's not very nice.

So this ticket we'll freeze the semver package version to 7.4.0 which does not have `require('util')` statement.