### PR TITLE
chore: rename Edge Config client

### DIFF
--- a/packages/sdk/vercel/examples/complete/lib/ldEdgeClient.ts
+++ b/packages/sdk/vercel/examples/complete/lib/ldEdgeClient.ts
@@ -1,8 +1,8 @@
 import { init } from '@launchdarkly/vercel-server-sdk';
 import { createClient } from '@vercel/edge-config';
 
-const edgeClient = createClient(process.env.EDGE_CONFIG);
-if (!edgeClient) {
-  throw new Error('Edge Client could not be initialized');
+const edgeConfigClient = createClient(process.env.EDGE_CONFIG);
+if (!edgeConfigClient) {
+  throw new Error('Edge Config client could not be initialized');
 }
-export const ldEdgeClient = init(process.env.LD_CLIENT_SIDE_ID || '', edgeClient);
+export const ldEdgeClient = init(process.env.LD_CLIENT_SIDE_ID || '', edgeConfigClient);


### PR DESCRIPTION
Renames the edgeClient variable to edgeConfigClient to be more descriptive and avoid confusion.
