### PR TITLE
feat: Add invoked measurement.

### DIFF
--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -29,6 +29,7 @@ app.get('/', (req, res) => {
       'big-segments',
       'user-type',
       'migrations',
+      'event-sampling'
     ],
   });
 });

--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -29,7 +29,7 @@ app.get('/', (req, res) => {
       'big-segments',
       'user-type',
       'migrations',
-      'event-sampling'
+      'event-sampling',
     ],
   });
 });

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -64,7 +64,7 @@ export function makeSdkConfig(options, tag) {
 }
 
 function getExecution(order) {
-  switch(order) {
+  switch (order) {
     case 'serial': {
       return new LDSerialExecution(LDExecutionOrdering.Fixed);
     }
@@ -164,7 +164,7 @@ export async function newSdkClientEntity(options) {
       case 'migrationOperation':
         const migrationOperation = params.migrationOperation;
         const readExecutionOrder = migrationOperation.readExecutionOrder;
-        
+
         const migration = new Migration(client, {
           execution: getExecution(readExecutionOrder),
           latencyTracking: migrationOperation.trackLatency,

--- a/packages/shared/sdk-server/__tests__/MigrationOpEvent.test.ts
+++ b/packages/shared/sdk-server/__tests__/MigrationOpEvent.test.ts
@@ -91,9 +91,9 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent.measurements[0].key).toEqual('consistent');
+          expect(migrationEvent.measurements[1].key).toEqual('consistent');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].value).toEqual(true);
+          expect(migrationEvent.measurements[1].value).toEqual(true);
         },
       );
 
@@ -110,9 +110,9 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent.measurements[0].key).toEqual('consistent');
+          expect(migrationEvent.measurements[1].key).toEqual('consistent');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].value).toEqual(true);
+          expect(migrationEvent.measurements[1].value).toEqual(true);
           expect(internal.shouldSample).toHaveBeenCalledWith(10);
         },
       );
@@ -130,7 +130,7 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent.measurements.length).toEqual(0);
+          expect(migrationEvent.measurements.length).toEqual(1);
           expect(internal.shouldSample).toHaveBeenCalledWith(12);
         },
       );
@@ -163,9 +163,9 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('consistent');
+          expect(migrationEvent.measurements[1].key).toEqual('consistent');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].value).toEqual(false);
+          expect(migrationEvent.measurements[1].value).toEqual(false);
         },
       );
     });
@@ -202,10 +202,10 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+          expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].values.old).toBeGreaterThanOrEqual(1);
-          expect(migrationEvent.measurements[0].values.new).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.old).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.new).toBeGreaterThanOrEqual(1);
         },
       );
 
@@ -220,10 +220,10 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+          expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].values.old).toBeGreaterThanOrEqual(1);
-          expect(migrationEvent.measurements[0].values.new).toBeUndefined();
+          expect(migrationEvent.measurements[1].values.old).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.new).toBeUndefined();
         },
       );
 
@@ -238,10 +238,10 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+          expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].values.new).toBeGreaterThanOrEqual(1);
-          expect(migrationEvent.measurements[0].values.old).toBeUndefined();
+          expect(migrationEvent.measurements[1].values.new).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.old).toBeUndefined();
         },
       );
 
@@ -254,10 +254,10 @@ describe('given an LDClient with test data', () => {
         await events.take();
         // Migration event.
         const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-        expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+        expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
         // This isn't a precise check, but we should have non-zero values.
-        expect(migrationEvent.measurements[0].values.old).toBeGreaterThanOrEqual(1);
-        expect(migrationEvent.measurements[0].values.new).toBeUndefined();
+        expect(migrationEvent.measurements[1].values.old).toBeGreaterThanOrEqual(1);
+        expect(migrationEvent.measurements[1].values.new).toBeUndefined();
       });
 
       it.each([LDMigrationStage.Complete])(
@@ -271,10 +271,10 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+          expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].values.new).toBeGreaterThanOrEqual(1);
-          expect(migrationEvent.measurements[0].values.old).toBeUndefined();
+          expect(migrationEvent.measurements[1].values.new).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.old).toBeUndefined();
         },
       );
 
