### PR TITLE
fix: Correct comparison for typeof check.

### DIFF
--- a/packages/shared/sdk-server/src/Migration.ts
+++ b/packages/shared/sdk-server/src/Migration.ts
@@ -355,7 +355,7 @@ class Migration<
     let end;
     let result: TResult;
     // TODO: Need to validate performance existence check with edge SDKs.
-    if (typeof performance !== undefined) {
+    if (typeof performance !== "undefined") {
       start = performance.now();
       result = await method();
       end = performance.now();

--- a/packages/shared/sdk-server/src/Migration.ts
+++ b/packages/shared/sdk-server/src/Migration.ts
@@ -355,7 +355,7 @@ class Migration<
     let end;
     let result: TResult;
     // TODO: Need to validate performance existence check with edge SDKs.
-    if (typeof performance !== "undefined") {
+    if (typeof performance !== 'undefined') {
       start = performance.now();
       result = await method();
       end = performance.now();


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
            *** I cannot validate tests execute due to following error during npm install:
                   npm ERR! code E404
                   npm ERR! 404 Not Found - GET https://registry.npmjs.org/@launchdarkly%2fprivate-js-mocks - Not found
                   npm ERR! 404 
                   npm ERR! 404  '@launchdarkly/private-js-mocks@0.0.1' is not in the npm registry.
                   npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
                   npm ERR! 404 It was specified as a dependency of 'sdk-server'
- [X] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

This fixes the following error on Node.js v14:

ReferenceError: performance is not defined
    at Migration.trackLatency (/<project>/node_modules/@launchdarkly/js-server-sdk-common/dist/Migration.js:245:13)

Since `"undefined" !== undefined` 😛 

**Additional context**

The `performance` module is available in Node 14, however, it is not available globally until Node 16. An ideal fix may be to include an import of `performance` from `perf_hooks` - see https://stackoverflow.com/questions/46436943/referenceerror-performance-is-not-defined-when-using-performance-now

I originally wanted to add this in, but would be unable to validate that change due to npm install errors around a private package described above. Regardless, this fix appears to work using the existing fallback mechanism using Date objects.
