### PR TITLE
fix: Use clientSideAvailability instead of clientSide for filtering client side flags.

### DIFF
--- a/packages/shared/akamai-edgeworker-sdk/src/__tests__/testData.json
+++ b/packages/shared/akamai-edgeworker-sdk/src/__tests__/testData.json
@@ -97,7 +97,7 @@
       "variations": [true, false],
       "clientSideAvailability": {
         "usingMobileKey": true,
-        "usingEnvironmentId": true
+        "usingEnvironmentId": false
       },
       "clientSide": false,
       "salt": "aef830243d6640d0a973be89988e008d",

--- a/packages/shared/sdk-server/__tests__/LDClient.allFlags.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClient.allFlags.test.ts
@@ -108,28 +108,28 @@ describe('given an LDClient with test data', () => {
       on: false,
       offVariation: 0,
       variations: ['a'],
-      clientSide: false,
     });
     td.usePreconfiguredFlag({
       key: 'server-side-2',
       on: false,
       offVariation: 0,
       variations: ['b'],
-      clientSide: false,
+      // Absence and false should be equivalent, so we add a false one here.
+      clientSideAvailability: { usingEnvironmentId: false },
     });
     td.usePreconfiguredFlag({
       key: 'client-side-1',
       on: false,
       offVariation: 0,
       variations: ['value1'],
-      clientSide: true,
+      clientSideAvailability: { usingEnvironmentId: true },
     });
     td.usePreconfiguredFlag({
       key: 'client-side-2',
       on: false,
       offVariation: 0,
       variations: ['value2'],
-      clientSide: true,
+      clientSideAvailability: { usingEnvironmentId: true },
     });
     const state = await client.allFlagsState(defaultUser, { clientSideOnly: true });
     expect(state.valid).toEqual(true);
@@ -241,28 +241,26 @@ describe('given an LDClient with test data', () => {
       on: false,
       offVariation: 0,
       variations: ['a'],
-      clientSide: false,
     });
     td.usePreconfiguredFlag({
       key: 'server-side-2',
       on: false,
       offVariation: 0,
       variations: ['b'],
-      clientSide: false,
     });
     td.usePreconfiguredFlag({
       key: 'client-side-1',
       on: false,
       offVariation: 0,
       variations: ['value1'],
-      clientSide: true,
+      clientSideAvailability: { usingEnvironmentId: true },
     });
     td.usePreconfiguredFlag({
       key: 'client-side-2',
       on: false,
       offVariation: 0,
       variations: ['value2'],
-      clientSide: true,
+      clientSideAvailability: { usingEnvironmentId: true },
     });
     client.allFlagsState(defaultUser, { clientSideOnly: true }, (err, state) => {
       expect(state.valid).toEqual(true);

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -301,7 +301,7 @@ export default class LDClientImpl implements LDClient {
             Object.values(allFlags),
             (storeItem, iterCb) => {
               const flag = storeItem as Flag;
-              if (clientOnly && !flag.clientSide) {
+              if (clientOnly && !flag.clientSideAvailability?.usingEnvironmentId) {
                 iterCb(true);
                 return;
               }


### PR DESCRIPTION
The node-server-sdk was not using the newer `clientSideAvailability`, but `clientSide`. In porting to TS that logic was retained. This updates it to use the newer field.