### PR TITLE
chore: Add issue templates for Akamai SDKs

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--bug_report.md
@@ -1,0 +1,37 @@
+---
+name: '@launchdarkly/akamai-server-base-sdk'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-base, bug'
+assignees: ''
+
+---
+
+**Is this a support request?**
+This issue tracker is maintained by LaunchDarkly SDK developers and is intended for feedback on the code in this library. If you're not sure whether the problem you are having is specifically related to this library, or to the LaunchDarkly service overall, it may be more appropriate to contact the LaunchDarkly support team; they can help to investigate the problem and will consult the SDK team if necessary. You can submit a support request by going [here](https://support.launchdarkly.com/) and clicking "submit a request", or by emailing support@launchdarkly.com.
+
+Note that issues filed on this issue tracker are publicly accessible. Do not provide any private account information on your issues. If your problem is specific to your account, you should submit a support request as described above.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add any log output related to your problem.
+
+**SDK version**
+The version of this SDK that you are using.
+
+**Language version, developer tools**
+For instance, Go 1.11 or Ruby 2.5.3. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler too.
+
+**OS/platform**
+For instance, Ubuntu 16.04, Windows 10, or Android 4.0.3. If your code is running in a browser, please also include the browser type and version.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: '@launchdarkly/akamai-server-base-sdk'
+name: '@launchdarkly/akamai-server-base-sdk Bug Report'
 about: Create a report to help us improve
 title: ''
 labels: 'package: sdk/akamai-base, bug'

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--feature_request.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-base--feature_request.md
@@ -1,0 +1,20 @@
+---
+name: '@launchdarkly/akamai-server-base-sdk Feature Request'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-base, feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I would love to see the SDK [...does something new...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: '@launchdarkly/akamai-server-edgekv-sdk'
+name: '@launchdarkly/akamai-server-edgekv-sdk Bug Report'
 about: Create a report to help us improve
 title: ''
 labels: 'package: sdk/akamai-edgekv, bug'

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--bug_report.md
@@ -1,0 +1,37 @@
+---
+name: '@launchdarkly/akamai-server-edgekv-sdk'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-edgekv, bug'
+assignees: ''
+
+---
+
+**Is this a support request?**
+This issue tracker is maintained by LaunchDarkly SDK developers and is intended for feedback on the code in this library. If you're not sure whether the problem you are having is specifically related to this library, or to the LaunchDarkly service overall, it may be more appropriate to contact the LaunchDarkly support team; they can help to investigate the problem and will consult the SDK team if necessary. You can submit a support request by going [here](https://support.launchdarkly.com/) and clicking "submit a request", or by emailing support@launchdarkly.com.
+
+Note that issues filed on this issue tracker are publicly accessible. Do not provide any private account information on your issues. If your problem is specific to your account, you should submit a support request as described above.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add any log output related to your problem.
+
+**SDK version**
+The version of this SDK that you are using.
+
+**Language version, developer tools**
+For instance, Go 1.11 or Ruby 2.5.3. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler too.
+
+**OS/platform**
+For instance, Ubuntu 16.04, Windows 10, or Android 4.0.3. If your code is running in a browser, please also include the browser type and version.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--feature_request.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgekv--feature_request.md
@@ -1,0 +1,20 @@
+---
+name: '@launchdarkly/akamai-server-edgekv-sdk Feature Request'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-edgekv, feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I would love to see the SDK [...does something new...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: '@launchdarkly/akamai-edgeworker-sdk-common'
+name: '@launchdarkly/akamai-edgeworker-sdk-common Bug Report'
 about: Create a report to help us improve
 title: ''
 labels: 'package: sdk/akamai-edgeworker-sdk, bug'

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--bug_report.md
@@ -1,0 +1,37 @@
+---
+name: '@launchdarkly/akamai-edgeworker-sdk-common'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-edgeworker-sdk, bug'
+assignees: ''
+
+---
+
+**Is this a support request?**
+This issue tracker is maintained by LaunchDarkly SDK developers and is intended for feedback on the code in this library. If you're not sure whether the problem you are having is specifically related to this library, or to the LaunchDarkly service overall, it may be more appropriate to contact the LaunchDarkly support team; they can help to investigate the problem and will consult the SDK team if necessary. You can submit a support request by going [here](https://support.launchdarkly.com/) and clicking "submit a request", or by emailing support@launchdarkly.com.
+
+Note that issues filed on this issue tracker are publicly accessible. Do not provide any private account information on your issues. If your problem is specific to your account, you should submit a support request as described above.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add any log output related to your problem.
+
+**SDK version**
+The version of this SDK that you are using.
+
+**Language version, developer tools**
+For instance, Go 1.11 or Ruby 2.5.3. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler too.
+
+**OS/platform**
+For instance, Ubuntu 16.04, Windows 10, or Android 4.0.3. If your code is running in a browser, please also include the browser type and version.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--feature_request.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-akamai-edgeworker-sdk--feature_request.md
@@ -1,0 +1,20 @@
+---
+name: '@launchdarkly/akamai-edgeworker-sdk-common Feature Request'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/akamai-edgeworker-sdk, feature'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I would love to see the SDK [...does something new...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.


### PR DESCRIPTION
Adding issue templates for the following sdks
- Akamai Base
- Akamai EdgeKV
- Akamai Edgworker SDK
