### PR TITLE
fix: adhere to specs by making 'default' export the last one

### DIFF
--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -12,12 +12,12 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
     },
     "./integrations": {
-      "default": "./dist/src/integrations.js",
-      "types": "./dist/src/integrations.d.ts"
+      "types": "./dist/src/integrations.d.ts",
+      "default": "./dist/src/integrations.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

This PR makes the `default` entry within `exports` sections of `package.json` the last one as mandated by the [specs](https://nodejs.org/api/packages.html#packages_conditional_exports). This inconsistency is actually causing error when building apps relying on `@launchdarkly/node-server-sdk` with Next.js (which uses Webpack internally):

```
Module not found: Default condition should be last one
```

**Describe the solution you've provided**

I have moved the `default` entry in the `exports` section so it has become the last one.

**Describe alternatives you've considered**

I haven't considered any.

**Additional context**

It appears to effect Next.js (and possibly any other project using Webpack), but plain Node.js project without bundler has no problem, maybe Node.js is not that rigorous regarding this rule. 