@@ -289,10 +289,10 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+          expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
           // This isn't a precise check, but we should have non-zero values.
-          expect(migrationEvent.measurements[0].values.old).toBeGreaterThanOrEqual(1);
-          expect(migrationEvent.measurements[0].values.new).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.old).toBeGreaterThanOrEqual(1);
+          expect(migrationEvent.measurements[1].values.new).toBeGreaterThanOrEqual(1);
         },
       );
 
@@ -305,10 +305,10 @@ describe('given an LDClient with test data', () => {
         await events.take();
         // Migration event.
         const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-        expect(migrationEvent.measurements[0].key).toEqual('latency_ms');
+        expect(migrationEvent.measurements[1].key).toEqual('latency_ms');
         // This isn't a precise check, but we should have non-zero values.
-        expect(migrationEvent.measurements[0].values.old).toBeGreaterThanOrEqual(1);
-        expect(migrationEvent.measurements[0].values.new).toBeGreaterThanOrEqual(1);
+        expect(migrationEvent.measurements[1].values.old).toBeGreaterThanOrEqual(1);
+        expect(migrationEvent.measurements[1].values.new).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -338,17 +338,14 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent).toMatchObject({
-            measurements: [
-              {
-                key: 'error',
-                values: {
-                  old: true,
-                },
+          expect(migrationEvent.measurements).toContainEqual(
+            {
+              key: 'error',
+              values: {
+                old: true,
               },
-            ],
-          });
-        },
+            });
+        }
       );
 
       it.each([LDMigrationStage.RampDown, LDMigrationStage.Complete])(
@@ -362,16 +359,13 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent).toMatchObject({
-            measurements: [
-              {
-                key: 'error',
-                values: {
-                  new: true,
-                },
+          expect(migrationEvent.measurements).toContainEqual(
+            {
+              key: 'error',
+              values: {
+                new: true,
               },
-            ],
-          });
+            });
         },
       );
 
@@ -387,17 +381,14 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent).toMatchObject({
-            measurements: [
-              {
-                key: 'error',
-                values: {
-                  old: true,
-                  new: true,
-                },
+          expect(migrationEvent.measurements).toContainEqual(
+            {
+              key: 'error',
+              values: {
+                old: true,
+                new: true,
               },
-            ],
-          });
+            });
         },
       );
 
@@ -412,16 +403,13 @@ describe('given an LDClient with test data', () => {
           await events.take();
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
-          expect(migrationEvent).toMatchObject({
-            measurements: [
-              {
-                key: 'error',
-                values: {
-                  old: true,
-                },
+          expect(migrationEvent.measurements).toContainEqual(
+            {
+              key: 'error',
+              values: {
+                old: true,
               },
-            ],
-          });
+            });
         },
       );
 
@@ -437,16 +425,13 @@ describe('given an LDClient with test data', () => {
           // Migration event.
           const migrationEvent = (await events.take()) as internal.InputMigrationEvent;
           // Only check the measurements component of the event.
-          expect(migrationEvent).toMatchObject({
-            measurements: [
-              {
-                key: 'error',
-                values: {
-                  new: true,
-                },
+          expect(migrationEvent.measurements).toContainEqual(
+            {
+              key: 'error',
+              values: {
+                new: true,
               },
-            ],
-          });
+            });
         },
       );
     });

