### PR TITLE
chore: Update the node version used for CI.

### DIFF
--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [16, 19]
+        version: [16, 20]
 
     env:
       TEST_HARNESS_PARAMS: '--skip-from=./contract-tests/testharness-suppressions.txt'

--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [16, 20]
+        version: [16, 18]
 
     env:
       TEST_HARNESS_PARAMS: '--skip-from=./contract-tests/testharness-suppressions.txt'


### PR DESCRIPTION
Node 19+ has a bug currently with connection resets. This only affects testing (because we have inbound connections), but I am downgrading to avoid it until it is resolved.