### PR TITLE
chore: bump semver dep

### DIFF
--- a/packages/shared/sdk-server/package.json
+++ b/packages/shared/sdk-server/package.json
@@ -27,10 +27,9 @@
     "lint:fix": "yarn run lint -- --fix"
   },
   "license": "Apache-2.0",
-  "//": "Pinned semver because 7.5.0 introduced require('util') without the node: prefix",
   "dependencies": {
     "@launchdarkly/js-sdk-common": "1.0.2",
-    "semver": "7.4.0"
+    "semver": "7.5.4"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",


### PR DESCRIPTION
Updating semver to latest. The reason it was pinned to 7.5.0 was because 7.5.0 introduced require('util') without the node: prefix. This has been fixed in [7.5.1](https://github.com/npm/node-semver/releases/tag/v7.5.1) so we'll update to latest which is 7.5.4.