### PR TITLE
fix: yarn topological dev build

### DIFF
--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -1,4 +1,4 @@
-name: sdk/cloudflare
+name: shared/mocks
 
 on:
   push:

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           workspace_name: '@launchdarkly/private-js-mocks'
           workspace_path: packages/shared/mocks
+          should_build_docs: false

--- a/actions/ci/action.yml
+++ b/actions/ci/action.yml
@@ -40,4 +40,5 @@ runs:
 
     - name: Build Docs
       shell: bash
+      if: ${{inputs.workspace_name != '@launchdarkly/private-js-mocks'}}
       run: yarn build:doc -- ${{ inputs.workspace_path }}

--- a/actions/ci/action.yml
+++ b/actions/ci/action.yml
@@ -11,7 +11,9 @@ inputs:
   workspace_path:
     description: 'Path to the package to release.'
     required: true
-
+  should_build_docs:
+    description: 'Whether docs should be built. It will be by default.'
+    default: true
 runs:
   using: composite
   steps:
@@ -40,5 +42,5 @@ runs:
 
     - name: Build Docs
       shell: bash
-      if: ${{inputs.workspace_name != '@launchdarkly/private-js-mocks'}}
+      if: ${{inputs.should_build_docs == 'true'}}
       run: yarn build:doc -- ${{ inputs.workspace_path }}

--- a/packages/shared/common/package.json
+++ b/packages/shared/common/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "test": "npx jest --ci",
+    "build-types": "npx tsc --declaration true --emitDeclarationOnly true --declarationDir dist",
     "build": "npx tsc",
     "clean": "npx tsc --build --clean",
     "lint": "npx eslint . --ext .ts",

--- a/packages/shared/mocks/package.json
+++ b/packages/shared/mocks/package.json
@@ -24,7 +24,8 @@
   ],
   "scripts": {
     "test": "",
-    "build": "npx tsc",
+    "build-types": "yarn workspace @launchdarkly/js-sdk-common build-types",
+    "build": "yarn build-types && npx tsc",
     "clean": "npx tsc --build --clean",
     "lint": "npx eslint  --ext .ts",
     "lint:fix": "yarn run lint -- --fix"


### PR DESCRIPTION
CI failed because `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/xxx' run build`. This is because `topological-dev` instructs yarn to build all deps (prod & dev) prior to running build in the current workspace. Since `mocks` need types from `common` this fails.

This pr adds a `build-types` command to common which gets run prior to mocks `build` command to ensure common types exist for mocks to be built successfully.