### PR TITLE
build(deps): bump `crypto-js` in `sdk-server-edge` package

### DIFF
--- a/packages/shared/sdk-server-edge/package.json
+++ b/packages/shared/sdk-server-edge/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@launchdarkly/js-server-sdk-common": "2.0.2",
-    "crypto-js": "^4.1.1"
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/advisories/GHSA-xwcq-pm8m-c4vf
https://nvd.nist.gov/vuln/detail/CVE-2023-46233
**Describe the solution you've provided**

Bump `crytpo-js` version to resolve vulnerability reported by tools such as `pnpm audit`. 
![image](https://github.com/launchdarkly/js-core/assets/2981598/58355e6b-4542-4e96-b52a-c4b905c5cd74)
GitHub link advisory https://github.com/advisories/GHSA-xwcq-pm8m-c4vf

**Describe alternatives you've considered**

None

**Additional context**
I couldn't find any usage of the vulnerable algorithm in the LaunchDarkly codebase, so most likely LaunchDarkly users aren't affected. Nevertheless, I believe it's important to address this issue to maintain clean security reports for repositories using this package.
