### PR TITLE
chore: localstorage pr feedback

### DIFF
--- a/packages/sdk/react-native/src/provider/setupListeners.ts
+++ b/packages/sdk/react-native/src/provider/setupListeners.ts
@@ -7,10 +7,6 @@ const setupListeners = (
   client: ReactNativeLDClient,
   setState: Dispatch<SetStateAction<ReactContext>>,
 ) => {
-  client.on('ready', () => {
-    setState({ client });
-  });
-
   client.on('change', () => {
     setState({ client });
   });

--- a/packages/shared/common/src/api/data/LDFlagChangeset.ts
+++ b/packages/shared/common/src/api/data/LDFlagChangeset.ts
@@ -1,8 +1,0 @@
-import { LDFlagValue } from './LDFlagValue';
-
-export interface LDFlagChangeset {
-  [key: string]: {
-    current?: LDFlagValue;
-    previous?: LDFlagValue;
-  };
-}

--- a/packages/shared/common/src/api/data/index.ts
+++ b/packages/shared/common/src/api/data/index.ts
@@ -2,4 +2,3 @@ export * from './LDEvaluationDetail';
 export * from './LDEvaluationReason';
 export * from './LDFlagSet';
 export * from './LDFlagValue';
-export * from './LDFlagChangeset';

--- a/packages/shared/mocks/src/streamingProcessor.ts
+++ b/packages/shared/mocks/src/streamingProcessor.ts
@@ -35,7 +35,7 @@ export const setupMockStreamingProcessor = (
             errorHandler(unauthorized);
           });
         } else {
-          // execute put which will resolve the init promise
+          // execute put which will resolve the identify promise
           process.nextTick(() => listeners.get('put')?.processJson(putResponseJson));
 
           if (patchResponseJson) {

--- a/packages/shared/sdk-client/src/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.test.ts
@@ -130,7 +130,7 @@ describe('sdk-client object', () => {
     expect(ldc.getContext()).toBeUndefined();
   });
 
-  test('identify ready and error listeners', async () => {
+  test('identify change and error listeners', async () => {
     // @ts-ignore
     const { emitter } = ldc;
 
@@ -142,7 +142,7 @@ describe('sdk-client object', () => {
     const carContext2: LDContext = { kind: 'car', key: 'subaru-forrester' };
     await ldc.identify(carContext2);
 
-    expect(emitter.listenerCount('ready')).toEqual(1);
+    expect(emitter.listenerCount('change')).toEqual(1);
     expect(emitter.listenerCount('error')).toEqual(1);
   });
 });

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -2,13 +2,11 @@ import {
   ClientContext,
   clone,
   Context,
-  fastDeepEqual,
   internal,
   LDClientError,
   LDContext,
   LDEvaluationDetail,
   LDEvaluationDetailTyped,
-  LDFlagChangeset,
   LDFlagSet,
   LDFlagValue,
   LDLogger,
@@ -23,9 +21,10 @@ import { LDClient, type LDOptions } from './api';
 import LDEmitter, { EventName } from './api/LDEmitter';
 import Configuration from './configuration';
 import createDiagnosticsManager from './diagnostics/createDiagnosticsManager';
-import type { DeleteFlag, Flags, PatchFlag } from './evaluation/fetchFlags';
 import createEventProcessor from './events/createEventProcessor';
 import EventFactory from './events/EventFactory';
+import { DeleteFlag, Flags, PatchFlag } from './types';
+import { calculateFlagChanges } from './utils';
 
 const { createErrorEvaluationDetail, createSuccessEvaluationDetail, ClientMessages, ErrorKinds } =
   internal;
@@ -42,7 +41,7 @@ export default class LDClientImpl implements LDClient {
   private eventFactoryWithReasons = new EventFactory(true);
   private emitter: LDEmitter;
   private flags: Flags = {};
-  private identifyReadyListener?: (c: LDContext) => void;
+  private identifyChangeListener?: (c: LDContext) => void;
   private identifyErrorListener?: (c: LDContext, err: any) => void;
 
   private readonly clientContext: ClientContext;
@@ -107,7 +106,7 @@ export default class LDClientImpl implements LDClient {
   private createStreamListeners(
     context: LDContext,
     canonicalKey: string,
-    initializedFromStorage: boolean,
+    identifyResolve: any,
   ): Map<StreamEventName, ProcessStreamResponse> {
     const listeners = new Map<StreamEventName, ProcessStreamResponse>();
 
@@ -115,40 +114,17 @@ export default class LDClientImpl implements LDClient {
       deserializeData: JSON.parse,
       processJson: async (dataJson: Flags) => {
         this.logger.debug(`Streamer PUT: ${Object.keys(dataJson)}`);
-        if (initializedFromStorage) {
-          this.logger.debug('Synchronizing all data');
-          const changeset: LDFlagChangeset = {};
-
-          Object.entries(this.flags).forEach(([k, f]) => {
-            const flagFromPut = dataJson[k];
-            if (!flagFromPut) {
-              // flag deleted
-              changeset[k] = { previous: f.value };
-            } else if (!fastDeepEqual(f, flagFromPut)) {
-              // flag changed
-              changeset[k] = { previous: f.value, current: flagFromPut.value };
-            }
-          });
-
-          Object.entries(dataJson).forEach(([k, f]) => {
-            const flagFromStorage = this.flags[k];
-            if (!flagFromStorage) {
-              // flag added
-              changeset[k] = { current: f.value };
-            }
-          });
-
-          if (Object.keys(changeset).length > 0) {
-            this.flags = dataJson;
-            await this.platform.storage?.set(canonicalKey, JSON.stringify(this.flags));
-            this.emitter.emit('change', context, changeset);
-          }
-        } else {
-          this.logger.debug('Initializing all data from stream');
+        const changedKeys = calculateFlagChanges(this.flags, dataJson);
+        if (changedKeys.length > 0) {
           this.context = context;
           this.flags = dataJson;
           await this.platform.storage?.set(canonicalKey, JSON.stringify(this.flags));
-          this.emitter.emit('ready', context);
+
+          // this resolves identifyPromise
+          this.emitter.emit('change', context, changedKeys);
+        } else {
+          // manually resolve identify
+          identifyResolve();
         }
       },
     });
@@ -159,21 +135,11 @@ export default class LDClientImpl implements LDClient {
         this.logger.debug(`Streamer PATCH ${JSON.stringify(dataJson, null, 2)}`);
         const existing = this.flags[dataJson.key];
 
-        // add flag if it doesn't exist
-        // if does, update it if version is newer
+        // add flag if it doesn't exist or update it if version is newer
         if (!existing || (existing && dataJson.version > existing.version)) {
-          const changeset: LDFlagChangeset = {};
-          changeset[dataJson.key] = {
-            current: dataJson.value,
-          };
-
-          if (existing) {
-            changeset[dataJson.key].previous = existing.value;
-          }
-
           this.flags[dataJson.key] = dataJson;
           await this.platform.storage?.set(canonicalKey, JSON.stringify(this.flags));
-          this.emitter.emit('change', context, changeset);
+          this.emitter.emit('change', context, [dataJson.key]);
         }
       },
     });
@@ -185,13 +151,9 @@ export default class LDClientImpl implements LDClient {
         const existing = this.flags[dataJson.key];
 
         if (existing && existing.version <= dataJson.version) {
-          const changeset: LDFlagChangeset = {};
-          changeset[dataJson.key] = {
-            previous: this.flags[dataJson.key].value,
-          };
           delete this.flags[dataJson.key];
           await this.platform.storage?.set(canonicalKey, JSON.stringify(this.flags));
-          this.emitter.emit('change', context, changeset);
+          this.emitter.emit('change', context, [dataJson.key]);
         }
       },
     });
@@ -205,11 +167,11 @@ export default class LDClientImpl implements LDClient {
    * For mobile key: /meval/${base64-encoded-context}
    * For clientSideId: /eval/${envId}/${base64-encoded-context}
    *
-   * @param context The LD context object to be base64 encoded and appended to
    * the path.
    *
    * @protected This function must be overridden in subclasses for streamer
    * to work.
+   * @param _context The LDContext object
    */
   protected createStreamUriPath(_context: LDContext): string {
     throw new Error(
@@ -218,16 +180,19 @@ export default class LDClientImpl implements LDClient {
   }
 
   private createPromiseWithListeners() {
-    return new Promise<void>((resolve, reject) => {
-      if (this.identifyReadyListener) {
-        this.emitter.off('ready', this.identifyReadyListener);
+    let res: any;
+    const p = new Promise<void>((resolve, reject) => {
+      res = resolve;
+
+      if (this.identifyChangeListener) {
+        this.emitter.off('change', this.identifyChangeListener);
       }
       if (this.identifyErrorListener) {
         this.emitter.off('error', this.identifyErrorListener);
       }
 
-      this.identifyReadyListener = (c: LDContext) => {
-        this.logger.debug(`ready: ${JSON.stringify(c)}`);
+      this.identifyChangeListener = (c: LDContext) => {
+        this.logger.debug(`change: ${JSON.stringify(c)}`);
         resolve();
       };
       this.identifyErrorListener = (c: LDContext, err: any) => {
@@ -235,9 +200,11 @@ export default class LDClientImpl implements LDClient {
         reject(err);
       };
 
-      this.emitter.on('ready', this.identifyReadyListener);
+      this.emitter.on('change', this.identifyChangeListener);
       this.emitter.on('error', this.identifyErrorListener);
     });
+
+    return { identifyPromise: p, identifyResolve: res };
   }
 
   private async getFlagsFromStorage(canonicalKey: string): Promise<Flags | undefined> {
@@ -255,15 +222,17 @@ export default class LDClientImpl implements LDClient {
       return Promise.reject(error);
     }
 
-    const p = this.createPromiseWithListeners();
-    this.emitter.emit('initializing', context);
+    const { identifyPromise, identifyResolve } = this.createPromiseWithListeners();
+    this.emitter.emit('identifying', context);
 
     const flagsStorage = await this.getFlagsFromStorage(checkedContext.canonicalKey);
     if (flagsStorage) {
-      this.logger.debug('Initializing all data from storage');
+      this.logger.debug('Using storage');
+
+      const changedKeys = calculateFlagChanges(this.flags, flagsStorage);
       this.context = context;
       this.flags = flagsStorage;
-      this.emitter.emit('ready', context);
+      this.emitter.emit('change', context, changedKeys);
     }
 
     this.streamer?.close();
@@ -271,7 +240,7 @@ export default class LDClientImpl implements LDClient {
       this.sdkKey,
       this.clientContext,
       this.createStreamUriPath(context),
-      this.createStreamListeners(context, checkedContext.canonicalKey, !!flagsStorage),
+      this.createStreamListeners(context, checkedContext.canonicalKey, identifyResolve),
       this.diagnosticsManager,
       (e) => {
         this.logger.error(e);
@@ -280,7 +249,7 @@ export default class LDClientImpl implements LDClient {
     );
     this.streamer.start();
 
-    return p;
+    return identifyPromise;
   }
 
   off(eventName: EventName, listener: Function): void {

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -41,7 +41,7 @@ export default class LDClientImpl implements LDClient {
   private eventFactoryWithReasons = new EventFactory(true);
   private emitter: LDEmitter;
   private flags: Flags = {};
-  private identifyChangeListener?: (c: LDContext) => void;
+  private identifyChangeListener?: (c: LDContext, changedKeys: string[]) => void;
   private identifyErrorListener?: (c: LDContext, err: any) => void;
 
   private readonly clientContext: ClientContext;
@@ -193,8 +193,8 @@ export default class LDClientImpl implements LDClient {
         this.emitter.off('error', this.identifyErrorListener);
       }
 
-      this.identifyChangeListener = (c: LDContext) => {
-        this.logger.debug(`change: ${JSON.stringify(c)}`);
+      this.identifyChangeListener = (c: LDContext, changedKeys: string[]) => {
+        this.logger.debug(`change: context: ${JSON.stringify(c)}, flags: ${changedKeys}`);
         resolve();
       };
       this.identifyErrorListener = (c: LDContext, err: any) => {

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -124,6 +124,7 @@ export default class LDClientImpl implements LDClient {
           this.emitter.emit('change', context, changedKeys);
         } else {
           // manually resolve identify
+          this.logger.debug('No changes from PUT');
           identifyResolve();
         }
       },

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -229,6 +229,7 @@ export default class LDClientImpl implements LDClient {
     }
 
     const { identifyPromise, identifyResolve } = this.createPromiseWithListeners();
+    this.logger.debug(`Identifying ${context}`);
     this.emitter.emit('identifying', context);
 
     const flagsStorage = await this.getFlagsFromStorage(checkedContext.canonicalKey);

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -229,7 +229,7 @@ export default class LDClientImpl implements LDClient {
     }
 
     const { identifyPromise, identifyResolve } = this.createPromiseWithListeners();
-    this.logger.debug(`Identifying ${context}`);
+    this.logger.debug(`Identifying ${JSON.stringify(context)}`);
     this.emitter.emit('identifying', context);
 
     const flagsStorage = await this.getFlagsFromStorage(checkedContext.canonicalKey);

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -116,6 +116,7 @@ export default class LDClientImpl implements LDClient {
         this.logger.debug(`Streamer PUT: ${Object.keys(dataJson)}`);
         const changedKeys = calculateFlagChanges(this.flags, dataJson);
         if (changedKeys.length > 0) {
+          this.logger.debug(`Detected changes from PUT: ${changedKeys}`);
           this.context = context;
           this.flags = dataJson;
           await this.platform.storage?.set(canonicalKey, JSON.stringify(this.flags));

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -196,21 +196,14 @@ export interface LDClient {
    *
    * The following event names (keys) are used by the client:
    *
-   * - `"ready"`: The client has finished starting up. This event will be sent regardless
-   *   of whether it successfully connected to LaunchDarkly, or encountered an error
-   *   and had to give up; to distinguish between these cases, see below.
-   * - `"initialized"`: The client successfully started up and has valid feature flag
-   *   data. This will always be accompanied by `"ready"`.
-   * - `"failed"`: The client encountered an error that prevented it from connecting to
-   *   LaunchDarkly, such as an invalid environment ID. All flag evaluations will
-   *   therefore receive default values. This will always be accompanied by `"ready"`.
+   * - `"identifying"`: The client starts to fetch feature flags.
    * - `"error"`: General event for any kind of error condition during client operation.
    *   The callback parameter is an Error object. If you do not listen for "error"
    *   events, then the errors will be logged with `console.log()`.
    * - `"change"`: The client has received new feature flag data. This can happen either
    *   because you have switched contexts with {@link identify}, or because the client has a
    *   stream connection and has received a live change to a flag value (see below).
-   *   The callback parameter is an {@link LDFlagChangeset}.
+   *   The callback parameters are the context and an array of flag keys that have changed.
    *
    * @param key
    *   The name of the event for which to listen.

--- a/packages/shared/sdk-client/src/api/LDEmitter.test.ts
+++ b/packages/shared/sdk-client/src/api/LDEmitter.test.ts
@@ -57,11 +57,11 @@ describe('LDEmitter', () => {
     const changeHandler = jest.fn();
     const readyHandler = jest.fn();
 
+    emitter.on('identifying', readyHandler);
     emitter.on('error', errorHandler1);
     emitter.on('change', changeHandler);
-    emitter.on('ready', readyHandler);
 
-    expect(emitter.eventNames()).toEqual(['error', 'change', 'ready']);
+    expect(emitter.eventNames()).toEqual(['identifying', 'error', 'change']);
   });
 
   test('listener count', () => {

--- a/packages/shared/sdk-client/src/api/LDEmitter.ts
+++ b/packages/shared/sdk-client/src/api/LDEmitter.ts
@@ -1,4 +1,4 @@
-export type EventName = 'initializing' | 'ready' | 'error' | 'change';
+export type EventName = 'identifying' | 'error' | 'change';
 
 type CustomEventListeners = {
   original: Function;

--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -36,8 +36,8 @@ describe('Configuration', () => {
   });
 
   test('specified options should be set', () => {
-    const config = new Configuration({ wrapperName: 'test', stream: true });
-    expect(config).toMatchObject({ wrapperName: 'test', stream: true });
+    const config = new Configuration({ wrapperName: 'test' });
+    expect(config).toMatchObject({ wrapperName: 'test' });
   });
 
   test('unknown option', () => {
@@ -52,7 +52,7 @@ describe('Configuration', () => {
     // @ts-ignore
     const config = new Configuration({ sendEvents: 0 });
 
-    expect(config.stream).toBeFalsy();
+    expect(config.sendEvents).toBeFalsy();
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('should be a boolean, got number, converting'),
     );
@@ -76,29 +76,6 @@ describe('Configuration', () => {
       1,
       expect.stringContaining('"flushInterval" had invalid value of 1, using minimum of 2 instead'),
     );
-  });
-
-  test('undefined stream should not log warning', () => {
-    const config = new Configuration({ stream: undefined });
-
-    expect(config.stream).toBeUndefined();
-    expect(console.error).not.toHaveBeenCalled();
-  });
-
-  test('null stream should default to undefined', () => {
-    // @ts-ignore
-    const config = new Configuration({ stream: null });
-
-    expect(config.stream).toBeUndefined();
-    expect(console.error).not.toHaveBeenCalled();
-  });
-
-  test('wrong stream type should be converted to boolean', () => {
-    // @ts-ignore
-    const config = new Configuration({ stream: 1 });
-
-    expect(config.stream).toBeTruthy();
-    expect(console.error).toHaveBeenCalled();
   });
 
   test('invalid bootstrap should use default', () => {

--- a/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.test.ts
+++ b/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.test.ts
@@ -23,7 +23,6 @@ describe('createDiagnosticsInitConfig', () => {
       eventsCapacity: 100,
       eventsFlushIntervalMillis: secondsToMillis(2),
       reconnectTimeMillis: secondsToMillis(1),
-      streamingDisabled: true,
       usingSecureMode: false,
     });
   });
@@ -38,7 +37,6 @@ describe('createDiagnosticsInitConfig', () => {
         flushInterval: 2,
         streamInitialReconnectDelay: 3,
         diagnosticRecordingInterval: 4,
-        stream: true,
         allAttributesPrivate: true,
         hash: 'test-hash',
         bootstrap: 'localStorage',
@@ -54,7 +52,6 @@ describe('createDiagnosticsInitConfig', () => {
       eventsCapacity: 1,
       eventsFlushIntervalMillis: 2000,
       reconnectTimeMillis: 3000,
-      streamingDisabled: false,
       usingSecureMode: true,
     });
   });

--- a/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.ts
+++ b/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.ts
@@ -11,7 +11,6 @@ export type DiagnosticsInitConfig = {
   eventsFlushIntervalMillis: number;
   reconnectTimeMillis: number;
   diagnosticRecordingIntervalMillis: number;
-  streamingDisabled: boolean;
   allAttributesPrivate: boolean;
 
   // client specific properties
@@ -26,7 +25,6 @@ const createDiagnosticsInitConfig = (config: Configuration): DiagnosticsInitConf
   eventsFlushIntervalMillis: secondsToMillis(config.flushInterval),
   reconnectTimeMillis: secondsToMillis(config.streamInitialReconnectDelay),
   diagnosticRecordingIntervalMillis: secondsToMillis(config.diagnosticRecordingInterval),
-  streamingDisabled: !config.stream,
   allAttributesPrivate: config.allAttributesPrivate,
   usingSecureMode: !!config.hash,
   bootstrapMode: !!config.bootstrap,

--- a/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
+++ b/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
@@ -14,12 +14,6 @@ describe('fetchFeatures', () => {
     'user-agent': 'TestUserAgent/2.0.2',
     'x-launchdarkly-wrapper': 'Rapper/1.2.3',
   };
-  const reportHeaders = {
-    authorization: 'testSdkKey1',
-    'content-type': 'application/json',
-    'user-agent': 'TestUserAgent/2.0.2',
-    'x-launchdarkly-wrapper': 'Rapper/1.2.3',
-  };
 
   let config: Configuration;
   const platformFetch = basicPlatform.requests.fetch as jest.Mock;
@@ -41,21 +35,6 @@ describe('fetchFeatures', () => {
       {
         method: 'GET',
         headers: getHeaders,
-      },
-    );
-    expect(json).toEqual(mockResponse);
-  });
-
-  test('report', async () => {
-    config = new Configuration({ useReport: true });
-    const json = await fetchFlags(sdkKey, context, config, basicPlatform);
-
-    expect(platformFetch).toBeCalledWith(
-      'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/context',
-      {
-        method: 'REPORT',
-        headers: reportHeaders,
-        body: '{"kind":"user","key":"test-user-key-1"}',
       },
     );
     expect(json).toEqual(mockResponse);

--- a/packages/shared/sdk-client/src/evaluation/fetchFlags.ts
+++ b/packages/shared/sdk-client/src/evaluation/fetchFlags.ts
@@ -1,28 +1,8 @@
-import { LDContext, LDEvaluationReason, LDFlagValue, Platform } from '@launchdarkly/js-sdk-common';
+import { LDContext, Platform } from '@launchdarkly/js-sdk-common';
 
 import Configuration from '../configuration';
+import { Flags } from '../types';
 import { createFetchOptions, createFetchUrl } from './fetchUtils';
-
-export interface Flag {
-  version: number;
-  flagVersion: number;
-  value: LDFlagValue;
-  variation: number;
-  trackEvents: boolean;
-  trackReason?: boolean;
-  reason?: LDEvaluationReason;
-  debugEventsUntilDate?: number;
-}
-
-export interface PatchFlag extends Flag {
-  key: string;
-}
-
-export type DeleteFlag = Pick<PatchFlag, 'key' | 'version'>;
-
-export type Flags = {
-  [k: string]: Flag;
-};
 
 const fetchFlags = async (
   sdkKey: string,

--- a/packages/shared/sdk-client/src/events/EventFactory.ts
+++ b/packages/shared/sdk-client/src/events/EventFactory.ts
@@ -1,6 +1,6 @@
 import { Context, internal, LDEvaluationReason, LDFlagValue } from '@launchdarkly/js-sdk-common';
 
-import { Flag } from '../evaluation/fetchFlags';
+import { Flag } from '../types';
 
 /**
  * @internal

--- a/packages/shared/sdk-client/src/types/index.ts
+++ b/packages/shared/sdk-client/src/types/index.ts
@@ -1,0 +1,22 @@
+import { LDEvaluationReason, LDFlagValue } from '@launchdarkly/js-sdk-common';
+
+export interface Flag {
+  version: number;
+  flagVersion: number;
+  value: LDFlagValue;
+  variation: number;
+  trackEvents: boolean;
+  trackReason?: boolean;
+  reason?: LDEvaluationReason;
+  debugEventsUntilDate?: number;
+}
+
+export interface PatchFlag extends Flag {
+  key: string;
+}
+
+export type DeleteFlag = Pick<PatchFlag, 'key' | 'version'>;
+
+export type Flags = {
+  [k: string]: Flag;
+};

--- a/packages/shared/sdk-client/src/utils/index.ts
+++ b/packages/shared/sdk-client/src/utils/index.ts
@@ -1,0 +1,25 @@
+import { fastDeepEqual } from '@launchdarkly/js-sdk-common';
+
+import { Flags } from '../types';
+
+// eslint-disable-next-line import/prefer-default-export
+export function calculateFlagChanges(flags: Flags, incomingFlags: Flags) {
+  const changedKeys: string[] = [];
+
+  // flag deleted or updated
+  Object.entries(flags).forEach(([k, f]) => {
+    const incoming = incomingFlags[k];
+    if (!incoming || !fastDeepEqual(f, incoming)) {
+      changedKeys.push(k);
+    }
+  });
+
+  // flag added
+  Object.keys(incomingFlags).forEach((k) => {
+    if (!flags[k]) {
+      changedKeys.push(k);
+    }
+  });
+
+  return changedKeys;
+}


### PR DESCRIPTION
This implements feedback from #326.

* Run synchronization logic for all `change` events.
* Removed `ready` event and use `change` instead.
* Callback argument for `change` is now just a string array of flag keys.
* Removed config options `stream` and `useReport` for now for this alpha.