### PR TITLE
fix: Fix double call when platform support performance API.

### DIFF
--- a/packages/shared/sdk-server/src/Migration.ts
+++ b/packages/shared/sdk-server/src/Migration.ts
@@ -359,10 +359,11 @@ export default class Migration<
       start = performance.now();
       result = await method();
       end = performance.now();
+    } else {
+      start = Date.now();
+      result = await method();
+      end = Date.now();
     }
-    start = Date.now();
-    result = await method();
-    end = Date.now();
 
     // Performance timer is in ms, but may have a microsecond resolution
     // fractional component.


### PR DESCRIPTION
Migration method would get called twice during latency measurement.