--- a/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
+++ b/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
@@ -69,6 +69,8 @@ it('includes errors if at least one is set', () => {
   );
   tracker.op('read');
   tracker.error('old');
+  tracker.invoked('old');
+  tracker.invoked('new');
 
   const event = tracker.createEvent();
   expect(event?.measurements).toContainEqual({
@@ -89,6 +91,8 @@ it('includes errors if at least one is set', () => {
   );
   trackerB.op('read');
   trackerB.error('new');
+  trackerB.invoked('old');
+  trackerB.invoked('new');
 
   const eventB = trackerB.createEvent();
   expect(eventB?.measurements).toContainEqual({
@@ -111,6 +115,8 @@ it('includes latency if at least one measurement exists', () => {
   );
   tracker.op('read');
   tracker.latency('old', 100);
+  tracker.invoked('old');
+  tracker.invoked('new');
 
   const event = tracker.createEvent();
   expect(event?.measurements).toContainEqual({
@@ -131,6 +137,8 @@ it('includes latency if at least one measurement exists', () => {
   );
   trackerB.op('read');
   trackerB.latency('new', 150);
+  trackerB.invoked('old');
+  trackerB.invoked('new');
 
   const eventB = trackerB.createEvent();
   expect(eventB?.measurements).toContainEqual({
@@ -153,6 +161,8 @@ it('includes if the result was consistent', () => {
   );
   tracker.op('read');
   tracker.consistency(LDConsistencyCheck.Consistent);
+  tracker.invoked('old');
+  tracker.invoked('new');
 
   const event = tracker.createEvent();
   expect(event?.measurements).toContainEqual({
@@ -173,6 +183,8 @@ it('includes if the result was inconsistent', () => {
     },
   );
   tracker.op('read');
+  tracker.invoked('old');
+  tracker.invoked('new');
   tracker.consistency(LDConsistencyCheck.Inconsistent);
 
   const event = tracker.createEvent();

--- a/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
+++ b/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
@@ -1,6 +1,6 @@
 import { LDConsistencyCheck, LDMigrationStage } from '../src';
-import MigrationOpTracker from '../src/MigrationOpTracker';
 import { LDMigrationOrigin } from '../src/api/LDMigration';
+import MigrationOpTracker from '../src/MigrationOpTracker';
 
 it('does not generate an event if an op is not set', () => {
   const tracker = new MigrationOpTracker(
@@ -45,12 +45,14 @@ it('generates an event if the minimal requirements are met.', () => {
     contextKeys: { user: 'bob' },
     evaluation: { default: 'off', key: 'flag', reason: { kind: 'FALLTHROUGH' }, value: 'off' },
     kind: 'migration_op',
-    measurements: [{
-      key: 'invoked',
-      values: {
-        old: true,
-      }
-    }],
+    measurements: [
+      {
+        key: 'invoked',
+        values: {
+          old: true,
+        },
+      },
+    ],
     operation: 'write',
   });
 });

--- a/packages/shared/sdk-server/src/Migration.ts
+++ b/packages/shared/sdk-server/src/Migration.ts
@@ -302,6 +302,7 @@ export default class Migration<
     origin: LDMigrationOrigin,
     method: (payload?: TInput) => Promise<LDMethodResult<TOutput>>,
   ): Promise<LDMigrationResult<TOutput>> {
+    context.tracker.invoked(origin);
     const res = await this.trackLatency(context.tracker, origin, () =>
       safeCall(() => method(context.payload)),
     );

--- a/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
+++ b/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
@@ -22,23 +22,23 @@ function isOperation(value: LDMigrationOp) {
 function isLatencyMeasurement(
   value: LDMigrationMeasurement,
 ): value is LDMigrationLatencyMeasurement {
-  return (value as any).kind === undefined && value.key === 'latency_ms';
+  return value.key === 'latency_ms';
 }
 
 function isErrorMeasurement(value: LDMigrationMeasurement): value is LDMigrationErrorMeasurement {
-  return (value as any).kind === undefined && value.key === 'error';
+  return value.key === 'error';
 }
 
 function isInvokedMeasurement(
   value: LDMigrationMeasurement,
 ): value is LDMigrationInvokedMeasurement {
-  return (value as any).kind === undefined && value.key === 'invoked';
+  return value.key === 'invoked';
 }
 
 function isConsistencyMeasurement(
   value: LDMigrationMeasurement,
 ): value is LDMigrationConsistencyMeasurement {
-  return (value as any).kind === undefined && value.key === 'consistent';
+  return value.key === 'consistent';
 }
 
 function areValidNumbers(values: { old?: number; new?: number }) {

--- a/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
+++ b/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
@@ -4,6 +4,7 @@ import {
   LDMigrationConsistencyMeasurement,
   LDMigrationErrorMeasurement,
   LDMigrationEvaluation,
+  LDMigrationInvokedMeasurement,
   LDMigrationLatencyMeasurement,
   LDMigrationMeasurement,
   LDMigrationOp,
@@ -26,6 +27,10 @@ function isLatencyMeasurement(
 
 function isErrorMeasurement(value: LDMigrationMeasurement): value is LDMigrationErrorMeasurement {
   return (value as any).kind === undefined && value.key === 'error';
+}
+
+function isInvokedMeasurement(value: LDMigrationMeasurement): value is LDMigrationInvokedMeasurement {
+  return (value as any).kind === undefined && value.key === 'invoked';
 }
 
 function isConsistencyMeasurement(
@@ -111,6 +116,22 @@ function validateMeasurement(
       key: measurement.key,
       value: measurement.value,
       samplingRatio: measurement.samplingRatio,
+    };
+  }
+
+  if(isInvokedMeasurement(measurement)) {
+    if (!TypeValidators.Object.is(measurement.values)) {
+      return undefined;
+    }
+    if (!areValidBooleans(measurement.values)) {
+      return undefined;
+    }
+    return {
+      key: measurement.key,
+      values: {
+        old: measurement.values.old,
+        new: measurement.values.new,
+      },
     };
   }
 

--- a/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
+++ b/packages/shared/sdk-server/src/MigrationOpEventConversion.ts
@@ -29,7 +29,9 @@ function isErrorMeasurement(value: LDMigrationMeasurement): value is LDMigration
   return (value as any).kind === undefined && value.key === 'error';
 }
 
-function isInvokedMeasurement(value: LDMigrationMeasurement): value is LDMigrationInvokedMeasurement {
+function isInvokedMeasurement(
+  value: LDMigrationMeasurement,
+): value is LDMigrationInvokedMeasurement {
   return (value as any).kind === undefined && value.key === 'invoked';
 }
 
@@ -119,7 +121,7 @@ function validateMeasurement(
     };
   }
 
-  if(isInvokedMeasurement(measurement)) {
+  if (isInvokedMeasurement(measurement)) {
     if (!TypeValidators.Object.is(measurement.values)) {
       return undefined;
     }

--- a/packages/shared/sdk-server/src/MigrationOpTracker.ts
+++ b/packages/shared/sdk-server/src/MigrationOpTracker.ts
@@ -75,7 +75,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
 
     if (Object.keys(this.contextKeys).length === 0) {
       this.logger?.error(
-        'The migration was not done against a valid context and cannot' + 'generate an event.',
+        'The migration was not done against a valid context and cannot generate an event.',
       );
       return undefined;
     }

--- a/packages/shared/sdk-server/src/MigrationOpTracker.ts
+++ b/packages/shared/sdk-server/src/MigrationOpTracker.ts
@@ -45,7 +45,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
     private readonly variation?: number,
     private readonly samplingRatio?: number,
     private readonly logger?: LDLogger,
-  ) { }
+  ) {}
 
   op(op: LDMigrationOp) {
     this.operation = op;
@@ -74,14 +74,17 @@ export default class MigrationOpTracker implements LDMigrationTracker {
     }
 
     if (Object.keys(this.contextKeys).length === 0) {
-      this.logger?.error('The migration was not done against a valid context and cannot' +
-        'generate an event.');
+      this.logger?.error(
+        'The migration was not done against a valid context and cannot' + 'generate an event.',
+      );
       return undefined;
     }
 
     if (!this.wasInvoked.old && !this.wasInvoked.new) {
-      this.logger?.error('The migration invoked neither the "old" or "new" implementation and' + 
-      'an event cannot be generated');
+      this.logger?.error(
+        'The migration invoked neither the "old" or "new" implementation and' +
+          'an event cannot be generated',
+      );
       return undefined;
     }
 

--- a/packages/shared/sdk-server/src/MigrationOpTracker.ts
+++ b/packages/shared/sdk-server/src/MigrationOpTracker.ts
@@ -113,19 +113,19 @@ export default class MigrationOpTracker implements LDMigrationTracker {
     };
   }
 
-  private logTag(): string {
+  private logTag() {
     return `For migration ${this.operation}-${this.flagKey}:`;
   }
 
-  private latencyConsistencyMessage(origin: LDMigrationOrigin): string {
+  private latencyConsistencyMessage(origin: LDMigrationOrigin) {
     return `Latency measurement for "${origin}", but "new" was not invoked.`;
   }
 
-  private errorConsistencyMessage(origin: LDMigrationOrigin): string {
+  private errorConsistencyMessage(origin: LDMigrationOrigin) {
     return `Error occurred for "${origin}", but "new" was not invoked.`;
   }
 
-  private consistencyCheckConsistencyMessage(origin: LDMigrationOrigin): string {
+  private consistencyCheckConsistencyMessage(origin: LDMigrationOrigin) {
     return (
       `Consistency check was done, but "${origin}" was not invoked.` +
       'Both "old" and "new" must be invoked to do a consistency check.'

--- a/packages/shared/sdk-server/src/MigrationOpTracker.ts
+++ b/packages/shared/sdk-server/src/MigrationOpTracker.ts
@@ -1,9 +1,10 @@
-import { LDEvaluationReason } from '@launchdarkly/js-sdk-common';
+import { LDEvaluationReason, LDLogger } from '@launchdarkly/js-sdk-common';
 
 import { LDMigrationStage, LDMigrationTracker } from './api';
 import {
   LDConsistencyCheck,
   LDMigrationErrorMeasurement,
+  LDMigrationInvokedMeasurement,
   LDMigrationMeasurement,
   LDMigrationOp,
   LDMigrationOpEvent,
@@ -16,6 +17,11 @@ function isPopulated(data: number): boolean {
 
 export default class MigrationOpTracker implements LDMigrationTracker {
   private errors = {
+    old: false,
+    new: false,
+  };
+
+  private wasInvoked = {
     old: false,
     new: false,
   };
@@ -38,6 +44,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
     private readonly checkRatio?: number,
     private readonly variation?: number,
     private readonly samplingRatio?: number,
+    private readonly logger?: LDLogger,
   ) {}
 
   op(op: LDMigrationOp) {
@@ -56,13 +63,19 @@ export default class MigrationOpTracker implements LDMigrationTracker {
     this.latencyMeasurement[origin] = value;
   }
 
+  invoked(origin: LDMigrationOrigin) {
+    this.wasInvoked[origin] = true;
+  }
+
   createEvent(): LDMigrationOpEvent | undefined {
     if (this.operation && Object.keys(this.contextKeys).length) {
       const measurements: LDMigrationMeasurement[] = [];
 
+      this.populateInvoked(measurements);
       this.populateConsistency(measurements);
       this.populateLatency(measurements);
       this.populateErrors(measurements);
+      this.measurementConsistencyCheck();
 
       return {
         kind: 'migration_op',
@@ -81,6 +94,70 @@ export default class MigrationOpTracker implements LDMigrationTracker {
       };
     }
     return undefined;
+  }
+
+  private logTag(): string {
+    return `For migration ${this.operation}-${this.flagKey}:`;
+  }
+
+  private latencyConsistencyMessage(origin: LDMigrationOrigin): string {
+    return `Latency measurement for "${origin}", but "new" was not invoked.`;
+  }
+
+  private errorConsistencyMessage(origin: LDMigrationOrigin): string {
+    return `Error occurred for "${origin}", but "new" was not invoked.`;
+  }
+
+  private consistencyCheckConsistencyMessage(origin: LDMigrationOrigin): string {
+    return (
+      `Consistency check was done, but "${origin}" was not invoked.` +
+      'Both "old" and "new" must be invoked to do a consistency check.'
+    );
+  }
+
+  private checkOriginEventConsistency(origin: LDMigrationOrigin) {
+    if (this.wasInvoked[origin]) {
+      return;
+    }
+
+    // If the specific origin was not invoked, but it contains measurements, then
+    // that is a problem. Check each measurement and log a message if it is present.
+    if (!Number.isNaN(this.latencyMeasurement[origin])) {
+      this.logger?.error(`${this.logTag()} ${this.latencyConsistencyMessage(origin)}`);
+    }
+
+    if (this.errors[origin]) {
+      this.logger?.error(`${this.logTag()} ${this.errorConsistencyMessage(origin)}`);
+    }
+
+    if (this.consistencyCheck !== LDConsistencyCheck.NotChecked) {
+      this.logger?.error(`${this.logTag()} ${this.consistencyCheckConsistencyMessage(origin)}`);
+    }
+  }
+
+  /**
+   * Check that the latency, error, consistency and invoked measurements are self-consistent.
+   */
+  private measurementConsistencyCheck() {
+    this.checkOriginEventConsistency('old');
+    this.checkOriginEventConsistency('new');
+  }
+
+  private populateInvoked(measurements: LDMigrationMeasurement[]) {
+    const measurement: LDMigrationInvokedMeasurement = {
+      key: 'invoked',
+      values: {},
+    };
+    if (!this.wasInvoked.old && !this.wasInvoked.new) {
+      this.logger?.error('Migration op completed without executing any origins (old/new).');
+    }
+    if (this.wasInvoked.old) {
+      measurement.values.old = true;
+    }
+    if (this.wasInvoked.new) {
+      measurement.values.new = true;
+    }
+    measurements.push(measurement);
   }
 
   private populateConsistency(measurements: LDMigrationMeasurement[]) {

--- a/packages/shared/sdk-server/src/api/data/LDMigrationDetail.ts
+++ b/packages/shared/sdk-server/src/api/data/LDMigrationDetail.ts
@@ -41,6 +41,16 @@ export interface LDMigrationTracker {
   consistency(result: LDConsistencyCheck): void;
 
   /**
+   * Call this to report that an origin was invoked (executed). There are some situations where the
+   * expectation is that both the old and new implementation will be used, but with writes
+   * it is possible that the non-authoritative will not execute. Reporting the execution allows
+   * for more accurate analytics.
+   *
+   * @param origin The origin that was invoked.
+   */
+  invoked(origin: LDMigrationOrigin): void;
+
+  /**
    * Report the latency of an operation.
    *
    * @param origin The origin the latency is being reported for.

--- a/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
+++ b/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
@@ -43,7 +43,7 @@ export interface LDMigrationInvokedMeasurement {
   values: {
     old?: boolean;
     new?: boolean;
-  }
+  };
 }
 
 /**

--- a/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
+++ b/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
@@ -38,13 +38,22 @@ export interface LDMigrationErrorMeasurement {
   };
 }
 
+export interface LDMigrationInvokedMeasurement {
+  key: 'invoked';
+  values: {
+    old?: boolean;
+    new?: boolean;
+  }
+}
+
 /**
  * Types of measurements supported by an LDMigrationOpEvent.
  */
 export type LDMigrationMeasurement =
   | LDMigrationLatencyMeasurement
   | LDMigrationErrorMeasurement
-  | LDMigrationConsistencyMeasurement;
+  | LDMigrationConsistencyMeasurement
+  | LDMigrationInvokedMeasurement;
 
 /**
  * Event used to track information about a migration operation.


### PR DESCRIPTION
The migration_op event now has a measurement for which "origins" were invoked. Basically was the 'new' method, the 'old' method, or both executed.

This is because from other data you cannot safely infer what was executed. We need to know total executions in order to properly analyze results.