### PR TITLE
chore: Unpin vercel release version to allow correct change log generation.

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,7 +4,7 @@
   "packages/sdk/server-node": "8.1.2",
   "packages/sdk/cloudflare": "2.0.9",
   "packages/shared/sdk-server-edge": "1.0.8",
-  "packages/sdk/vercel": "1.0.0",
+  "packages/sdk/vercel": "1.0.2",
   "packages/sdk/akamai-base": "1.0.2",
   "packages/sdk/akamai-edgekv": "1.0.2",
   "packages/shared/akamai-edgeworker-sdk": "0.2.7",

--- a/packages/sdk/vercel/package.json
+++ b/packages/sdk/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchdarkly/vercel-server-sdk",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "LaunchDarkly Server-Side SDK for Vercel Edge",
   "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/sdk/vercel",
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,7 @@
     "packages/sdk/server-node": {},
     "packages/sdk/cloudflare": {},
     "packages/sdk/vercel": {
-      "extra-files": ["src/createPlatformInfo.ts"],
-      "release-as": "1.0.0"
+      "extra-files": ["src/createPlatformInfo.ts"]
     },
     "packages/sdk/akamai-base": {
       "extra-files": ["src/index.ts"]


### PR DESCRIPTION
Release-As was left in the release please config.

Two versions have actually been released since then. They released fine, but the changelog was getting incorrect headers.