### PR TITLE
fix: remove useless defaults

### DIFF
--- a/packages/shared/sdk-server-edge/src/api/createOptions.ts
+++ b/packages/shared/sdk-server-edge/src/api/createOptions.ts
@@ -3,14 +3,8 @@ import { BasicLogger, LDOptions } from '@launchdarkly/js-server-sdk-common';
 export const defaultOptions: LDOptions = {
   stream: false,
   sendEvents: false,
-  offline: false,
   useLdd: true,
-  allAttributesPrivate: false,
-  privateAttributes: [],
-  contextKeysCapacity: 1000,
-  contextKeysFlushInterval: 300,
   diagnosticOptOut: true,
-  diagnosticRecordingInterval: 900,
   logger: BasicLogger.get(),
 };
 


### PR DESCRIPTION
The options below are already defined with the same defaults in the common sdk-server [Configuration](https://github.com/launchdarkly/js-core/blob/6be132f19284a65bf0623e51b9d3ae047f89a879/packages/shared/sdk-server/src/options/Configuration.ts#L64) class so we can safely remove them for the edge sdk to avoid repetition:

```js
  stream: false,
  sendEvents: false,
  // offline: false,
  useLdd: true,
  // allAttributesPrivate: false,
  // privateAttributes: [],
  // contextKeysCapacity: 1000,
  // contextKeysFlushInterval: 300,
  diagnosticOptOut: true,
  // diagnosticRecordingInterval: 900,
  logger: BasicLogger.get(),
```