### PR TITLE
fix: fix packagejson import

### DIFF
--- a/packages/sdk/vercel/src/createPlatformInfo.test.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.test.ts
@@ -1,6 +1,6 @@
-import { name, version } from '../package.json';
-
 import createPlatformInfo from './createPlatformInfo';
+
+const packageJson = require('../package.json');
 
 describe('Vercel Platform Info', () => {
   it('platformData shows correct information', () => {
@@ -15,8 +15,8 @@ describe('Vercel Platform Info', () => {
     const platformData = createPlatformInfo();
 
     expect(platformData.sdkData()).toEqual({
-      name,
-      version,
+      name: packageJson.name,
+      version: packageJson.version,
     });
   });
 });

--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -1,6 +1,6 @@
 import type { Info, PlatformData, SdkData } from '@launchdarkly/js-server-sdk-common-edge';
 
-import { name, version } from '../package.json';
+import packageJson from '../package.json';
 
 class VercelPlatformInfo implements Info {
   platformData(): PlatformData {
@@ -11,8 +11,8 @@ class VercelPlatformInfo implements Info {
 
   sdkData(): SdkData {
     return {
-      name,
-      version,
+      name: packageJson.name,
+      version: packageJson.version,
     };
   }
 }

--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -1,6 +1,6 @@
 import type { Info, PlatformData, SdkData } from '@launchdarkly/js-server-sdk-common-edge';
 
-import packageJson from '../package.json';
+const packageJson = require('../package.json');
 
 class VercelPlatformInfo implements Info {
   platformData(): PlatformData {


### PR DESCRIPTION
I was getting build errors complaining about package.json only being able to be used as a default import/export in ESM