### PR TITLE
feat: Allow specifying the user agent per-sdk implementation.

### DIFF
--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -13,7 +13,7 @@ class CloudflarePlatformInfo implements Info {
     return {
       name,
       version,
-      userAgent: 'CloudflareEdgeSDK',
+      userAgentBase: 'CloudflareEdgeSDK',
     };
   }
 }

--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -13,6 +13,7 @@ class CloudflarePlatformInfo implements Info {
     return {
       name,
       version,
+      userAgent: 'Cloudflare',
     };
   }
 }

--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -13,7 +13,7 @@ class CloudflarePlatformInfo implements Info {
     return {
       name,
       version,
-      userAgent: 'Cloudflare',
+      userAgent: 'CloudflareEdgeSDK',
     };
   }
 }

--- a/packages/sdk/server-node/src/platform/NodeInfo.ts
+++ b/packages/sdk/server-node/src/platform/NodeInfo.ts
@@ -37,6 +37,7 @@ export default class NodeInfo implements platform.Info {
     return {
       name: packageJson.name,
       version: packageJson.version,
+      userAgent: 'NodeJSClient',
       // No wrapper name/version at the moment.
     };
   }

--- a/packages/sdk/server-node/src/platform/NodeInfo.ts
+++ b/packages/sdk/server-node/src/platform/NodeInfo.ts
@@ -37,7 +37,7 @@ export default class NodeInfo implements platform.Info {
     return {
       name: packageJson.name,
       version: packageJson.version,
-      userAgent: 'NodeJSClient',
+      userAgentBase: 'NodeJSClient',
       // No wrapper name/version at the moment.
     };
   }

--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -11,6 +11,7 @@ class VercelPlatformInfo implements Info {
     return {
       name: '@launchdarkly/vercel-server-sdk',
       version: '__LD_VERSION__',
+      userAgent: 'VercelEdgeSDK',
     };
   }
 }

--- a/packages/sdk/vercel/src/createPlatformInfo.ts
+++ b/packages/sdk/vercel/src/createPlatformInfo.ts
@@ -11,7 +11,7 @@ class VercelPlatformInfo implements Info {
     return {
       name: '@launchdarkly/vercel-server-sdk',
       version: '__LD_VERSION__',
-      userAgent: 'VercelEdgeSDK',
+      userAgentBase: 'VercelEdgeSDK',
     };
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
@@ -20,6 +20,7 @@ describe('Akamai Platform Info', () => {
     expect(platformData.sdkData()).toEqual({
       name: packageJson.name,
       version: packageJson.version,
+      userAgent: 'Akamai',
     });
   });
 });

--- a/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
@@ -20,7 +20,7 @@ describe('Akamai Platform Info', () => {
     expect(platformData.sdkData()).toEqual({
       name: packageJson.name,
       version: packageJson.version,
-      userAgent: 'AkamaiEdgeSDK',
+      userAgentBase: 'AkamaiEdgeSDK',
     });
   });
 });

--- a/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/__tests__/platform/info/index.test.ts
@@ -20,7 +20,7 @@ describe('Akamai Platform Info', () => {
     expect(platformData.sdkData()).toEqual({
       name: packageJson.name,
       version: packageJson.version,
-      userAgent: 'Akamai',
+      userAgent: 'AkamaiEdgeSDK',
     });
   });
 });

