### PR TITLE
chore: fix eslint extraneous dep error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,11 @@ module.exports = {
   rules: {
     'prettier/prettier': ['error'],
     'class-methods-use-this': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/jest*.ts', '**/*.test.ts'],
+      },
+    ],
   },
 };


### PR DESCRIPTION
Exclude test files from the eslint no-extraneous-deps rule. This is failing in cloudflare index.test.ts where eslint insists 'miniflare' should be in deps, not devDep:

```js
    'import/no-extraneous-dependencies': [
      'error',
      {
        devDependencies: ['**/jest*.ts', '**/*.test.ts'],
      },
    ],
```