### PR TITLE
fix: move "default" conditional exports to be last

### DIFF
--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -12,12 +12,12 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./integrations": {
-      "default": "./dist/src/integrations.js",
-      "types": "./dist/src/integrations.d.ts"
+      "types": "./dist/src/integrations.d.ts",
+      "default": "./dist/src/integrations.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

I was trying to upgrade our Next.js application to use `@launchdarkly/node-server-sdk`, but was running into the following error when trying to build our app:

```
Module not found: Default condition should be last one
```

According to https://nodejs.org/api/packages.html#conditional-exports, the `default` conditional export should be the last one listed. After making that change the app built successfully. I created a simple reproduction here: https://github.com/seanparmelee/ld-server-nextjs.
