### PR TITLE
feat: Release beta version of Akamai SDKs

### DIFF
--- a/packages/sdk/akamai-base/README.md
+++ b/packages/sdk/akamai-base/README.md
@@ -6,6 +6,8 @@
 [![NPM][sdk-akamai-base-dm-badge]][sdk-akamai-base-npm-link]
 [![NPM][sdk-akamai-base-dt-badge]][sdk-akamai-base-npm-link]
 
+> This library is a beta version and should not be considered ready for production use while this message is visible.
+
 The LaunchDarkly Akamai SDK is designed primarily for use in Akamai Edgeworkers. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 
 For more information, see the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/edge/akamai).

--- a/packages/sdk/akamai-edgekv/README.md
+++ b/packages/sdk/akamai-edgekv/README.md
@@ -6,6 +6,8 @@
 [![NPM][sdk-akamai-edgekv-dm-badge]][sdk-akamai-edgekv-npm-link]
 [![NPM][sdk-akamai-edgekv-dt-badge]][sdk-akamai-edgekv-npm-link]
 
+> This library is a beta version and should not be considered ready for production use while this message is visible.
+
 The LaunchDarkly Akamai SDK is designed primarily for use in Akamai Edgeworkers. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 
 For more information, see the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/edge/akamai).

--- a/packages/shared/akamai-edgeworker-sdk/README.md
+++ b/packages/shared/akamai-edgeworker-sdk/README.md
@@ -1,8 +1,9 @@
-# LaunchDarkly SDK JavaScript Common Server Edge Code
+# LaunchDarkly Akamai Edgeworker SDK
+
+> This library is a beta version and should not be considered ready for production use while this message is visible.
 
 This project contains Typescript classes and interfaces that are applicable to Akamai's edge SDKs.
 
-This library is a beta version and should not be considered ready for production use while this message is visible.
 
 ## Contributing
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     "packages/shared/sdk-server": {},
     "packages/shared/sdk-server-edge": {},
     "packages/shared/akamai-edgeworker-sdk": {
-      "bump-minor-pre-major": true,
       "release-as": "1.0.0-beta"
     },
     "packages/sdk/server-node": {
@@ -21,14 +20,12 @@
       "extra-files": [
         "src/index.ts"
       ],
-      "bump-minor-pre-major": true,
       "release-as": "1.0.0-beta"
     },
     "packages/sdk/akamai-edgekv": {
       "extra-files": [
         "src/index.ts"
       ],
-      "bump-minor-pre-major": true,
       "release-as": "1.0.0-beta"
     }
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
     "packages/sdk/akamai-base": {
       "extra-files": [
         "src/index.ts"
-      ]
+      ],
+      "bump-minor-pre-major": true
     },
     "packages/sdk/akamai-edgekv": {
       "extra-files": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
     "packages/shared/sdk-server": {},
     "packages/shared/sdk-server-edge": {},
     "packages/shared/akamai-edgeworker-sdk": {
-      "release-as": "1.0.0-beta"
+      "bump-minor-pre-major": true
     },
     "packages/sdk/server-node": {
       "bump-minor-pre-major": true
@@ -19,14 +19,13 @@
     "packages/sdk/akamai-base": {
       "extra-files": [
         "src/index.ts"
-      ],
-      "release-as": "1.0.0-beta"
+      ]
     },
     "packages/sdk/akamai-edgekv": {
       "extra-files": [
         "src/index.ts"
       ],
-      "release-as": "1.0.0-beta"
+      "bump-minor-pre-major": true
     }
   },
   "plugins": ["node-workspace"]


### PR DESCRIPTION
Remove `release-as` from Akamai SDKs
Update documentation to indicate that the SDK is changing from `alpha -> beta`