### PR TITLE
fix: broken local build due to sed -i warning

### DIFF
--- a/scripts/replace-version.sh
+++ b/scripts/replace-version.sh
@@ -1,7 +1,7 @@
 # Run this script like:
 # ./scripts/replace-version.sh packages/sdk/node
 
-# It will look for the string __LD_VERSION__ in the `dist` directory and replace 
+# It will look for the string __LD_VERSION__ in the `dist` directory and replace
 # any instances with the version from the package.json.
 
 # This is a workaround for a bug with the node-workspace plugin with release-please.
@@ -11,4 +11,5 @@ set -e
 
 version=$(node -p "let pj = require('./$1/package.json');\`\${pj.version}\`");
 
-find "$1/dist" -type f -exec sed -i "s/__LD_VERSION__/$version/g" {} +
+find "$1/dist" -type f -exec sed -i.UNUSED_BAK "s/__LD_VERSION__/$version/g" {} +
+find "$1/dist" -type f -name "*.UNUSED_BAK" -exec rm {} +


### PR DESCRIPTION
The workaround to replace sdk versions in [replace-version.sh](https://github.com/launchdarkly/js-core/blob/main/scripts/replace-version.sh#L14) does not work locally on OS X because the sed command is not posix compliant. This breaks yarn build locally on os x.

On os x, `sed -i` expects the next argument to a backup file extension.
On Linux/Unix, it does not.

This ticket implements a workaround for the workaround. As you can see, this is a rabbit hole which eventually is best solved by not using this script at all.