### PR TITLE
fix: remove type modifiers on imports for better TS compatibility

### DIFF
--- a/packages/shared/common/src/internal/stream/index.ts
+++ b/packages/shared/common/src/internal/stream/index.ts
@@ -1,4 +1,5 @@
 import StreamingProcessor from './StreamingProcessor';
-import { type StreamingErrorHandler } from './types';
+import type { StreamingErrorHandler } from './types';
 
-export { StreamingProcessor, type StreamingErrorHandler };
+export { StreamingProcessor };
+export type { StreamingErrorHandler };


### PR DESCRIPTION
**Requirements**

- [ ] ~I have added test coverage for new or changed functionality~
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] ~I have validated my changes against all supported platform versions~

No new functionality has been added (only types import/export refactoring).

**Related issues**

https://github.com/launchdarkly/js-core/issues/345 https://github.com/launchdarkly/js-core/issues/347

**Describe the solution you've provided**

Remove the usage of [type modifiers on import names](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) to improve backwards compatibility with early versions of TypeScript.

**Describe alternatives you've considered**

The obvious solution would be upgrading the TypeScript version in the consumer, but this is not always easy (it's not in our case). [More info here](https://github.com/microsoft/TypeScript/issues/25778).
