### PR TITLE
fix: remove Vercel examples from yarn workspace to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "packages/sdk/cloudflare",
     "packages/sdk/cloudflare/example",
     "packages/sdk/vercel",
-    "packages/sdk/vercel/examples/complete",
-    "packages/sdk/vercel/examples/route-handler",
     "packages/sdk/akamai"
   ],
   "private": true,


### PR DESCRIPTION
This PR removes the newly added Vercel examples from the yarn workspace to fix the build. I confirmed that `yarn && yarn build` did not result in any errors.
