### PR TITLE
chore: update readme badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/cloudflare-server-sdk](packages/sdk/cloudflare/README.md) | [![NPM][sdk-cloudflare-npm-badge]][sdk-cloudflare-npm-link]   | [Cloudflare][package-sdk-cloudflare-issues]      | [![Actions Status][sdk-cloudflare-ci-badge]][sdk-cloudflare-ci]   |
 | [@launchdarkly/node-server-sdk](packages/sdk/server-node/README.md)      | [![NPM][sdk-server-node-npm-badge]][sdk-server-node-npm-link] | [Node.js Server][package-sdk-server-node-issues] | [![Actions Status][sdk-server-node-ci-badge]][sdk-server-node-ci] |
 | [@launchdarkly/vercel-server-sdk](packages/sdk/vercel/README.md)         | [![NPM][sdk-vercel-npm-badge]][sdk-vercel-npm-link]           | [Vercel][package-sdk-vercel-issues]              | [![Actions Status][sdk-vercel-ci-badge]][sdk-vercel-ci]           |
-| [@launchdarkly/akamai-edgeworker-sdk](packages/sdk/akamai/README.md)         | [![NPM][sdk-akamai-npm-badge]][sdk-akamai-npm-link]           | [Akamai][package-sdk-akamai-issues]              | [![Actions Status][sdk-akamai-ci-badge]][sdk-akamai-ci]           |
+| [@launchdarkly/akamai-server-base-sdk](packages/sdk/akamai-base/README.md)         | [![NPM][sdk-akamai-base-npm-badge]][sdk-akamai-base-npm-link]           | [Akamai Base][package-sdk-akamai-base-issues]              | [![Actions Status][sdk-akamai-base-ci-badge]][sdk-akamai-base-ci]           |
+| [@launchdarkly/akamai-server-edgekv-sdk](packages/sdk/akamai-edgekv/README.md)         | [![NPM][sdk-akamai-edgekv-npm-badge]][sdk-akamai-edgekv-npm-link]           | [Akamai EdgeKV][package-sdk-akamai-edgekv-issues]              | [![Actions Status][sdk-akamai-edgekv-ci-badge]][sdk-akamai-edgekv-ci]           |
 
 | Shared packages                                                                      | npm                                                                       | issues                                                      | tests                                                                           |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -99,12 +100,22 @@ We encourage pull requests and other contributions from the community. Check out
 [sdk-vercel-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/vercel-server-sdk.svg?style=flat-square
 [package-sdk-vercel-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fvercel%22+
 [//]: # 'sdk/akamai-base'
-[sdk-akamai-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml/badge.svg
-[sdk-akamai-ci]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml
-[sdk-akamai-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
-[sdk-akamai-npm-link]: https://www.npmjs.com/package/@launchdarkly/akamai-server-base-sdk
-[sdk-akamai-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
-[sdk-akamai-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/akamai/docs/
-[sdk-akamai-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
-[sdk-akamai-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
-[package-sdk-akamai-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fakamai-base%22+
+[sdk-akamai-base-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml/badge.svg
+[sdk-akamai-base-ci]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml
+[sdk-akamai-base-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[sdk-akamai-base-npm-link]: https://www.npmjs.com/package/@launchdarkly/akamai-server-base-sdk
+[sdk-akamai-base-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[sdk-akamai-base-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/akamai/docs/
+[sdk-akamai-base-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[sdk-akamai-base-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[package-sdk-akamai-base-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fakamai-base%22+
+[//]: # 'sdk/akamai-edgekv'
+[sdk-akamai-edgekv-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-edgekv.yml/badge.svg
+[sdk-akamai-edgekv-ci]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-edgekv.yml
+[sdk-akamai-edgekv-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[sdk-akamai-edgekv-npm-link]: https://www.npmjs.com/package/@launchdarkly/akamai-server-edgekv-sdk
+[sdk-akamai-edgekv-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[sdk-akamai-edgekv-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/akamai/docs/
+[sdk-akamai-edgekv-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[sdk-akamai-edgekv-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[package-sdk-akamai-edgekv-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fakamai-edgekv%22+

--- a/packages/sdk/akamai-base/README.md
+++ b/packages/sdk/akamai-base/README.md
@@ -1,14 +1,14 @@
 # LaunchDarkly Akamai SDK
 
-[![NPM][sdk-akamai-npm-badge]][sdk-akamai-npm-link]
-[![Actions Status][sdk-akamai-ci-badge]][sdk-akamai-ci]
-[![Documentation][sdk-akamai-ghp-badge]][sdk-akamai-ghp-link]
-[![NPM][sdk-akamai-dm-badge]][sdk-akamai-npm-link]
-[![NPM][sdk-akamai-dt-badge]][sdk-akamai-npm-link]
+[![NPM][sdk-akamai-base-npm-badge]][sdk-akamai-base-npm-link]
+[![Actions Status][sdk-akamai-base-ci-badge]][sdk-akamai-base-ci]
+[![Documentation][sdk-akamai-base-ghp-badge]][sdk-akamai-base-ghp-link]
+[![NPM][sdk-akamai-base-dm-badge]][sdk-akamai-base-npm-link]
+[![NPM][sdk-akamai-base-dt-badge]][sdk-akamai-base-npm-link]
 
 The LaunchDarkly Akamai SDK is designed primarily for use in Akamai Edgeworkers. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 
-For more information, see the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/server-side/akamai).
+For more information, see the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/edge/akamai).
 
 ## Install
 
@@ -44,3 +44,13 @@ yarn test
   - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
   - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+[sdk-akamai-base-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml/badge.svg
+[sdk-akamai-base-ci]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-base.yml
+[sdk-akamai-base-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[sdk-akamai-base-npm-link]: https://www.npmjs.com/package/@launchdarkly/akamai-server-base-sdk
+[sdk-akamai-base-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[sdk-akamai-base-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/akamai/docs/
+[sdk-akamai-base-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[sdk-akamai-base-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/akamai-server-base-sdk.svg?style=flat-square
+[package-sdk-akamai-base-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fakamai-base%22+

--- a/packages/sdk/akamai-base/README.md
+++ b/packages/sdk/akamai-base/README.md
@@ -1,4 +1,4 @@
-# LaunchDarkly Akamai SDK
+# LaunchDarkly Akamai Base SDK
 
 [![NPM][sdk-akamai-base-npm-badge]][sdk-akamai-base-npm-link]
 [![Actions Status][sdk-akamai-base-ci-badge]][sdk-akamai-base-ci]

--- a/packages/sdk/akamai-edgekv/README.md
+++ b/packages/sdk/akamai-edgekv/README.md
@@ -1,10 +1,10 @@
 # LaunchDarkly Akamai SDK for EdgeKV
 
-[![NPM][sdk-akamai-npm-badge]][sdk-akamai-npm-link]
-[![Actions Status][sdk-akamai-ci-badge]][sdk-akamai-ci]
-[![Documentation][sdk-akamai-ghp-badge]][sdk-akamai-ghp-link]
-[![NPM][sdk-akamai-dm-badge]][sdk-akamai-npm-link]
-[![NPM][sdk-akamai-dt-badge]][sdk-akamai-npm-link]
+[![NPM][sdk-akamai-edgekv-npm-badge]][sdk-akamai-edgekv-npm-link]
+[![Actions Status][sdk-akamai-edgekv-ci-badge]][sdk-akamai-edgekv-ci]
+[![Documentation][sdk-akamai-edgekv-ghp-badge]][sdk-akamai-edgekv-ghp-link]
+[![NPM][sdk-akamai-edgekv-dm-badge]][sdk-akamai-edgekv-npm-link]
+[![NPM][sdk-akamai-edgekv-dt-badge]][sdk-akamai-edgekv-npm-link]
 
 The LaunchDarkly Akamai SDK is designed primarily for use in Akamai Edgeworkers. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 
@@ -44,3 +44,13 @@ yarn test
   - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
   - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+[sdk-akamai-edgekv-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-edgekv.yml/badge.svg
+[sdk-akamai-edgekv-ci]: https://github.com/launchdarkly/js-core/actions/workflows/akamai-edgekv.yml
+[sdk-akamai-edgekv-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[sdk-akamai-edgekv-npm-link]: https://www.npmjs.com/package/@launchdarkly/akamai-server-edgekv-sdk
+[sdk-akamai-edgekv-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[sdk-akamai-edgekv-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/akamai/docs/
+[sdk-akamai-edgekv-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[sdk-akamai-edgekv-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/akamai-server-edgekv-sdk.svg?style=flat-square
+[package-sdk-akamai-edgekv-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fakamai-edgekv%22+


### PR DESCRIPTION
Update readme badge links for the Akamai Base and Akamai EdgeKV SDKs

Old:

<img width="625" alt="Screenshot 2023-06-05 at 11 22 24 AM" src="https://github.com/launchdarkly/js-core/assets/104030863/c5f4e487-70b9-4066-81ac-b07b5d0c2f39">

New:

<img width="614" alt="Screenshot 2023-06-05 at 11 22 08 AM" src="https://github.com/launchdarkly/js-core/assets/104030863/bdce6fc8-2c92-4cdd-a4e6-afd6a639a9e8">
