### PR TITLE
fix: Ensure that test data user targets are handled correctly.

### DIFF
--- a/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
@@ -137,6 +137,29 @@ describe('given an LDClient with test data', () => {
       reason: { kind: 'ERROR', errorKind: 'FLAG_NOT_FOUND' },
     });
   });
+
+  it('evaluates and updates user targets from test data', async () => {
+    // This is a specific test case for a customer issue.
+    // It tests the combination of evaluation and test data functionality.
+    const userUuid = '1234';
+    const userContextObject = {
+      kind: 'user',
+      key: userUuid,
+    };
+
+    await td.update(
+      td.flag('my-feature-flag-1').variationForUser(userUuid, false).fallthroughVariation(false),
+    );
+    const valueA = await client.variation('my-feature-flag-1', userContextObject, 'default');
+    expect(valueA).toEqual(false);
+
+    await td.update(
+      td.flag('my-feature-flag-1').variationForUser(userUuid, true).fallthroughVariation(false),
+    );
+
+    const valueB = await client.variation('my-feature-flag-1', userContextObject, 'default');
+    expect(valueB).toEqual(true);
+  });
 });
 
 describe('given an offline client', () => {

--- a/packages/shared/sdk-server/src/integrations/test_data/TestDataFlagBuilder.ts
+++ b/packages/shared/sdk-server/src/integrations/test_data/TestDataFlagBuilder.ts
@@ -394,18 +394,24 @@ export default class TestDataFlagBuilder {
 
     if (this.data.targetsByVariation) {
       const contextTargets: Target[] = [];
+      const userTargets: Omit<Target, 'contextKind'>[] = [];
       Object.entries(this.data.targetsByVariation).forEach(
         ([variation, contextTargetsForVariation]) => {
           Object.entries(contextTargetsForVariation).forEach(([contextKind, values]) => {
+            const numberVariation = parseInt(variation, 10);
             contextTargets.push({
               contextKind,
-              values,
+              values: contextKind === 'user' ? [] : values,
               // Iterating the object it will be a string.
-              variation: parseInt(variation, 10),
+              variation: numberVariation,
             });
+            if (contextKind === 'user') {
+              userTargets.push({ values, variation: numberVariation });
+            }
           });
         },
       );
+      baseFlagObject.targets = userTargets;
       baseFlagObject.contextTargets = contextTargets;
     }
 


### PR DESCRIPTION
User targets require special logic to put the variation/values into `targets` instead of just in `contextTargets`. This was not being done, so user specific targets were not evaluating correctly.

Github issue: https://github.com/launchdarkly/node-server-sdk/issues/283

