### PR TITLE
chore: Use error filter in rn event source

### DIFF
--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -1,5 +1,6 @@
 import {
   base64UrlEncode,
+  BasicLogger,
   LDClientImpl,
   type LDContext,
   type LDOptions,
@@ -9,7 +10,14 @@ import platform from './platform';
 
 export default class ReactNativeLDClient extends LDClientImpl {
   constructor(sdkKey: string, options: LDOptions = {}) {
-    super(sdkKey, platform, options);
+    const logger =
+      options.logger ??
+      new BasicLogger({
+        level: 'info',
+        // eslint-disable-next-line no-console
+        destination: console.log,
+      });
+    super(sdkKey, platform, { ...options, logger });
   }
 
   override createStreamUriPath(context: LDContext) {

--- a/packages/sdk/react-native/src/platform.ts
+++ b/packages/sdk/react-native/src/platform.ts
@@ -25,7 +25,6 @@ class PlatformRequests implements Requests {
     return new RNEventSource<EventName>(url, {
       headers: eventSourceInitDict.headers,
       retryAndHandleError: eventSourceInitDict.errorFilter,
-      debug: true,
     });
   }
 

--- a/packages/sdk/react-native/src/platform.ts
+++ b/packages/sdk/react-native/src/platform.ts
@@ -22,8 +22,11 @@ import RNEventSource from './react-native-sse';
 
 class PlatformRequests implements Requests {
   createEventSource(url: string, eventSourceInitDict: EventSourceInitDict): EventSource {
-    // TODO: add retry logic
-    return new RNEventSource<EventName>(url, eventSourceInitDict);
+    return new RNEventSource<EventName>(url, {
+      headers: eventSourceInitDict.headers,
+      retryAndHandleError: eventSourceInitDict.errorFilter,
+      debug: true,
+    });
   }
 
   fetch(url: string, options?: Options): Promise<Response> {

--- a/packages/sdk/react-native/src/react-native-sse/EventSource.ts
+++ b/packages/sdk/react-native/src/react-native-sse/EventSource.ts
@@ -307,7 +307,7 @@ export default class EventSource<E extends string = never> {
         this.onerror(data);
         break;
       case 'retry':
-        this.onretrying();
+        this.onretrying({ delayMillis: this.pollingInterval });
         break;
       default:
         break;
@@ -327,5 +327,5 @@ export default class EventSource<E extends string = never> {
   onopen() {}
   onclose() {}
   onerror(_err: any) {}
-  onretrying() {}
+  onretrying(_e: any) {}
 }

--- a/packages/sdk/react-native/src/react-native-sse/EventSource.ts
+++ b/packages/sdk/react-native/src/react-native-sse/EventSource.ts
@@ -17,7 +17,7 @@ const defaultOptions: EventSourceOptions = {
   method: 'GET',
   pollingInterval: 5000,
   timeout: 0,
-  timeoutBeforeConnection: 500,
+  timeoutBeforeConnection: 0,
   withCredentials: false,
 };
 

--- a/packages/sdk/react-native/src/react-native-sse/types.ts
+++ b/packages/sdk/react-native/src/react-native-sse/types.ts
@@ -53,6 +53,7 @@ export interface EventSourceOptions {
   body?: any;
   debug?: boolean;
   pollingInterval?: number;
+  retryAndHandleError?: (err: any) => boolean;
 }
 
 type BuiltInEventMap = {


### PR DESCRIPTION
Pass `errorFilter` to rn eventSource to specify custom retry logic and error handling.