### PR TITLE
feat: Add typed variation methods.

### DIFF
--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -31,7 +31,8 @@ app.get('/', (req, res) => {
       'migrations',
       'event-sampling',
       'config-override-kind',
-      'metric-kind'
+      'metric-kind',
+      'strongly-typed',
     ],
   });
 });

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -140,8 +140,7 @@ export async function newSdkClientEntity(options) {
           switch(pe.valueType) {
             case "bool":
               return {value: await client.boolVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
-            case "int":
-              return {value: await client.numberVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+            case "int": // Intentional fallthrough.
             case "double":
               return {value: await client.numberVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
             case "string":

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -127,8 +127,7 @@ export async function newSdkClientEntity(options) {
           switch(pe.valueType) {
             case "bool":
               return await client.boolVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
-            case "int":
-              return await client.numberVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+            case "int": // Intentional fallthrough.
             case "double":
               return await client.numberVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
             case "string":

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -124,10 +124,32 @@ export async function newSdkClientEntity(options) {
       case 'evaluate': {
         const pe = params.evaluate;
         if (pe.detail) {
-          return await client.variationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+          switch(pe.valueType) {
+            case "bool":
+              return await client.boolVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+            case "int":
+              return await client.numberVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+            case "double":
+              return await client.numberVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+            case "string":
+              return await client.stringVariationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+            default:
+              return await client.variationDetail(pe.flagKey, pe.context || pe.user, pe.defaultValue);
+          }
+
         } else {
-          const value = await client.variation(pe.flagKey, pe.context || pe.user, pe.defaultValue);
-          return { value };
+          switch(pe.valueType) {
+            case "bool":
+              return {value: await client.boolVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+            case "int":
+              return {value: await client.numberVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+            case "double":
+              return {value: await client.numberVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+            case "string":
+              return {value: await client.stringVariation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+            default:
+              return {value: await client.variation(pe.flagKey, pe.context || pe.user, pe.defaultValue)};
+          }
         }
       }
 
@@ -160,7 +182,7 @@ export async function newSdkClientEntity(options) {
 
       case 'migrationVariation':
         const migrationVariation = params.migrationVariation;
-        const res = await client.variationMigration(
+        const res = await client.migrationVariation(
           migrationVariation.key,
           migrationVariation.context,
           migrationVariation.defaultStage,

--- a/packages/shared/common/src/api/data/LDEvaluationDetail.ts
+++ b/packages/shared/common/src/api/data/LDEvaluationDetail.ts
@@ -27,3 +27,22 @@ export interface LDEvaluationDetail {
    */
   reason: LDEvaluationReason;
 }
+
+export interface LDEvaluationDetailTyped<TFlag> {
+  /**
+   * The result of the flag evaluation. This will be either one of the flag's variations or
+   * the default value that was passed to `LDClient.variationDetail`.
+   */
+  value: TFlag;
+
+  /**
+   * The index of the returned value within the flag's list of variations, e.g. 0 for the
+   * first variation-- or `null` if the default value was returned.
+   */
+  variationIndex?: number | null;
+
+  /**
+   * An object describing the main factor that influenced the flag evaluation value.
+   */
+  reason: LDEvaluationReason;
+}

--- a/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
@@ -160,6 +160,99 @@ describe('given an LDClient with test data', () => {
     const valueB = await client.variation('my-feature-flag-1', userContextObject, 'default');
     expect(valueB).toEqual(true);
   });
+
+  it('evaluates with jsonVariation', async () => {
+    td.update(td.flag('flagkey').booleanFlag().on(true));
+    const boolRes: boolean = (await client.jsonVariation('flagkey', defaultUser, false)) as boolean;
+    expect(boolRes).toBe(true);
+
+    td.update(td.flag('flagkey').valueForAll(62));
+    const numericRes: number = (await client.jsonVariation(
+      'flagkey',
+      defaultUser,
+      false,
+    )) as number;
+    expect(numericRes).toBe(62);
+
+    td.update(td.flag('flagkey').valueForAll('potato'));
+    const stringRes: string = (await client.jsonVariation('flagkey', defaultUser, false)) as string;
+    expect(stringRes).toBe('potato');
+  });
+
+  it('evaluates an existing boolean flag', async () => {
+    td.update(td.flag('flagkey').booleanFlag().on(true));
+    expect(await client.boolVariation('flagkey', defaultUser, false)).toEqual(true);
+  });
+
+  it('it uses the default value when a boolean variation is for a flag of the wrong type', async () => {
+    td.update(td.flag('flagkey').valueForAll('potato'));
+    expect(await client.boolVariation('flagkey', defaultUser, false)).toEqual(false);
+  });
+
+  it('evaluates an existing numeric flag', async () => {
+    td.update(td.flag('flagkey').booleanFlag().valueForAll(18));
+    expect(await client.numberVariation('flagkey', defaultUser, 36)).toEqual(18);
+  });
+
+  it('it uses the default value when a numeric variation is for a flag of the wrong type', async () => {
+    td.update(td.flag('flagkey').valueForAll('potato'));
+    expect(await client.numberVariation('flagkey', defaultUser, 36)).toEqual(36);
+  });
+
+  it('evaluates an existing string flag', async () => {
+    td.update(td.flag('flagkey').booleanFlag().valueForAll('potato'));
+    expect(await client.stringVariation('flagkey', defaultUser, 'default')).toEqual('potato');
+  });
+
+  it('it uses the default value when a string variation is for a flag of the wrong type', async () => {
+    td.update(td.flag('flagkey').valueForAll(8));
+    expect(await client.stringVariation('flagkey', defaultUser, 'default')).toEqual('default');
+  });
+
+  it('evaluates an existing boolean flag with detail', async () => {
+    td.update(td.flag('flagkey').booleanFlag().on(true));
+    const res = await client.boolVariationDetail('flagkey', defaultUser, false);
+    expect(res.value).toEqual(true);
+    expect(res.reason.kind).toBe('FALLTHROUGH');
+  });
+
+  it('it uses the default value when a boolean variation is for a flag of the wrong type with detail', async () => {
+    td.update(td.flag('flagkey').valueForAll('potato'));
+    const res = await client.boolVariationDetail('flagkey', defaultUser, false);
+    expect(res.value).toEqual(false);
+    expect(res.reason.kind).toEqual('ERROR');
+    expect(res.reason.errorKind).toEqual('WRONG_TYPE');
+  });
+
+  it('evaluates an existing numeric flag with detail', async () => {
+    td.update(td.flag('flagkey').booleanFlag().valueForAll(18));
+    const res = await client.numberVariationDetail('flagkey', defaultUser, 36);
+    expect(res.value).toEqual(18);
+    expect(res.reason.kind).toBe('FALLTHROUGH');
+  });
+
+  it('it uses the default value when a numeric variation is for a flag of the wrong type with detail', async () => {
+    td.update(td.flag('flagkey').valueForAll('potato'));
+    const res = await client.numberVariationDetail('flagkey', defaultUser, 36);
+    expect(res.value).toEqual(36);
+    expect(res.reason.kind).toEqual('ERROR');
+    expect(res.reason.errorKind).toEqual('WRONG_TYPE');
+  });
+
+  it('evaluates an existing string flag with detail', async () => {
+    td.update(td.flag('flagkey').booleanFlag().valueForAll('potato'));
+    const res = await client.stringVariationDetail('flagkey', defaultUser, 'default');
+    expect(res.value).toEqual('potato');
+    expect(res.reason.kind).toBe('FALLTHROUGH');
+  });
+
+  it('it uses the default value when a string variation is for a flag of the wrong type with detail', async () => {
+    td.update(td.flag('flagkey').valueForAll(8));
+    const res = await client.stringVariationDetail('flagkey', defaultUser, 'default');
+    expect(res.value).toEqual('default');
+    expect(res.reason.kind).toEqual('ERROR');
+    expect(res.reason.errorKind).toEqual('WRONG_TYPE');
+  });
 });
 
 describe('given an offline client', () => {

--- a/packages/shared/sdk-server/__tests__/LDClient.migrations.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClient.migrations.test.ts
@@ -57,7 +57,7 @@ describe('given an LDClient with test data', () => {
       const defaultValue = Object.values(LDMigrationStage).find((item) => item !== value);
       // Verify the pre-condition that the default value is not the value under test.
       expect(defaultValue).not.toEqual(value);
-      const res = await client.variationMigration(
+      const res = await client.migrationVariation(
         flagKey,
         { key: 'test-key' },
         defaultValue as LDMigrationStage,
@@ -74,7 +74,7 @@ describe('given an LDClient with test data', () => {
     LDMigrationStage.RampDown,
     LDMigrationStage.Complete,
   ])('returns the default value if the flag does not exist: default = %p', async (stage) => {
-    const res = await client.variationMigration('no-flag', { key: 'test-key' }, stage);
+    const res = await client.migrationVariation('no-flag', { key: 'test-key' }, stage);
 
     expect(res.value).toEqual(stage);
   });
@@ -82,7 +82,7 @@ describe('given an LDClient with test data', () => {
   it('produces an error event for a migration flag with an incorrect value', async () => {
     const flagKey = 'bad-migration';
     td.update(td.flag(flagKey).valueForAll('potato'));
-    const res = await client.variationMigration(flagKey, { key: 'test-key' }, LDMigrationStage.Off);
+    const res = await client.migrationVariation(flagKey, { key: 'test-key' }, LDMigrationStage.Off);
     expect(res.value).toEqual(LDMigrationStage.Off);
     expect(errors.length).toEqual(1);
     expect(errors[0].message).toEqual(

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -678,21 +678,19 @@ export default class LDClientImpl implements LDClient {
           if (typeChecker) {
             const [matched, type] = typeChecker(evalRes.detail.value);
             if (!matched) {
-              // TODO: change the detail.
-              // TODO: Use the default.
               const errorRes = EvalResult.forError(
                 ErrorKinds.WrongType,
                 `Did not receive expected type (${type}) evaluating feature flag "${flagKey}"`,
                 defaultValue,
               );
-              // Method intentionally not awaited.
+              // Method intentionally not awaited, puts event processing outside hot path.
               this.sendEvalEvent(evalRes, eventFactory, flag, evalContext, defaultValue);
               cb(errorRes, flag);
               return;
             }
           }
 
-          // Method intentionally not awaited.
+          // Method intentionally not awaited, puts event processing outside hot path.
           this.sendEvalEvent(evalRes, eventFactory, flag, evalContext, defaultValue);
           cb(evalRes, flag);
         },

--- a/packages/shared/sdk-server/src/Migration.ts
+++ b/packages/shared/sdk-server/src/Migration.ts
@@ -232,7 +232,7 @@ class Migration<
     defaultStage: LDMigrationStage,
     payload?: TMigrationReadInput,
   ): Promise<LDMigrationReadResult<TMigrationRead>> {
-    const stage = await this.client.variationMigration(key, context, defaultStage);
+    const stage = await this.client.migrationVariation(key, context, defaultStage);
     const res = await this.readTable[stage.value]({
       payload,
       tracker: stage.tracker,
@@ -248,7 +248,7 @@ class Migration<
     defaultStage: LDMigrationStage,
     payload?: TMigrationWriteInput,
   ): Promise<LDMigrationWriteResult<TMigrationWrite>> {
-    const stage = await this.client.variationMigration(key, context, defaultStage);
+    const stage = await this.client.migrationVariation(key, context, defaultStage);
     const res = await this.writeTable[stage.value]({
       payload,
       tracker: stage.tracker,

--- a/packages/shared/sdk-server/src/api/LDClient.ts
+++ b/packages/shared/sdk-server/src/api/LDClient.ts
@@ -1,4 +1,9 @@
-import { LDContext, LDEvaluationDetail, LDFlagValue } from '@launchdarkly/js-sdk-common';
+import {
+  LDContext,
+  LDEvaluationDetail,
+  LDEvaluationDetailTyped,
+  LDFlagValue,
+} from '@launchdarkly/js-sdk-common';
 
 import { LDMigrationOpEvent, LDMigrationVariation } from './data';
 import { LDFlagsState } from './data/LDFlagsState';
@@ -137,11 +142,186 @@ export interface LDClient {
    * @returns
    *   A Promise which will be resolved with the result (as an{@link LDMigrationVariation}).
    */
-  variationMigration(
+  migrationVariation(
     key: string,
     context: LDContext,
     defaultValue: LDMigrationStage,
   ): Promise<LDMigrationVariation>;
+
+  /**
+   * Determines the boolean variation of a feature flag for a context.
+   *
+   * If the flag variation does not have a boolean value, defaultValue is returned.
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result value.
+   */
+  boolVariation(key: string, context: LDContext, defaultValue: boolean): Promise<boolean>;
+
+  /**
+   * Determines the numeric variation of a feature flag for a context.
+   *
+   * If the flag variation does not have a numeric value, defaultValue is returned.
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result value.
+   */
+  numberVariation(key: string, context: LDContext, defaultValue: number): Promise<number>;
+
+  /**
+   * Determines the string variation of a feature flag for a context.
+   *
+   * If the flag variation does not have a string value, defaultValue is returned.
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result value.
+   */
+  stringVariation(key: string, context: LDContext, defaultValue: string): Promise<string>;
+
+  /**
+   * Determines the variation of a feature flag for a context.
+   *
+   * This version may be favored in TypeScript versus `variation` because it returns
+   * an `unknown` type instead of `any`. `unknown` will require a cast before usage.
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result value.
+   */
+  jsonVariation(key: string, context: LDContext, defaultValue: unknown): Promise<unknown>;
+
+  /**
+   * Determines the boolean variation of a feature flag for a context, along with information about
+   * how it was calculated.
+   *
+   * The `reason` property of the result will also be included in analytics events, if you are
+   * capturing detailed event data for this flag.
+   *
+   * If the flag variation does not have a boolean value, defaultValue is returned. The reason will
+   * indicate an error of the type `WRONG_KIND` in this case.
+   *
+   * For more information, see the [SDK reference
+   * guide](https://docs.launchdarkly.com/sdk/features/evaluation-reasons#nodejs-server-side).
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result
+   *  (as an {@link LDEvaluationDetailTyped<boolean>}).
+   */
+  boolVariationDetail(
+    key: string,
+    context: LDContext,
+    defaultValue: boolean,
+  ): Promise<LDEvaluationDetailTyped<boolean>>;
+
+  /**
+   * Determines the numeric variation of a feature flag for a context, along with information about
+   * how it was calculated.
+   *
+   * The `reason` property of the result will also be included in analytics events, if you are
+   * capturing detailed event data for this flag.
+   *
+   * If the flag variation does not have a numeric value, defaultValue is returned. The reason will
+   * indicate an error of the type `WRONG_KIND` in this case.
+   *
+   * For more information, see the [SDK reference
+   * guide](https://docs.launchdarkly.com/sdk/features/evaluation-reasons#nodejs-server-side).
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result
+   *  (as an {@link LDEvaluationDetailTyped<number>}).
+   */
+  numberVariationDetail(
+    key: string,
+    context: LDContext,
+    defaultValue: number,
+  ): Promise<LDEvaluationDetailTyped<number>>;
+
+  /**
+   * Determines the string variation of a feature flag for a context, along with information about
+   * how it was calculated.
+   *
+   * The `reason` property of the result will also be included in analytics events, if you are
+   * capturing detailed event data for this flag.
+   *
+   * If the flag variation does not have a string value, defaultValue is returned. The reason will
+   * indicate an error of the type `WRONG_KIND` in this case.
+   *
+   * For more information, see the [SDK reference
+   * guide](https://docs.launchdarkly.com/sdk/features/evaluation-reasons#nodejs-server-side).
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @returns
+   *   A Promise which will be resolved with the result
+   *  (as an {@link LDEvaluationDetailTyped<string>}).
+   */
+  stringVariationDetail(
+    key: string,
+    context: LDContext,
+    defaultValue: string,
+  ): Promise<LDEvaluationDetailTyped<string>>;
+
+  /**
+   * Determines the variation of a feature flag for a context, along with information about how it
+   * was calculated.
+   *
+   * The `reason` property of the result will also be included in analytics events, if you are
+   * capturing detailed event data for this flag.
+   *
+   * This version may be favored in TypeScript versus `variation` because it returns
+   * an `unknown` type instead of `any`. `unknown` will require a cast before usage.
+   *
+   * For more information, see the [SDK reference
+   * guide](https://docs.launchdarkly.com/sdk/features/evaluation-reasons#nodejs-server-side).
+   *
+   * @param key The unique key of the feature flag.
+   * @param context The context requesting the flag. The client will generate an analytics event to
+   *   register this context with LaunchDarkly if the context does not already exist.
+   * @param defaultValue The default value of the flag, to be used if the value is not available
+   *   from LaunchDarkly.
+   * @param callback A Node-style callback to receive the result (as an {@link LDEvaluationDetail}).
+   *   If omitted, you will receive a Promise instead.
+   * @returns
+   *   If you provided a callback, then nothing. Otherwise, a Promise which will be resolved with
+   *   the result (as an{@link LDEvaluationDetailTyped<unknown>}).
+   */
+  jsonVariationDetail(
+    key: string,
+    context: LDContext,
+    defaultValue: unknown,
+  ): Promise<LDEvaluationDetailTyped<unknown>>;
 
   /**
    * Builds an object that encapsulates the state of all feature flags for a given context.

--- a/packages/shared/sdk-server/src/api/data/LDMigrationVariation.ts
+++ b/packages/shared/sdk-server/src/api/data/LDMigrationVariation.ts
@@ -80,7 +80,7 @@ export interface LDMigrationTracker {
 export interface LDMigrationVariation {
   /**
    * The result of the flag evaluation. This will be either one of the flag's variations or
-   * the default value that was passed to `LDClient.variationMigration`.
+   * the default value that was passed to `LDClient.migrationVariation`.
    */
   value: LDMigrationStage;
 

--- a/packages/shared/sdk-server/src/evaluation/ErrorKinds.ts
+++ b/packages/shared/sdk-server/src/evaluation/ErrorKinds.ts
@@ -8,6 +8,7 @@ enum ErrorKinds {
   UserNotSpecified = 'USER_NOT_SPECIFIED',
   FlagNotFound = 'FLAG_NOT_FOUND',
   ClientNotReady = 'CLIENT_NOT_READY',
+  WrongType = 'WRONG_TYPE',
 }
 
 /**


### PR DESCRIPTION
This adds typed variation methods. 

This works for both JS and TS, but may be especially nice for those that want to be more type safe in typescript.

resolves #285 