### PR TITLE
chore: Disable diagnostic events when running contract tests.

### DIFF
--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -9,6 +9,7 @@ export { badCommandError };
 export function makeSdkConfig(options, tag) {
   const cf = {
     logger: sdkLogger(tag),
+    diagnosticOptOut: true
   };
   const maybeTime = (seconds) =>
     seconds === undefined || seconds === null ? undefined : seconds / 1000;


### PR DESCRIPTION
I have done some investigation and found that the intermittent issues with contract tests seem to be related to how the test harness handles them. We do not actually test them using the test harness, so I am disabling them now to improve CI and release robustness.

I've basically been running the contract tests in a loop. Usually they fail in a few hours, but with diagnostic opt out they ran overnight.

I was testing them in combination with some other robustness improvements, but I am re-testing now with just this change. Those changes can be independent. 

Once we know what is going on the test harness side we should be able to re-enable these, but it likely isn't worth doing unless there are some tests for them.