### PR TITLE
chore: remove release-as and sha

### DIFF
--- a/packages/shared/sdk-server/package.json
+++ b/packages/shared/sdk-server/package.json
@@ -20,9 +20,9 @@
     "lint:fix": "yarn run lint -- --fix"
   },
   "license": "Apache-2.0",
+  "//": "Pinned semver because 7.5.0 introduced require('util') without the node: prefix",
   "dependencies": {
     "@launchdarkly/js-sdk-common": "0.3.0",
-    "//": "Pinned because 7.5.0 introduced require('util') without the node: prefix",
     "semver": "7.4.0"
   },
   "devDependencies": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,17 +7,13 @@
       "bump-minor-pre-major": true
     },
     "packages/shared/sdk-server-edge": {
-      "bump-minor-pre-major": true,
-      "release-as": "0.0.1",
-      "bootstrap-sha": "0578190123e2712b50774ca3087c7577ef2b9eb2"
+      "bump-minor-pre-major": true
     },
     "packages/sdk/server-node": {
       "bump-minor-pre-major": true
     },
     "packages/sdk/cloudflare": {
-      "bump-minor-pre-major": true,
-      "release-as": "0.0.1",
-      "bootstrap-sha": "0578190123e2712b50774ca3087c7577ef2b9eb2"
+      "bump-minor-pre-major": true
     }
   },
   "plugins": ["node-workspace"]


### PR DESCRIPTION
Remove release-as and sha from cloudflare and sdk-server-edge packages now that they are published.