### PR TITLE
fix: add ga workflow to publish sdk-client.

### DIFF
--- a/.github/workflows/sdk-client.yml
+++ b/.github/workflows/sdk-client.yml
@@ -21,4 +21,4 @@ jobs:
         uses: ./actions/ci
         with:
           workspace_name: '@launchdarkly/js-client-sdk-common'
-          workspace_path: packages/sdk/cloudflare
+          workspace_path: packages/shared/sdk-client

--- a/.github/workflows/sdk-client.yml
+++ b/.github/workflows/sdk-client.yml
@@ -1,0 +1,24 @@
+name: shared/sdk-client
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-sdk-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/js-client-sdk-common'
+          workspace_path: packages/sdk/cloudflare


### PR DESCRIPTION
This is needed for the sdk-client package to be published to npm.