### PR TITLE
fix: Correctly handle excluded big segments.

### DIFF
--- a/contract-tests/BigSegmentTestStore.js
+++ b/contract-tests/BigSegmentTestStore.js
@@ -1,0 +1,29 @@
+import got from 'got';
+
+export default class BigSegmentTestStore {
+  /**
+   * Create a big segment test store suitable for use with the contract tests.
+   * @param {string} callbackUri Uri on the test service to direct big segments
+   * calls to.
+   */
+  constructor(callbackUri) {
+    this._callbackUri = callbackUri;
+  }
+
+  async getMetadata() {
+    const data = await got.get(`${this._callbackUri}/getMetadata`, { retry: { limit: 0 } }).json();
+    return data;
+  }
+
+  async getUserMembership(contextHash) {
+    const data = await got.post(`${this._callbackUri}/getMembership`, {
+      retry: { limit: 0 },
+      json: {
+        contextHash
+      }
+    }).json();
+    return data?.values;
+  }
+
+  close() { }
+}

--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -1,8 +1,8 @@
-const express = require('express');
-const bodyParser = require('body-parser');
+import express from 'express';
+import bodyParser from 'body-parser';
 
-const { Log } = require('./log');
-const { newSdkClientEntity, badCommandError } = require('./sdkClientEntity');
+import { Log } from './log.js';
+import { newSdkClientEntity, badCommandError } from './sdkClientEntity.js';
 
 const app = express();
 let server = null;
@@ -26,6 +26,7 @@ app.get('/', (req, res) => {
       'all-flags-details-only-for-tracked-flags',
       'all-flags-with-reasons',
       'tags',
+      'big-segments'
     ],
   });
 });

--- a/contract-tests/log.js
+++ b/contract-tests/log.js
@@ -1,6 +1,6 @@
-const ld = require('node-server-sdk');
+import ld from 'node-server-sdk';
 
-function Log(tag) {
+export function Log(tag) {
   function doLog(level, message) {
     console.log(new Date().toISOString() + ` [${tag}] ${level}: ${message}`);
   }
@@ -10,7 +10,7 @@ function Log(tag) {
   };
 }
 
-function sdkLogger(tag) {
+export function sdkLogger(tag) {
   return ld.basicLogger({
     level: 'debug',
     destination: (line) => {
@@ -18,6 +18,3 @@ function sdkLogger(tag) {
     },
   });
 }
-
-module.exports.Log = Log;
-module.exports.sdkLogger = sdkLogger;

--- a/contract-tests/package.json
+++ b/contract-tests/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "start": "node --inspect index.js"
   },
+  "type": "module",
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "node-server-sdk": "file:../packages/sdk/server-node"
+    "node-server-sdk": "file:../packages/sdk/server-node",
+    "got": "13.0.0"
   }
 }

--- a/packages/sdk/server-node/src/index.ts
+++ b/packages/sdk/server-node/src/index.ts
@@ -13,10 +13,10 @@ import {
   BasicLoggerOptions,
   LDLogger,
   LDOptions,
-  LDClient,
 } from '@launchdarkly/js-server-sdk-common';
 import { EventEmitter } from 'events';
 import LDClientImpl from './LDClientNode';
+import { LDClient } from './api/LDClient';
 
 export * from '@launchdarkly/js-server-sdk-common';
 
@@ -45,7 +45,7 @@ export { LDClient, BigSegmentStoreStatusProvider } from './api';
  * @return
  *   The new {@link LDClient} instance.
  */
-export function init(sdkKey: string, options: LDOptions = {}): LDClient & EventEmitter {
+export function init(sdkKey: string, options: LDOptions = {}): LDClient {
   return new LDClientImpl(sdkKey, options);
 }
 

--- a/packages/sdk/server-node/src/index.ts
+++ b/packages/sdk/server-node/src/index.ts
@@ -14,7 +14,6 @@ import {
   LDLogger,
   LDOptions,
 } from '@launchdarkly/js-server-sdk-common';
-import { EventEmitter } from 'events';
 import LDClientImpl from './LDClientNode';
 import { LDClient } from './api/LDClient';
 

--- a/packages/shared/common/__tests__/logging/BasicLogger.test.ts
+++ b/packages/shared/common/__tests__/logging/BasicLogger.test.ts
@@ -48,11 +48,15 @@ describe('given a logger with a custom name', () => {
     logger.info('b');
     logger.warn('c');
     logger.error('d');
+    logger.debug('This %s is %s', 'log', 'working');
+    logger.debug('This %s is %s', 'log', 'working', 'extra');
     expect(strings).toEqual([
       'debug: [MyLDLogger] a',
       'info: [MyLDLogger] b',
       'warn: [MyLDLogger] c',
       'error: [MyLDLogger] d',
+      'debug: [MyLDLogger] This log is working',
+      'debug: [MyLDLogger] This log is working extra',
     ]);
   });
 });

