### PR TITLE
chore: Workaround x-release-please-version problem.

### DIFF
--- a/packages/sdk/akamai-base/package.json
+++ b/packages/sdk/akamai-base/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "doc": "npx typedoc --name \"$(../../../scripts/doc-name.sh .)\" --readme none --entryPointStrategy resolve src/index.ts",
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js && ../../../scripts/replace-version.sh .",
     "clean": "rimraf dist",
     "tsw": "yarn tsc --watch",
     "start": "rimraf dist && yarn tsw",

--- a/packages/sdk/akamai-base/src/index.ts
+++ b/packages/sdk/akamai-base/src/index.ts
@@ -44,6 +44,6 @@ export const init = ({
     edgeFeatureStore: new EdgeFeatureStore(featureStoreProvider, sdkKey, 'Akamai', logger),
     platformName: 'Akamai EdgeWorker',
     sdkName: '@launchdarkly/akamai-server-base-sdk',
-    sdkVersion: '0.4.0', // {x-release-please-version}
+    sdkVersion: '__LD_VERSION__',
   });
 };

--- a/packages/sdk/akamai-edgekv/package.json
+++ b/packages/sdk/akamai-edgekv/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "doc": "npx typedoc --name \"$(../../../scripts/doc-name.sh .)\" --readme none --entryPointStrategy resolve src/index.ts",
-    "build": "rollup -c rollup.config.js && ./../../scripts/replace-version.sh .",
+    "build": "rollup -c rollup.config.js && ../../../scripts/replace-version.sh .",
     "clean": "rimraf dist",
     "tsw": "yarn tsc --watch",
     "start": "rimraf dist && yarn tsw",

--- a/packages/sdk/akamai-edgekv/package.json
+++ b/packages/sdk/akamai-edgekv/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "doc": "npx typedoc --name \"$(../../../scripts/doc-name.sh .)\" --readme none --entryPointStrategy resolve src/index.ts",
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js && ./../../scripts/replace-version.sh .",
     "clean": "rimraf dist",
     "tsw": "yarn tsc --watch",
     "start": "rimraf dist && yarn tsw",

--- a/packages/sdk/akamai-edgekv/src/index.ts
+++ b/packages/sdk/akamai-edgekv/src/index.ts
@@ -48,6 +48,6 @@ export const init = ({
     edgeFeatureStore: featureStore,
     platformName: 'Akamai EdgeWorker',
     sdkName: '@launchdarkly/akamai-server-edgekv-sdk',
-    sdkVersion: '0.4.0', // {x-release-please-version}
+    sdkVersion: '__LD_VERSION__',
   });
 };

--- a/packages/sdk/vercel/package.json
+++ b/packages/sdk/vercel/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "doc": "../../../scripts/build-doc.sh .",
-    "build": "../../../scripts/build-package.sh",
+    "build": "../../../scripts/build-package.sh && ../../../scripts/replace-version.sh .",
     "clean": "rimraf dist",
     "tsw": "yarn tsc --watch",
     "start": "rimraf dist && yarn tsw",

--- a/packages/sdk/vercel/src/createPlatformInfo.test.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.test.ts
@@ -14,9 +14,6 @@ describe('Vercel Platform Info', () => {
   it('sdkData shows correct information', () => {
     const platformData = createPlatformInfo();
 
-    expect(platformData.sdkData()).toEqual({
-      name: packageJson.name,
-      version: packageJson.version,
-    });
+    expect(platformData.sdkData().name).toEqual(packageJson.name);
   });
 });

--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -10,7 +10,7 @@ class VercelPlatformInfo implements Info {
   sdkData(): SdkData {
     return {
       name: '@launchdarkly/vercel-server-sdk',
-      version: '0.4.3', // {x-release-please-version}
+      version: '__LD_VERSION__',
     };
   }
 }

--- a/scripts/replace-version.sh
+++ b/scripts/replace-version.sh
@@ -1,0 +1,14 @@
+# Run this script like:
+# ./scripts/replace-version.sh packages/sdk/node
+
+# It will look for the string __LD_VERSION__ in the `dist` directory and replace 
+# any instances with the version from the package.json.
+
+# This is a workaround for a bug with the node-workspace plugin with release-please.
+# https://github.com/googleapis/release-please/issues/1978
+
+set -e
+
+version=$(node -p "let pj = require('./$1/package.json');\`\${pj.version}\`");
+
+find "$1/dist" -type f -exec sed -i "s/__LD_VERSION__/$version/g" {} +


### PR DESCRIPTION
Workaround for https://github.com/googleapis/release-please/issues/1978

Basically this just runs a post processing step to put the version number into the build.

So we build as normal, then it replaces `__LD_VERSION__` in the built package with the version from the package.json.

Once the release-please bug is fixed we can remove this workaround.