### PR TITLE
chore: Change akamai module to nodenext

### DIFF
--- a/packages/sdk/akamai-base/example/tsconfig.json
+++ b/packages/sdk/akamai-base/example/tsconfig.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "incremental": true,
     "strict": true,
-    "module": "node",
+    "module": "nodenext",
     "outDir": "dist/ew",
     "target": "ESNext",
     "lib": ["es2023", "DOM"],
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },

--- a/packages/sdk/akamai-base/tsconfig.json
+++ b/packages/sdk/akamai-base/tsconfig.json
@@ -15,7 +15,7 @@
     "declarationMap": true, // enables importers to jump to source
     "resolveJsonModule": true,
     "stripInternal": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "types": ["jest", "node"],
     "skipLibCheck": true
   },


### PR DESCRIPTION

I am putting these back to nodenext. After pinning typescript I found that rollup and typescript are not agreeing on what these options should be set to.