--- a/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
@@ -17,7 +17,7 @@ class AkamaiPlatformInfo implements Info {
     return {
       name: this.sdkName,
       version: this.sdkVersion,
-      userAgent: 'Akamai',
+      userAgent: 'AkamaiEdgeSDK',
     };
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
@@ -17,7 +17,7 @@ class AkamaiPlatformInfo implements Info {
     return {
       name: this.sdkName,
       version: this.sdkVersion,
-      userAgent: 'AkamaiEdgeSDK',
+      userAgentBase: 'AkamaiEdgeSDK',
     };
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/platform/info/index.ts
@@ -17,6 +17,7 @@ class AkamaiPlatformInfo implements Info {
     return {
       name: this.sdkName,
       version: this.sdkVersion,
+      userAgent: 'Akamai',
     };
   }
 }

--- a/packages/shared/common/src/api/platform/Info.ts
+++ b/packages/shared/common/src/api/platform/Info.ts
@@ -45,6 +45,11 @@ export interface SdkData {
   version?: string;
 
   /**
+   * If this is a top-level (not a wrapper) SDK this will be the user agent string.
+   */
+  userAgent?: string;
+
+  /**
    * Name of the wrapper SDK if present.
    */
   wrapperName?: string;

--- a/packages/shared/common/src/api/platform/Info.ts
+++ b/packages/shared/common/src/api/platform/Info.ts
@@ -45,9 +45,10 @@ export interface SdkData {
   version?: string;
 
   /**
-   * If this is a top-level (not a wrapper) SDK this will be the user agent string.
+   * If this is a top-level (not a wrapper) SDK this will be used to create the user agent string.
+   * It will take the form 'userAgentBase/version`.
    */
-  userAgent?: string;
+  userAgentBase?: string;
 
   /**
    * Name of the wrapper SDK if present.

--- a/packages/shared/sdk-server/__tests__/data_sources/defaultHeaders.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/defaultHeaders.test.ts
@@ -3,14 +3,14 @@ import { Info, PlatformData, SdkData } from '@launchdarkly/js-sdk-common';
 import defaultHeaders from '../../src/data_sources/defaultHeaders';
 import Configuration from '../../src/options/Configuration';
 
-const makeInfo = (wrapperName?: string, wrapperVersion?: string, userAgent?: string): Info => ({
+const makeInfo = (wrapperName?: string, wrapperVersion?: string, userAgentBase?: string): Info => ({
   platformData(): PlatformData {
     return {};
   },
   sdkData(): SdkData {
     const sdkData: SdkData = {
       version: '2.2.2',
-      userAgent,
+      userAgentBase,
       wrapperName,
       wrapperVersion,
     };

--- a/packages/shared/sdk-server/__tests__/data_sources/defaultHeaders.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/defaultHeaders.test.ts
@@ -3,13 +3,14 @@ import { Info, PlatformData, SdkData } from '@launchdarkly/js-sdk-common';
 import defaultHeaders from '../../src/data_sources/defaultHeaders';
 import Configuration from '../../src/options/Configuration';
 
-const makeInfo = (wrapperName?: string, wrapperVersion?: string): Info => ({
+const makeInfo = (wrapperName?: string, wrapperVersion?: string, userAgent?: string): Info => ({
   platformData(): PlatformData {
     return {};
   },
   sdkData(): SdkData {
     const sdkData: SdkData = {
       version: '2.2.2',
+      userAgent,
       wrapperName,
       wrapperVersion,
     };
@@ -23,10 +24,16 @@ it('sets SDK key', () => {
   expect(h).toMatchObject({ authorization: 'my-sdk-key' });
 });
 
-it('sets user agent', () => {
+it('sets the default user agent', () => {
   const config = new Configuration({});
   const h = defaultHeaders('my-sdk-key', config, makeInfo());
   expect(h).toMatchObject({ 'user-agent': 'NodeJSClient/2.2.2' });
+});
+
+it('sets the SDK specific user agent', () => {
+  const config = new Configuration({});
+  const h = defaultHeaders('my-sdk-key', config, makeInfo(undefined, undefined, 'CATS'));
+  expect(h).toMatchObject({ 'user-agent': 'CATS/2.2.2' });
 });
 
 it('does not include wrapper header by default', () => {

--- a/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
+++ b/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
@@ -12,7 +12,7 @@ export default function defaultHeaders(
   const sdkData = info.sdkData();
   const headers: { [key: string]: string } = {
     authorization: sdkKey,
-    'user-agent': `NodeJSClient/${sdkData.version}`,
+    'user-agent': `${sdkData.userAgent ? sdkData.userAgent : 'NodeJSClient'}/${sdkData.version}`,
   };
 
   if (sdkData.wrapperName) {

--- a/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
+++ b/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
@@ -12,7 +12,9 @@ export default function defaultHeaders(
   const sdkData = info.sdkData();
   const headers: { [key: string]: string } = {
     authorization: sdkKey,
-    'user-agent': `${sdkData.userAgentBase ? sdkData.userAgentBase : 'NodeJSClient'}/${sdkData.version}`,
+    'user-agent': `${sdkData.userAgentBase ? sdkData.userAgentBase : 'NodeJSClient'}/${
+      sdkData.version
+    }`,
   };
 
   if (sdkData.wrapperName) {

--- a/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
+++ b/packages/shared/sdk-server/src/data_sources/defaultHeaders.ts
@@ -12,7 +12,7 @@ export default function defaultHeaders(
   const sdkData = info.sdkData();
   const headers: { [key: string]: string } = {
     authorization: sdkKey,
-    'user-agent': `${sdkData.userAgent ? sdkData.userAgent : 'NodeJSClient'}/${sdkData.version}`,
+    'user-agent': `${sdkData.userAgentBase ? sdkData.userAgentBase : 'NodeJSClient'}/${sdkData.version}`,
   };
 
   if (sdkData.wrapperName) {


### PR DESCRIPTION
Currently `NodeJSClient` is being used as the user agent for all server SDKs.

This was not apparent because only node was sending events. Events are being added to Vercel and it revealed this issue.