--- a/packages/shared/common/src/logging/BasicLogger.ts
+++ b/packages/shared/common/src/logging/BasicLogger.ts
@@ -74,7 +74,7 @@ export default class BasicLogger implements LDLogger {
       const prefix = `${LevelNames[level]}: [${this.name}]`;
       try {
         if (this.destination) {
-          this.tryWrite(this.tryFormat(prefix, ...args));
+          this.tryWrite(`${prefix} ${this.tryFormat(...args)}`);
         } else {
           // `console.error` has its own formatter.
           // So we don't need to do anything.

--- a/packages/shared/sdk-server/src/evaluation/Evaluator.ts
+++ b/packages/shared/sdk-server/src/evaluation/Evaluator.ts
@@ -574,8 +574,8 @@ export default class Evaluator {
   ): Promise<MatchOrError> {
     const segmentRef = makeBigSegmentRef(segment);
     const included = membership?.[segmentRef];
-    if (included) {
-      return new Match(true);
+    if (included !== undefined) {
+      return new Match(included);
     }
     return this.simpleSegmentMatchContext(segment, context, state, []);
   }

--- a/packages/shared/sdk-server/src/evaluation/Evaluator.ts
+++ b/packages/shared/sdk-server/src/evaluation/Evaluator.ts
@@ -465,9 +465,11 @@ export default class Evaluator {
     state: EvalState,
     segmentsVisited: string[]
   ): Promise<MatchOrError> {
-    const includeExclude = matchSegmentTargets(segment, context);
-    if (includeExclude !== undefined) {
-      return new Match(includeExclude);
+    if (!segment.unbounded) {
+      const includeExclude = matchSegmentTargets(segment, context);
+      if (includeExclude !== undefined) {
+        return new Match(includeExclude);
+      }
     }
 
     let evalResult: EvalResult | undefined;
@@ -501,6 +503,13 @@ export default class Evaluator {
       return this.simpleSegmentMatchContext(segment, context, state, segmentsVisited);
     }
 
+    const bigSegmentKind = segment.unboundedContextKind || 'user';
+    const keyForBigSegment = context.key(bigSegmentKind);
+
+    if (keyForBigSegment === undefined) {
+      return new Match(false);
+    }
+
     if (!segment.generation) {
       // Big Segment queries can only be done if the generation is known. If it's unset,
       // that probably means the data store was populated by an older SDK that doesn't know
@@ -511,13 +520,6 @@ export default class Evaluator {
         state.bigSegmentsStatus,
         'NOT_CONFIGURED'
       );
-      return new Match(false);
-    }
-
-    const bigSegmentKind = segment.unboundedContextKind || 'user';
-    const keyForBigSegment = context.key(bigSegmentKind);
-
-    if (keyForBigSegment === undefined) {
       return new Match(false);
     }
 

--- a/packages/shared/sdk-server/src/evaluation/Evaluator.ts
+++ b/packages/shared/sdk-server/src/evaluation/Evaluator.ts
@@ -102,7 +102,7 @@ export default class Evaluator {
     const state = new EvalState();
     const res = await this.evaluateInternal(flag, context, state, [], eventFactory);
     if (state.bigSegmentsStatus) {
-      res.detail.reason.bigSegmentsStatus = state.bigSegmentsStatus;
+      res.detail.reason = { ...res.detail.reason, bigSegmentsStatus: state.bigSegmentsStatus };
     }
     res.events = state.events;
     return res;

--- a/packages/shared/sdk-server/src/evaluation/Evaluator.ts
+++ b/packages/shared/sdk-server/src/evaluation/Evaluator.ts
@@ -506,7 +506,7 @@ export default class Evaluator {
     const bigSegmentKind = segment.unboundedContextKind || 'user';
     const keyForBigSegment = context.key(bigSegmentKind);
 
-    if (keyForBigSegment === undefined) {
+    if (!keyForBigSegment) {
       return new Match(false);
     }
 

--- a/packages/shared/sdk-server/src/evaluation/Evaluator.ts
+++ b/packages/shared/sdk-server/src/evaluation/Evaluator.ts
@@ -574,7 +574,10 @@ export default class Evaluator {
   ): Promise<MatchOrError> {
     const segmentRef = makeBigSegmentRef(segment);
     const included = membership?.[segmentRef];
-    if (included !== undefined) {
+    // Typically null is not checked because we filter it from the data
+    // we get in flag updates. Here it is checked because big segment data
+    // will be contingent on the store that implements it.
+    if (included !== undefined && included !== null) {
       return new Match(included);
     }
     return this.simpleSegmentMatchContext(segment, context, state, []);


### PR DESCRIPTION
fix: Correctly handle cached big segment status for excluded users.
fix: Handle log formatting correctly when there is a prefix. 
chore: Implement support for big segments contract tests.
fix: Do not query big segment status for a context which doesn't match the big segment kind. Verify the kind before checking the generation.

