### PR TITLE
feat: Use version number from release process instead of package.json.

### DIFF
--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -1,7 +1,5 @@
 import type { Info, PlatformData, SdkData } from '@launchdarkly/js-server-sdk-common-edge';
 
-const packageJson = require('../package.json');
-
 class VercelPlatformInfo implements Info {
   platformData(): PlatformData {
     return {
@@ -11,8 +9,8 @@ class VercelPlatformInfo implements Info {
 
   sdkData(): SdkData {
     return {
-      name: packageJson.name,
-      version: packageJson.version,
+      name: '@launchdarkly/vercel-server-sdk',
+      version: '0.2.2', // {x-release-please-version}
     };
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
     },
     "packages/sdk/cloudflare": {},
     "packages/sdk/vercel": {
+      "extra-files": [
+        "src/createPlatformInfo.ts"
+      ],
       "bump-minor-pre-major": true
     }
   },


### PR DESCRIPTION
I ended up using the release-please extra files instead of the `.default`. The edge environment doesn't seem to agree with TS expectations here, so `.default` would violate the local typings.

The test file still loads from pacakge.json, which passes here, and should pass as the release PRs update things. If the module name changed, it would fail, which is good actually.

After this is merged we can check the release PR.
