### PR TITLE
feat: Implement common client side support for auto environment attributes.

### DIFF
--- a/packages/shared/mocks/README.md
+++ b/packages/shared/mocks/README.md
@@ -2,9 +2,111 @@
 
 [![Actions Status][mocks-ci-badge]][mocks-ci]
 
-**Internal use only.**
+> [!CAUTION]
+> Internal use only.
+> This project contains JavaScript mocks that are consumed in unit tests in client-side and server-side JavaScript SDKs.
 
-This project contains JavaScript mocks that are consumed in unit tests in client-side and server-side JavaScript SDKs.
+## Installation
+
+This package is not published publicly. To use it internally, add the following line to your project's package.json
+devDependencies. yarn workspace has been setup to recognize this package so this dependency should automatically work:
+
+```bash
+  "devDependencies": {
+    "@launchdarkly/private-js-mocks": "0.0.1",
+    ...
+```
+
+Then in your jest config add `@launchdarkly/private-js-mocks/setup` to setupFilesAfterEnv:
+
+```js
+// jest.config.js or jest.config.json
+module.exports = {
+  setupFilesAfterEnv: ['@launchdarkly/private-js-mocks/setup'],
+  ...
+}
+```
+
+## Usage
+
+> [!IMPORTANT]  
+> basicPlatform and clientContext must be used inside a test because it's setup before each test.
+
+- `basicPlatform`: a concrete but basic implementation of [Platform](https://github.com/launchdarkly/js-core/blob/main/packages/shared/common/src/api/platform/Platform.ts). This is setup beforeEach so it must be used inside a test.
+
+- `clientContext`: ClientContext object including `basicPlatform` above. This is setup beforeEach so it must be used inside a test as well.
+
+- `hasher`: a Hasher object returned by `Crypto.createHash`. All functions in this object are jest mocks. This is exported
+  separately as a top level export because `Crypto` does not expose this publicly and we want to respect that.
+
+## Example
+
+```tsx
+import { basicPlatform, clientContext, hasher } from '@launchdarkly/private-js-mocks';
+
+// DOES NOT WORK: crypto is undefined because basicPlatform must be inside a test
+// because it's setup by the package in beforeEach.
+const { crypto } = basicPlatform; // DON'T DO THIS HERE
+
+// DOES NOT WORK: clientContext must be used inside a test. Otherwise all properties
+// of it will be undefined.
+const {
+  basicConfiguration: { serviceEndpoints, tags },
+  platform: { info },
+} = clientContext; // DON'T DO THIS HERE
+
+describe('button', () => {
+  // DOES NOT WORK: again must be inside an actual test. At the test suite,
+  // level, beforeEach has not been run.
+  const { crypto } = basicPlatform; // DON'T DO THIS HERE
+
+  // DO THIS
+  let crypto: Crypto;
+  let info: Info;
+  let serviceEndpoints: ServiceEndpoints;
+  let tags: ApplicationTags;
+
+  beforeEach(() => {
+    // WORKS: basicPlatform and clientContext have been setup by the package.
+    ({ crypto, info } = basicPlatform);
+
+    // WORKS
+    ({
+      basicConfiguration: { serviceEndpoints, tags },
+      platform: { info },
+    } = clientContext);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('hashes the correct string', () => {
+    // arrange
+    const bucketer = new Bucketer(crypto);
+
+    // act
+    const [bucket, hadContext] = bucketer.bucket();
+
+    // assert
+    // WORKS
+    expect(crypto.createHash).toHaveBeenCalled();
+
+    // WORKS: alternatively you can just use the full path to access the properties
+    // of basicPlatform
+    expect(basicPlatform.crypto.createHash).toHaveBeenCalled();
+
+    // GOTCHA: hasher is a separte import from crypto to respect
+    // the public Crypto interface.
+    expect(hasher.update).toHaveBeenCalledWith(expected);
+    expect(hasher.digest).toHaveBeenCalledWith('hex');
+  });
+});
+```
+
+## Developing this package
+
+If you make changes to this package, you'll need to run `yarn build` in the `mocks` directory for changes to take effect.
 
 ## Contributing
 

--- a/packages/shared/mocks/package.json
+++ b/packages/shared/mocks/package.json
@@ -5,6 +5,12 @@
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./setup": {
+      "default": "./dist/setupMocks.js"
+    }
+  },
   "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/shared/common",
   "repository": {
     "type": "git",

--- a/packages/shared/mocks/src/clientContext.ts
+++ b/packages/shared/mocks/src/clientContext.ts
@@ -1,20 +1,22 @@
 import type { ClientContext } from '@common';
 
-import basicPlatform from './platform';
+import { basicPlatform } from './platform';
 
-const clientContext: ClientContext = {
-  basicConfiguration: {
-    sdkKey: 'testSdkKey',
-    serviceEndpoints: {
-      events: '',
-      polling: '',
-      streaming: 'https://mockstream.ld.com',
-      diagnosticEventPath: '/diagnostic',
-      analyticsEventPath: '/bulk',
-      includeAuthorizationHeader: true,
+// eslint-disable-next-line import/no-mutable-exports
+export let clientContext: ClientContext;
+export const setupClientContext = () => {
+  clientContext = {
+    basicConfiguration: {
+      sdkKey: 'testSdkKey',
+      serviceEndpoints: {
+        events: '',
+        polling: '',
+        streaming: 'https://mockstream.ld.com',
+        diagnosticEventPath: '/diagnostic',
+        analyticsEventPath: '/bulk',
+        includeAuthorizationHeader: true,
+      },
     },
-  },
-  platform: basicPlatform,
+    platform: basicPlatform,
+  };
 };
-
-export default clientContext;

--- a/packages/shared/mocks/src/crypto.ts
+++ b/packages/shared/mocks/src/crypto.ts
@@ -1,0 +1,23 @@
+import type { Hasher } from '@common';
+
+// eslint-disable-next-line import/no-mutable-exports
+export let hasher: Hasher;
+
+export const setupCrypto = () => {
+  let counter = 0;
+  hasher = {
+    update: jest.fn(),
+    digest: jest.fn(() => '1234567890123456'),
+  };
+
+  return {
+    createHash: jest.fn(() => hasher),
+    createHmac: jest.fn(),
+    randomUUID: jest.fn(() => {
+      counter += 1;
+      // Will provide a unique value for tests.
+      // Very much not a UUID of course.
+      return `${counter}`;
+    }),
+  };
+};

--- a/packages/shared/mocks/src/index.ts
+++ b/packages/shared/mocks/src/index.ts
@@ -1,18 +1,17 @@
-import clientContext from './clientContext';
+import { clientContext } from './clientContext';
 import ContextDeduplicator from './contextDeduplicator';
-import { crypto, hasher } from './hasher';
+import { hasher } from './crypto';
 import logger from './logger';
 import mockFetch from './mockFetch';
-import basicPlatform from './platform';
+import { basicPlatform } from './platform';
 import { MockStreamingProcessor, setupMockStreamingProcessor } from './streamingProcessor';
 
 export {
   basicPlatform,
   clientContext,
-  mockFetch,
-  crypto,
-  logger,
   hasher,
+  mockFetch,
+  logger,
   ContextDeduplicator,
   MockStreamingProcessor,
   setupMockStreamingProcessor,

--- a/packages/shared/mocks/src/mockFetch.ts
+++ b/packages/shared/mocks/src/mockFetch.ts
@@ -1,6 +1,6 @@
 import { Response } from '@common';
 
-import basicPlatform from './platform';
+import { basicPlatform } from './platform';
 
 const createMockResponse = (remoteJson: any, statusCode: number) => {
   const response: Response = {

--- a/packages/shared/mocks/src/platform.ts
+++ b/packages/shared/mocks/src/platform.ts
@@ -1,14 +1,14 @@
 import type { Encoding, Info, Platform, PlatformData, Requests, SdkData, Storage } from '@common';
 
-import { crypto } from './hasher';
+import { setupCrypto } from './crypto';
 
 const encoding: Encoding = {
   btoa: (s: string) => Buffer.from(s).toString('base64'),
 };
 
-const info: Info = {
-  platformData(): PlatformData {
-    return {
+const setupInfo = () => ({
+  platformData: jest.fn(
+    (): PlatformData => ({
       os: {
         name: 'An OS',
         version: '1.0.1',
@@ -18,18 +18,31 @@ const info: Info = {
       additional: {
         nodeVersion: '42',
       },
-    };
-  },
-  sdkData(): SdkData {
-    return {
+      ld_application: {
+        key: '',
+        envAttributesVersion: '1.0',
+        id: 'com.testapp.ld',
+        name: 'LDApplication.TestApp',
+        version: '1.1.1',
+      },
+      ld_device: {
+        key: '',
+        envAttributesVersion: '1.0',
+        os: { name: 'Another OS', version: '99', family: 'orange' },
+        manufacturer: 'coconut',
+      },
+    }),
+  ),
+  sdkData: jest.fn(
+    (): SdkData => ({
       name: 'An SDK',
       version: '2.0.2',
       userAgentBase: 'TestUserAgent',
       wrapperName: 'Rapper',
       wrapperVersion: '1.2.3',
-    };
-  },
-};
+    }),
+  ),
+});
 
 const requests: Requests = {
   fetch: jest.fn(),
@@ -42,12 +55,14 @@ const storage: Storage = {
   clear: jest.fn(),
 };
 
-const basicPlatform: Platform = {
-  encoding,
-  info,
-  crypto,
-  requests,
-  storage,
+// eslint-disable-next-line import/no-mutable-exports
+export let basicPlatform: Platform;
+export const setupBasicPlatform = () => {
+  basicPlatform = {
+    encoding,
+    info: setupInfo(),
+    crypto: setupCrypto(),
+    requests,
+    storage,
+  };
 };
-
-export default basicPlatform;

--- a/packages/shared/mocks/src/setupMocks.ts
+++ b/packages/shared/mocks/src/setupMocks.ts
@@ -1,0 +1,12 @@
+import { setupClientContext } from './clientContext';
+import { setupBasicPlatform } from './platform';
+
+beforeAll(() => {
+  setupBasicPlatform();
+  setupClientContext();
+});
+
+beforeEach(() => {
+  setupBasicPlatform();
+  setupClientContext();
+});

--- a/packages/shared/sdk-client/jest.config.json
+++ b/packages/shared/sdk-client/jest.config.json
@@ -6,5 +6,5 @@
   "testEnvironment": "jsdom",
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
   "collectCoverageFrom": ["src/**/*.ts"],
-  "setupFilesAfterEnv": ["./jest-setupFilesAfterEnv.ts"]
+  "setupFilesAfterEnv": ["@launchdarkly/private-js-mocks/setup"]
 }

--- a/packages/shared/sdk-client/src/LDClientImpl.storage.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.storage.test.ts
@@ -5,6 +5,7 @@ import LDEmitter from './api/LDEmitter';
 import * as mockResponseJson from './evaluation/mockResponse.json';
 import LDClientImpl from './LDClientImpl';
 import { DeleteFlag, Flag, Flags, PatchFlag } from './types';
+import { toMulti } from './utils/addAutoEnv';
 
 jest.mock('@launchdarkly/js-sdk-common', () => {
   const actual = jest.requireActual('@launchdarkly/js-sdk-common');
@@ -76,7 +77,11 @@ describe('sdk-client storage', () => {
       .spyOn(LDClientImpl.prototype as any, 'createStreamUriPath')
       .mockReturnValue('/stream/path');
 
-    ldc = new LDClientImpl(testSdkKey, basicPlatform, { logger, sendEvents: false });
+    ldc = new LDClientImpl(testSdkKey, basicPlatform, {
+      autoEnvAttributes: false,
+      logger,
+      sendEvents: false,
+    });
 
     // @ts-ignore
     emitter = ldc.emitter;
@@ -101,6 +106,52 @@ describe('sdk-client storage', () => {
       3,
       'error',
       context,
+      expect.objectContaining({ message: 'test-error' }),
+    );
+    expect(allFlags).toEqual({
+      'dev-test-flag': true,
+      'easter-i-tunes-special': false,
+      'easter-specials': 'no specials',
+      fdsafdsafdsafdsa: true,
+      'log-level': 'warn',
+      'moonshot-demo': true,
+      test1: 's1',
+      'this-is-a-test': true,
+    });
+  });
+
+  test('initialize from storage succeeds with auto env', async () => {
+    ldc = new LDClientImpl(testSdkKey, basicPlatform, {
+      logger,
+      sendEvents: false,
+    });
+    // @ts-ignore
+    emitter = ldc.emitter;
+    jest.spyOn(emitter as LDEmitter, 'emit');
+
+    const allFlags = await identifyGetAllFlags(true, defaultPutResponse);
+
+    expect(basicPlatform.storage.get).toHaveBeenLastCalledWith(
+      expect.stringMatching(/org:Testy Pizza$/),
+    );
+
+    // 'change' should not have been emitted
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
+    expect(emitter.emit).toHaveBeenNthCalledWith(
+      1,
+      'identifying',
+      expect.objectContaining(toMulti(context)),
+    );
+    expect(emitter.emit).toHaveBeenNthCalledWith(
+      2,
+      'change',
+      expect.objectContaining(toMulti(context)),
+      defaultFlagKeys,
+    );
+    expect(emitter.emit).toHaveBeenNthCalledWith(
+      3,
+      'error',
+      expect.objectContaining(toMulti(context)),
       expect.objectContaining({ message: 'test-error' }),
     );
     expect(allFlags).toEqual({

--- a/packages/shared/sdk-client/src/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.test.ts
@@ -1,5 +1,10 @@
 import { clone, LDContext } from '@launchdarkly/js-sdk-common';
-import { basicPlatform, logger, setupMockStreamingProcessor } from '@launchdarkly/private-js-mocks';
+import {
+  basicPlatform,
+  hasher,
+  logger,
+  setupMockStreamingProcessor,
+} from '@launchdarkly/private-js-mocks';
 
 import * as mockResponseJson from './evaluation/mockResponse.json';
 import LDClientImpl from './LDClientImpl';
@@ -19,9 +24,23 @@ jest.mock('@launchdarkly/js-sdk-common', () => {
   };
 });
 
-const { crypto } = basicPlatform;
 const testSdkKey = 'test-sdk-key';
 const context: LDContext = { kind: 'org', key: 'Testy Pizza' };
+const autoEnv = {
+  ld_application: {
+    key: 'digested1',
+    envAttributesVersion: '1.0',
+    id: 'com.testapp.ld',
+    name: 'LDApplication.TestApp',
+    version: '1.1.1',
+  },
+  ld_device: {
+    key: 'random1',
+    envAttributesVersion: '1.0',
+    manufacturer: 'coconut',
+    os: { name: 'An OS', version: '1.0.1', family: 'orange' },
+  },
+};
 let ldc: LDClientImpl;
 let defaultPutResponse: Flags;
 
@@ -29,7 +48,8 @@ describe('sdk-client object', () => {
   beforeEach(() => {
     defaultPutResponse = clone<Flags>(mockResponseJson);
     setupMockStreamingProcessor(false, defaultPutResponse);
-    crypto.randomUUID.mockReturnValueOnce('random1');
+    basicPlatform.crypto.randomUUID.mockReturnValue('random1');
+    hasher.digest.mockReturnValue('digested1');
 
     ldc = new LDClientImpl(testSdkKey, basicPlatform, { logger, sendEvents: false });
     jest
@@ -129,7 +149,30 @@ describe('sdk-client object', () => {
     const c = ldc.getContext();
     const all = ldc.allFlags();
 
-    expect(carContext).toEqual(c);
+    expect(c).toEqual({
+      kind: 'multi',
+      car: { key: 'mazda-cx7' },
+      ...autoEnv,
+    });
+    expect(all).toMatchObject({
+      'dev-test-flag': false,
+    });
+  });
+
+  test('identify success without auto env', async () => {
+    defaultPutResponse['dev-test-flag'].value = false;
+    const carContext: LDContext = { kind: 'car', key: 'mazda-cx7' };
+    ldc = new LDClientImpl(testSdkKey, basicPlatform, {
+      autoEnvAttributes: false,
+      logger,
+      sendEvents: false,
+    });
+
+    await ldc.identify(carContext);
+    const c = ldc.getContext();
+    const all = ldc.allFlags();
+
+    expect(c).toEqual(carContext);
     expect(all).toMatchObject({
       'dev-test-flag': false,
     });
@@ -143,18 +186,21 @@ describe('sdk-client object', () => {
     const c = ldc.getContext();
     const all = ldc.allFlags();
 
-    expect(c!.key).toEqual('random1');
+    expect(c).toEqual({
+      kind: 'multi',
+      car: { anonymous: true, key: 'random1' },
+      ...autoEnv,
+    });
     expect(all).toMatchObject({
       'dev-test-flag': false,
     });
   });
 
   test('identify error invalid context', async () => {
-    // @ts-ignore
-    const carContext: LDContext = { kind: 'car', key: undefined };
+    const carContext: LDContext = { kind: 'car', key: '' };
 
-    await expect(ldc.identify(carContext)).rejects.toThrowError(/no key/);
-    expect(logger.error).toBeCalledTimes(1);
+    await expect(ldc.identify(carContext)).rejects.toThrow(/no key/);
+    expect(logger.error).toHaveBeenCalledTimes(1);
     expect(ldc.getContext()).toBeUndefined();
   });
 
@@ -166,7 +212,7 @@ describe('sdk-client object', () => {
       code: 401,
       message: 'test-error',
     });
-    expect(logger.error).toBeCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledTimes(1);
     expect(ldc.getContext()).toBeUndefined();
   });
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -24,7 +24,7 @@ import createDiagnosticsManager from './diagnostics/createDiagnosticsManager';
 import createEventProcessor from './events/createEventProcessor';
 import EventFactory from './events/EventFactory';
 import { DeleteFlag, Flags, PatchFlag } from './types';
-import { calculateFlagChanges, ensureKey } from './utils';
+import { addAutoEnv, calculateFlagChanges, ensureKey } from './utils';
 
 const { createErrorEvaluationDetail, createSuccessEvaluationDetail, ClientMessages, ErrorKinds } =
   internal;
@@ -193,7 +193,7 @@ export default class LDClientImpl implements LDClient {
    */
   protected createStreamUriPath(_context: LDContext): string {
     throw new Error(
-      'createStreamUriPath not implemented. client sdks must implement createStreamUriPath for streamer to work',
+      'createStreamUriPath not implemented. Client sdks must implement createStreamUriPath for streamer to work',
     );
   }
 
@@ -232,7 +232,11 @@ export default class LDClientImpl implements LDClient {
 
   // TODO: implement secure mode
   async identify(pristineContext: LDContext, _hash?: string): Promise<void> {
-    const context = await ensureKey(pristineContext, this.platform);
+    let context = await ensureKey(pristineContext, this.platform);
+
+    if (this.config.autoEnvAttributes) {
+      context = await addAutoEnv(context, this.platform, this.config);
+    }
 
     const checkedContext = Context.fromLDContext(context);
     if (!checkedContext.valid) {

--- a/packages/shared/sdk-client/src/api/LDOptions.ts
+++ b/packages/shared/sdk-client/src/api/LDOptions.ts
@@ -24,7 +24,6 @@ export interface LDOptions {
      * Example: `authentication-service`
      */
     id?: string;
-
     /**
      * A unique identifier representing the version of the application where the LaunchDarkly SDK is running.
      *
@@ -35,6 +34,18 @@ export interface LDOptions {
      */
     version?: string;
   };
+
+  /**
+   * Enable / disable Auto environment attributes. When enabled, the SDK will automatically
+   * provide data about the mobile environment where the application is running. This data makes it simpler to target
+   * your mobile customers based on application name or version, or on device characteristics including manufacturer,
+   * model, operating system, locale, and so on. We recommend enabling this when you configure the SDK. To learn more,
+   * read [Automatic environment attributes](https://docs.launchdarkly.com/sdk/features/environment-attributes).
+   * for more documentation.
+   *
+   * The default is true.
+   */
+  autoEnvAttributes?: boolean;
 
   /**
    * The base uri for the LaunchDarkly server.

--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -12,6 +12,7 @@ describe('Configuration', () => {
 
     expect(config).toMatchObject({
       allAttributesPrivate: false,
+      autoEnvAttributes: true,
       baseUri: 'https://sdk.launchdarkly.com',
       capacity: 100,
       diagnosticOptOut: false,

--- a/packages/shared/sdk-client/src/configuration/Configuration.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.ts
@@ -28,6 +28,7 @@ export default class Configuration {
   public readonly flushInterval = 2;
   public readonly streamInitialReconnectDelay = 1;
 
+  public readonly autoEnvAttributes = true;
   public readonly allAttributesPrivate = false;
   public readonly diagnosticOptOut = false;
   public readonly withReasons = false;
@@ -41,6 +42,8 @@ export default class Configuration {
   public readonly tags: ApplicationTags;
   public readonly application?: { id?: string; version?: string };
   public readonly bootstrap?: 'localStorage' | LDFlagSet;
+
+  // TODO: implement requestHeaderTransform
   public readonly requestHeaderTransform?: (headers: Map<string, string>) => Map<string, string>;
   public readonly stream?: boolean;
   public readonly hash?: string;

--- a/packages/shared/sdk-client/src/configuration/validators.ts
+++ b/packages/shared/sdk-client/src/configuration/validators.ts
@@ -25,6 +25,7 @@ const validators: Record<keyof LDOptions, TypeValidator> = {
   flushInterval: TypeValidators.numberWithMin(2),
   streamInitialReconnectDelay: TypeValidators.numberWithMin(0),
 
+  autoEnvAttributes: TypeValidators.Boolean,
   allAttributesPrivate: TypeValidators.Boolean,
   diagnosticOptOut: TypeValidators.Boolean,
   withReasons: TypeValidators.Boolean,

--- a/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
+++ b/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
@@ -16,9 +16,10 @@ describe('fetchFeatures', () => {
   };
 
   let config: Configuration;
-  const platformFetch = basicPlatform.requests.fetch as jest.Mock;
+  let platformFetch: jest.Mock;
 
   beforeEach(() => {
+    platformFetch = basicPlatform.requests.fetch as jest.Mock;
     mockFetch(mockResponse);
     config = new Configuration();
   });
@@ -30,7 +31,7 @@ describe('fetchFeatures', () => {
   test('get', async () => {
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
-    expect(platformFetch).toBeCalledWith(
+    expect(platformFetch).toHaveBeenCalledWith(
       'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9',
       {
         method: 'GET',
@@ -45,7 +46,7 @@ describe('fetchFeatures', () => {
     config = new Configuration({ withReasons: true });
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
-    expect(platformFetch).toBeCalledWith(
+    expect(platformFetch).toHaveBeenCalledWith(
       'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?withReasons=true',
       {
         method: 'GET',
@@ -59,7 +60,7 @@ describe('fetchFeatures', () => {
     config = new Configuration({ hash: 'test-hash', withReasons: false });
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
-    expect(platformFetch).toBeCalledWith(
+    expect(platformFetch).toHaveBeenCalledWith(
       'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?h=test-hash',
       {
         method: 'GET',

--- a/packages/shared/sdk-client/src/utils/addAutoEnv.test.ts
+++ b/packages/shared/sdk-client/src/utils/addAutoEnv.test.ts
@@ -1,0 +1,208 @@
+import { Info, type LDContext, LDUser } from '@launchdarkly/js-sdk-common';
+import { basicPlatform } from '@launchdarkly/private-js-mocks';
+
+import Configuration from '../configuration';
+import { addApplicationInfo, addAutoEnv, addDeviceInfo, toMulti } from './addAutoEnv';
+
+describe('addAutoEnv', () => {
+  let crypto: Crypto;
+  let info: Info;
+
+  beforeEach(() => {
+    ({ crypto, info } = basicPlatform);
+    (crypto.randomUUID as jest.Mock).mockResolvedValue('test-device-key-1');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('toMulti', () => {
+    const singleContext = { kind: 'user', key: 'test-user-key-1', name: 'bob' };
+    const multi = toMulti(singleContext);
+
+    expect(multi).toEqual({ kind: 'multi', user: { key: 'test-user-key-1', name: 'bob' } });
+  });
+
+  test('LDUser is unsupported', async () => {
+    const config = new Configuration();
+    // const context = { kind: 'user', key: 'test-user-key-1', name: 'bob' };
+    const user: LDUser = { key: 'legacy-user-key', name: 'bob' };
+    const result = await addAutoEnv(user, basicPlatform, config);
+
+    expect(result).toEqual(user);
+  });
+
+  test('single kind should be converted to multi', async () => {
+    const config = new Configuration();
+    const context = { kind: 'user', key: 'test-user-key-1', name: 'bob' };
+
+    const result = await addAutoEnv(context, basicPlatform, config);
+
+    expect(result).toEqual({
+      kind: 'multi',
+      ld_application: {
+        envAttributesVersion: '1.0',
+        id: 'com.testapp.ld',
+        key: '1234567890123456',
+        name: 'LDApplication.TestApp',
+        version: '1.1.1',
+      },
+      ld_device: {
+        envAttributesVersion: '1.0',
+        key: 'test-device-key-1',
+        manufacturer: 'coconut',
+        os: { name: 'An OS', version: '1.0.1', family: 'orange' },
+      },
+      user: { key: 'test-user-key-1', name: 'bob' },
+    });
+  });
+
+  test('multi kind', async () => {
+    const config = new Configuration();
+    const context: LDContext = {
+      kind: 'multi',
+      user: { key: 'test-user-key-1', name: 'bob' },
+      org: { key: 'test-org-key-1', name: 'Best company' },
+    };
+    const result = await addAutoEnv(context, basicPlatform, config);
+
+    expect(result).toEqual({
+      kind: 'multi',
+      user: { key: 'test-user-key-1', name: 'bob' },
+      org: { key: 'test-org-key-1', name: 'Best company' },
+      ld_application: {
+        envAttributesVersion: '1.0',
+        id: 'com.testapp.ld',
+        key: '1234567890123456',
+        name: 'LDApplication.TestApp',
+        version: '1.1.1',
+      },
+      ld_device: {
+        envAttributesVersion: '1.0',
+        key: 'test-device-key-1',
+        manufacturer: 'coconut',
+        os: { name: 'An OS', version: '1.0.1', family: 'orange' },
+      },
+    });
+  });
+
+  test('addApplicationInfo with config application id, version', () => {
+    const config = new Configuration({
+      application: { id: 'com.from-config.ld', version: '2.2.2' },
+    });
+    const ldApplication = addApplicationInfo(basicPlatform, config);
+
+    expect(ldApplication).toEqual({
+      envAttributesVersion: '1.0',
+      id: 'com.from-config.ld',
+      key: '1234567890123456',
+      name: 'LDApplication.TestApp',
+      version: '2.2.2',
+    });
+  });
+
+  test('addApplicationInfo with auto env application id, name, version', () => {
+    const config = new Configuration();
+    const ldApplication = addApplicationInfo(basicPlatform, config);
+
+    expect(ldApplication).toEqual({
+      envAttributesVersion: '1.0',
+      id: 'com.testapp.ld',
+      key: '1234567890123456',
+      name: 'LDApplication.TestApp',
+      version: '1.1.1',
+    });
+  });
+
+  test('addApplicationInfo with sdk data name, version', () => {
+    const platformData = info.platformData();
+    delete platformData.ld_application;
+    delete platformData.ld_device;
+    info.platformData = jest.fn().mockReturnValueOnce(platformData);
+    info.sdkData = jest.fn().mockReturnValueOnce({
+      name: 'Name from sdk data',
+      version: '3.3.3',
+      userAgentBase: 'TestUserAgent',
+      wrapperName: 'Rapper',
+      wrapperVersion: '9.9.9',
+    });
+
+    const config = new Configuration();
+    const ldApplication = addApplicationInfo(basicPlatform, config);
+
+    expect(ldApplication).toEqual({
+      envAttributesVersion: '1.0',
+      id: 'Name from sdk data',
+      key: '1234567890123456',
+      name: 'Name from sdk data',
+      version: '3.3.3',
+    });
+  });
+
+  test('addApplicationInfo with sdkData wrapperName, wrapperVersion', () => {
+    const platformData = info.platformData();
+    delete platformData.ld_application;
+    delete platformData.ld_device;
+    info.platformData = jest.fn().mockReturnValueOnce(platformData);
+    info.sdkData = jest.fn().mockReturnValueOnce({
+      name: '',
+      version: '',
+      userAgentBase: 'TestUserAgent',
+      wrapperName: 'Rapper',
+      wrapperVersion: '9.9.9',
+    });
+
+    const config = new Configuration();
+    const ldApplication = addApplicationInfo(basicPlatform, config);
+
+    expect(ldApplication).toEqual({
+      envAttributesVersion: '1.0',
+      id: 'Rapper',
+      key: '1234567890123456',
+      name: 'Rapper',
+      version: '9.9.9',
+    });
+  });
+
+  test('addDeviceInfo with platformData os name, version', async () => {
+    const ldDevice = await addDeviceInfo(basicPlatform);
+
+    expect(ldDevice).toEqual({
+      envAttributesVersion: '1.0',
+      key: 'test-device-key-1',
+      manufacturer: 'coconut',
+      os: { name: 'An OS', version: '1.0.1', family: 'orange' },
+    });
+  });
+
+  test('addDeviceInfo with auto env os name, version', async () => {
+    const platformData = info.platformData();
+    delete platformData.os;
+    info.platformData = jest.fn().mockReturnValueOnce(platformData);
+
+    const ldDevice = await addDeviceInfo(basicPlatform);
+
+    expect(ldDevice).toEqual({
+      envAttributesVersion: '1.0',
+      key: 'test-device-key-1',
+      manufacturer: 'coconut',
+      os: { name: 'Another OS', version: '99', family: 'orange' },
+    });
+  });
+
+  test('addDeviceInfo with auto env os name, version when platform data are empty strings', async () => {
+    const platformData = info.platformData();
+    platformData.os = { name: '', version: '' };
+    info.platformData = jest.fn().mockReturnValueOnce(platformData);
+
+    const ldDevice = await addDeviceInfo(basicPlatform);
+
+    expect(ldDevice).toEqual({
+      envAttributesVersion: '1.0',
+      key: 'test-device-key-1',
+      manufacturer: 'coconut',
+      os: { name: 'Another OS', version: '99', family: 'orange' },
+    });
+  });
+});

--- a/packages/shared/sdk-client/src/utils/addAutoEnv.ts
+++ b/packages/shared/sdk-client/src/utils/addAutoEnv.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {
+  clone,
+  internal,
+  LDApplication,
+  LDContext,
+  LDDevice,
+  LDMultiKindContext,
+  LDSingleKindContext,
+  LDUser,
+  Platform,
+} from '@launchdarkly/js-sdk-common';
+
+import Configuration from '../configuration';
+import { getOrGenerateKey } from './getOrGenerateKey';
+
+const { isLegacyUser, isSingleKind } = internal;
+const defaultAutoEnvSchemaVersion = '1.0';
+
+export const toMulti = (c: LDSingleKindContext) => {
+  const { kind, ...contextCommon } = c;
+
+  return {
+    kind: 'multi',
+    [kind]: contextCommon,
+  };
+};
+
+/**
+ * Clones the LDApplication object and populates the key, id and version fields.
+ *
+ * @param crypto
+ * @param info
+ * @param config
+ * @return An LDApplication object with populated key, id and version.
+ */
+export const addApplicationInfo = ({ crypto, info }: Platform, config: Configuration) => {
+  const { name, version, wrapperName, wrapperVersion } = info.sdkData();
+  const { ld_application } = info.platformData();
+
+  const ldApplication = clone<LDApplication>(ld_application) ?? {};
+  ldApplication.id = config.application?.id || ldApplication?.id || name || wrapperName;
+  ldApplication.name = ldApplication?.name || name || wrapperName;
+  ldApplication.version =
+    config.application?.version || ldApplication.version || version || wrapperVersion;
+
+  const hasher = crypto.createHash('sha256');
+  hasher.update(ldApplication.id!);
+  ldApplication.key = hasher.digest('base64');
+  ldApplication.envAttributesVersion =
+    ldApplication.envAttributesVersion || defaultAutoEnvSchemaVersion;
+
+  return ldApplication;
+};
+
+/**
+ * Clones the LDDevice object and populates the key field.
+ *
+ * @param platform
+ * @return An LDDevice object with populated key.
+ */
+export const addDeviceInfo = async (platform: Platform) => {
+  const { ld_device, os } = platform.info.platformData();
+  const ldDevice = clone<LDDevice>(ld_device);
+
+  ldDevice.os.name = os?.name || ldDevice.os.name;
+  ldDevice.os.version = os?.version || ldDevice.os.version;
+  ldDevice.key = await getOrGenerateKey('ld_device', platform);
+  ldDevice.envAttributesVersion = ldDevice.envAttributesVersion || defaultAutoEnvSchemaVersion;
+
+  return ldDevice;
+};
+
+export const addAutoEnv = async (context: LDContext, platform: Platform, config: Configuration) => {
+  // LDUser is not supported for auto env reporting
+  if (isLegacyUser(context)) {
+    return context as LDUser;
+  }
+
+  const multi = isSingleKind(context) ? toMulti(context) : context;
+
+  return {
+    ...multi,
+    ld_application: addApplicationInfo(platform, config),
+    ld_device: await addDeviceInfo(platform),
+  } as LDMultiKindContext;
+};

--- a/packages/shared/sdk-client/src/utils/ensureKey.test.ts
+++ b/packages/shared/sdk-client/src/utils/ensureKey.test.ts
@@ -1,17 +1,25 @@
 import type {
+  Crypto,
   LDContext,
   LDContextCommon,
   LDMultiKindContext,
   LDUser,
+  Storage,
 } from '@launchdarkly/js-sdk-common';
 import { basicPlatform } from '@launchdarkly/private-js-mocks';
 
-import ensureKey, { addNamespace, getOrGenerateKey } from './ensureKey';
+import ensureKey from './ensureKey';
+import { addNamespace, getOrGenerateKey } from './getOrGenerateKey';
 
-const { crypto, storage } = basicPlatform;
 describe('ensureKey', () => {
+  let crypto: Crypto;
+  let storage: Storage;
+
   beforeEach(() => {
-    crypto.randomUUID.mockReturnValueOnce('random1').mockReturnValueOnce('random2');
+    crypto = basicPlatform.crypto;
+    storage = basicPlatform.storage;
+
+    (crypto.randomUUID as jest.Mock).mockReturnValueOnce('random1').mockReturnValueOnce('random2');
   });
 
   afterEach(() => {
@@ -33,8 +41,8 @@ describe('ensureKey', () => {
   });
 
   test('getOrGenerateKey existing key', async () => {
-    storage.get.mockImplementation((nsKind: string) =>
-      nsKind === 'LaunchDarkly_AnonKeys_org' ? 'random1' : undefined,
+    (storage.get as jest.Mock).mockImplementation((namespacedKind: string) =>
+      namespacedKind === 'LaunchDarkly_AnonKeys_org' ? 'random1' : undefined,
     );
 
     const key = await getOrGenerateKey('org', basicPlatform);

--- a/packages/shared/sdk-client/src/utils/ensureKey.ts
+++ b/packages/shared/sdk-client/src/utils/ensureKey.ts
@@ -9,21 +9,9 @@ import {
   Platform,
 } from '@launchdarkly/js-sdk-common';
 
+import { getOrGenerateKey } from './getOrGenerateKey';
+
 const { isLegacyUser, isMultiKind, isSingleKind } = internal;
-
-export const addNamespace = (s: string) => `LaunchDarkly_AnonKeys_${s}`;
-
-export const getOrGenerateKey = async (kind: string, { crypto, storage }: Platform) => {
-  const nsKind = addNamespace(kind);
-  let contextKey = await storage?.get(nsKind);
-
-  if (!contextKey) {
-    contextKey = crypto.randomUUID();
-    await storage?.set(nsKind, contextKey);
-  }
-
-  return contextKey;
-};
 
 /**
  * This is the root ensureKey function. All other ensureKey functions reduce to this.
@@ -66,6 +54,13 @@ const ensureKeyLegacy = async (c: LDUser, platform: Platform) => {
   await ensureKeyCommon('user', c, platform);
 };
 
+/**
+ * Ensure a key is always present in anonymous contexts. Non-anonymous contexts
+ * are not processed and will just be returned as is.
+ *
+ * @param context
+ * @param platform
+ */
 const ensureKey = async (context: LDContext, platform: Platform) => {
   const cloned = clone<LDContext>(context);
 

--- a/packages/shared/sdk-client/src/utils/getOrGenerateKey.test.ts
+++ b/packages/shared/sdk-client/src/utils/getOrGenerateKey.test.ts
@@ -1,0 +1,38 @@
+import { Crypto, Storage } from '@launchdarkly/js-sdk-common';
+import { basicPlatform } from '@launchdarkly/private-js-mocks';
+
+import { getOrGenerateKey } from './getOrGenerateKey';
+
+describe('getOrGenerateKey', () => {
+  let crypto: Crypto;
+  let storage: Storage;
+
+  beforeEach(() => {
+    crypto = basicPlatform.crypto;
+    storage = basicPlatform.storage;
+
+    (crypto.randomUUID as jest.Mock).mockResolvedValue('test-org-key-1');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('key does not exist in cache so it must be generated', async () => {
+    (storage.get as jest.Mock).mockResolvedValue(undefined);
+    const k = await getOrGenerateKey('org', basicPlatform);
+
+    expect(crypto.randomUUID).toHaveBeenCalled();
+    expect(storage.set).toHaveBeenCalled();
+    expect(k).toEqual('test-org-key-1');
+  });
+
+  test('key exists in cache so not generated', async () => {
+    (storage.get as jest.Mock).mockResolvedValue('test-org-key-2');
+    const k = await getOrGenerateKey('org', basicPlatform);
+
+    expect(crypto.randomUUID).not.toHaveBeenCalled();
+    expect(storage.set).not.toHaveBeenCalled();
+    expect(k).toEqual('test-org-key-2');
+  });
+});

--- a/packages/shared/sdk-client/src/utils/getOrGenerateKey.ts
+++ b/packages/shared/sdk-client/src/utils/getOrGenerateKey.ts
@@ -1,0 +1,15 @@
+import { Platform } from '@launchdarkly/js-sdk-common';
+
+export const addNamespace = (s: string) => `LaunchDarkly_AnonKeys_${s}`;
+
+export const getOrGenerateKey = async (kind: string, { crypto, storage }: Platform) => {
+  const namespacedKind = addNamespace(kind);
+  let contextKey = await storage?.get(namespacedKind);
+
+  if (!contextKey) {
+    contextKey = crypto.randomUUID();
+    await storage?.set(namespacedKind, contextKey);
+  }
+
+  return contextKey;
+};

--- a/packages/shared/sdk-client/src/utils/index.ts
+++ b/packages/shared/sdk-client/src/utils/index.ts
@@ -1,4 +1,5 @@
+import { addAutoEnv } from './addAutoEnv';
 import calculateFlagChanges from './calculateFlagChanges';
 import ensureKey from './ensureKey';
 
-export { calculateFlagChanges, ensureKey };
+export { calculateFlagChanges, ensureKey, addAutoEnv };

--- a/packages/shared/sdk-server-edge/jest.config.json
+++ b/packages/shared/sdk-server-edge/jest.config.json
@@ -5,5 +5,6 @@
   "modulePathIgnorePatterns": ["dist"],
   "testEnvironment": "node",
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
-  "collectCoverageFrom": ["src/**/*.ts"]
+  "collectCoverageFrom": ["src/**/*.ts"],
+  "setupFilesAfterEnv": ["@launchdarkly/private-js-mocks/setup"]
 }

--- a/packages/shared/sdk-server/__tests__/evaluation/Bucketer.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Bucketer.test.ts
@@ -2,124 +2,128 @@
 // We cannot fully validate bucketing in the common tests. Platform implementations
 // should contain a consistency test.
 // Testing here can only validate we are providing correct inputs to the hashing algorithm.
-import { AttributeReference, Context, LDContext } from '@launchdarkly/js-sdk-common';
-import * as mocks from '@launchdarkly/private-js-mocks';
+import { AttributeReference, Context, Crypto, LDContext } from '@launchdarkly/js-sdk-common';
+import { basicPlatform, hasher } from '@launchdarkly/private-js-mocks';
 
 import Bucketer from '../../src/evaluation/Bucketer';
 
-describe.each<
-  [
-    context: LDContext,
-    key: string,
-    attr: string,
-    salt: string,
-    kindForRollout: string | undefined,
-    seed: number | undefined,
-    expected: string,
-  ]
->([
-  [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, undefined, 'flag-key.salty.is-key'],
-  // No specified kind, and user, are equivalent.
-  [{ key: 'is-key' }, 'flag-key', 'key', 'salty', 'user', undefined, 'flag-key.salty.is-key'],
-  [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, undefined, 'flag-key.salty.is-key'],
+describe('Bucketer.test', () => {
+  let crypto: Crypto;
 
-  [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, 82, '82.is-key'],
-  [
-    { key: 'is-key', kind: 'org' },
-    'flag-key',
-    'key',
-    'salty',
-    'org',
-    undefined,
-    'flag-key.salty.is-key',
-  ],
-  [
-    { key: 'is-key', kind: 'org', integer: 17 },
-    'flag-key',
-    'integer',
-    'salty',
-    'org',
-    undefined,
-    'flag-key.salty.17',
-  ],
-  [
-    { kind: 'multi', user: { key: 'user-key' }, org: { key: 'org-key' } },
-    'flag-key',
-    'key',
-    'salty',
-    undefined,
-    undefined,
-    'flag-key.salty.user-key',
-  ],
-  [
-    { kind: 'multi', user: { key: 'user-key' }, org: { key: 'org-key' } },
-    'flag-key',
-    'key',
-    'salty',
-    'org',
-    undefined,
-    'flag-key.salty.org-key',
-  ],
-])('given bucketing parameters', (context, key, attr, salt, kindForRollout, seed, expected) => {
-  it('hashes the correct string', () => {
-    const validatedContext = Context.fromLDContext(context);
-    const attrRef = new AttributeReference(attr);
-
-    const bucketer = new Bucketer(mocks.crypto);
-    const [bucket, hadContext] = bucketer.bucket(
-      validatedContext!,
-      key,
-      attrRef,
-      salt,
-      kindForRollout,
-      seed,
-    );
-
-    // The mocks.hasher always returns the same value. This just checks that it converts it to a number
-    // in the expected way.
-    expect(bucket).toBeCloseTo(0.07111111110140983, 5);
-    expect(hadContext).toBeTruthy();
-    expect(mocks.hasher.update).toHaveBeenCalledWith(expected);
-    expect(mocks.hasher.digest).toHaveBeenCalledWith('hex');
+  beforeEach(() => {
+    crypto = basicPlatform.crypto;
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
-});
 
-describe.each([
-  ['org', 'object'],
-  ['org', 'array'],
-  ['org', 'null'],
-  ['bad', 'key'],
-])('when given a non string or integer reference', (kind, attr) => {
-  it('buckets to 0 when given bad data', () => {
-    const validatedContext = Context.fromLDContext({
-      key: 'context-key',
-      kind,
-      object: {},
-      array: [],
-      null: null,
-    });
-    const attrRef = new AttributeReference(attr);
+  describe.each<
+    [
+      context: LDContext,
+      key: string,
+      attr: string,
+      salt: string,
+      kindForRollout: string | undefined,
+      seed: number | undefined,
+      expected: string,
+    ]
+  >([
+    [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, undefined, 'flag-key.salty.is-key'],
+    // No specified kind, and user, are equivalent.
+    [{ key: 'is-key' }, 'flag-key', 'key', 'salty', 'user', undefined, 'flag-key.salty.is-key'],
+    [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, undefined, 'flag-key.salty.is-key'],
 
-    const bucketer = new Bucketer(mocks.crypto);
-    const [bucket, hadContext] = bucketer.bucket(
-      validatedContext!,
+    [{ key: 'is-key' }, 'flag-key', 'key', 'salty', undefined, 82, '82.is-key'],
+    [
+      { key: 'is-key', kind: 'org' },
+      'flag-key',
       'key',
-      attrRef,
       'salty',
       'org',
       undefined,
-    );
-    expect(bucket).toEqual(0);
-    expect(hadContext).toEqual(kind === 'org');
-    expect(mocks.hasher.update).toBeCalledTimes(0);
-    expect(mocks.hasher.digest).toBeCalledTimes(0);
+      'flag-key.salty.is-key',
+    ],
+    [
+      { key: 'is-key', kind: 'org', integer: 17 },
+      'flag-key',
+      'integer',
+      'salty',
+      'org',
+      undefined,
+      'flag-key.salty.17',
+    ],
+    [
+      { kind: 'multi', user: { key: 'user-key' }, org: { key: 'org-key' } },
+      'flag-key',
+      'key',
+      'salty',
+      undefined,
+      undefined,
+      'flag-key.salty.user-key',
+    ],
+    [
+      { kind: 'multi', user: { key: 'user-key' }, org: { key: 'org-key' } },
+      'flag-key',
+      'key',
+      'salty',
+      'org',
+      undefined,
+      'flag-key.salty.org-key',
+    ],
+  ])('given bucketing parameters', (context, key, attr, salt, kindForRollout, seed, expected) => {
+    it('hashes the correct string', () => {
+      const validatedContext = Context.fromLDContext(context);
+      const attrRef = new AttributeReference(attr);
+
+      const bucketer = new Bucketer(crypto);
+      const [bucket, hadContext] = bucketer.bucket(
+        validatedContext!,
+        key,
+        attrRef,
+        salt,
+        kindForRollout,
+        seed,
+      );
+
+      // The mocks.hasher always returns the same value. This just checks that it converts it to a number
+      // in the expected way.
+      expect(bucket).toBeCloseTo(0.07111111110140983, 5);
+      expect(hadContext).toBeTruthy();
+      expect(hasher.update).toHaveBeenCalledWith(expected);
+      expect(hasher.digest).toHaveBeenCalledWith('hex');
+    });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  describe.each([
+    ['org', 'object'],
+    ['org', 'array'],
+    ['org', 'null'],
+    ['bad', 'key'],
+  ])('when given a non string or integer reference', (kind, attr) => {
+    it('buckets to 0 when given bad data', () => {
+      const validatedContext = Context.fromLDContext({
+        key: 'context-key',
+        kind,
+        object: {},
+        array: [],
+        null: null,
+      });
+      const attrRef = new AttributeReference(attr);
+
+      const bucketer = new Bucketer(crypto);
+      const [bucket, hadContext] = bucketer.bucket(
+        validatedContext!,
+        'key',
+        attrRef,
+        'salty',
+        'org',
+        undefined,
+      );
+      expect(bucket).toEqual(0);
+      expect(hadContext).toEqual(kind === 'org');
+      expect(hasher.update).toHaveBeenCalledTimes(0);
+      expect(hasher.digest).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/packages/shared/sdk-server/__tests__/evaluation/Evaluator.bucketing.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Evaluator.bucketing.test.ts
@@ -6,9 +6,17 @@ import { Rollout } from '../../src/evaluation/data/Rollout';
 import Evaluator from '../../src/evaluation/Evaluator';
 import noQueries from './mocks/noQueries';
 
-const evaluator = new Evaluator(mocks.basicPlatform, noQueries);
-
 describe('given a flag with a rollout', () => {
+  let evaluator: Evaluator;
+
+  beforeEach(() => {
+    evaluator = new Evaluator(mocks.basicPlatform, noQueries);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   const seed = 61;
   const flagKey = 'flagkey';
   const salt = 'salt';

--- a/packages/shared/sdk-server/__tests__/evaluation/Evaluator.clause.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Evaluator.clause.test.ts
@@ -12,460 +12,465 @@ import {
 } from './flags';
 import noQueries from './mocks/noQueries';
 
-const evaluator = new Evaluator(mocks.basicPlatform, noQueries);
-
-// Either a legacy user, or context with equivalent user.
-describe('given user clauses and contexts', () => {
-  it.each<LDContext>([
-    { key: 'x', name: 'Bob' },
-    { kind: 'user', key: 'x', name: 'Bob' },
-    { kind: 'multi', user: { key: 'x', name: 'Bob' } },
-  ])('can match built-in attribute', async (user) => {
-    const clause: Clause = {
-      attribute: 'name',
-      op: 'in',
-      values: ['Bob'],
-      attributeReference: new AttributeReference('name'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
+describe('Evaluator.clause', () => {
+  let evaluator: Evaluator;
+  beforeEach(() => {
+    evaluator = new Evaluator(mocks.basicPlatform, noQueries);
   });
 
-  it.each<LDContext>([
-    { key: 'x', name: 'Bob', custom: { legs: 4 } },
-    {
-      kind: 'user',
-      key: 'x',
-      name: 'Bob',
-      legs: 4,
-    },
-    { kind: 'multi', user: { key: 'x', name: 'Bob', legs: 4 } },
-  ])('can match custom attribute', async (user) => {
-    const clause: Clause = {
-      attribute: 'legs',
-      op: 'in',
-      values: [4],
-      attributeReference: new AttributeReference('legs'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it.each<[LDContext, string]>([
-    [{ key: 'x', name: 'Bob', custom: { '//': 4 } }, '//'],
-    [
-      {
-        kind: 'user',
-        key: 'x',
-        name: 'Bob',
-        '//': 4,
-      },
-      '//',
-    ],
-    [{ kind: 'multi', user: { key: 'x', name: 'Bob', '//': 4 } }, '//'],
-    [{ key: 'x', name: 'Bob', custom: { '/~~': 4 } }, '/~~'],
-    [
-      {
-        kind: 'user',
-        key: 'x',
-        name: 'Bob',
-        '/~~': 4,
-      },
-      '/~~',
-    ],
-    [{ kind: 'multi', user: { key: 'x', name: 'Bob', '/~~': 4 } }, '/~~'],
-  ])(
-    'can match attributes which would have be invalid references, but are valid literals',
-    async (user, attribute) => {
+  // Either a legacy user, or context with equivalent user.
+  describe('given user clauses and contexts', () => {
+    it.each<LDContext>([
+      { key: 'x', name: 'Bob' },
+      { kind: 'user', key: 'x', name: 'Bob' },
+      { kind: 'multi', user: { key: 'x', name: 'Bob' } },
+    ])('can match built-in attribute', async (user) => {
       const clause: Clause = {
-        attribute,
+        attribute: 'name',
         op: 'in',
-        values: [4],
-        attributeReference: new AttributeReference(attribute, true),
+        values: ['Bob'],
+        attributeReference: new AttributeReference('name'),
       };
       const flag = makeBooleanFlagWithOneClause(clause);
       const context = Context.fromLDContext(user);
       const res = await evaluator.evaluate(flag, context!);
       expect(res.detail.value).toBe(true);
+    });
+
+    it.each<LDContext>([
+      { key: 'x', name: 'Bob', custom: { legs: 4 } },
+      {
+        kind: 'user',
+        key: 'x',
+        name: 'Bob',
+        legs: 4,
+      },
+      { kind: 'multi', user: { key: 'x', name: 'Bob', legs: 4 } },
+    ])('can match custom attribute', async (user) => {
+      const clause: Clause = {
+        attribute: 'legs',
+        op: 'in',
+        values: [4],
+        attributeReference: new AttributeReference('legs'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it.each<[LDContext, string]>([
+      [{ key: 'x', name: 'Bob', custom: { '//': 4 } }, '//'],
+      [
+        {
+          kind: 'user',
+          key: 'x',
+          name: 'Bob',
+          '//': 4,
+        },
+        '//',
+      ],
+      [{ kind: 'multi', user: { key: 'x', name: 'Bob', '//': 4 } }, '//'],
+      [{ key: 'x', name: 'Bob', custom: { '/~~': 4 } }, '/~~'],
+      [
+        {
+          kind: 'user',
+          key: 'x',
+          name: 'Bob',
+          '/~~': 4,
+        },
+        '/~~',
+      ],
+      [{ kind: 'multi', user: { key: 'x', name: 'Bob', '/~~': 4 } }, '/~~'],
+    ])(
+      'can match attributes which would have be invalid references, but are valid literals',
+      async (user, attribute) => {
+        const clause: Clause = {
+          attribute,
+          op: 'in',
+          values: [4],
+          attributeReference: new AttributeReference(attribute, true),
+        };
+        const flag = makeBooleanFlagWithOneClause(clause);
+        const context = Context.fromLDContext(user);
+        const res = await evaluator.evaluate(flag, context!);
+        expect(res.detail.value).toBe(true);
+      },
+    );
+
+    it.each<LDContext>([
+      { key: 'x', name: 'Bob' },
+      { kind: 'user', key: 'x', name: 'Bob' },
+      { kind: 'multi', user: { key: 'x', name: 'Bob' } },
+    ])('does not match missing attribute', async (user) => {
+      const clause: Clause = {
+        attribute: 'legs',
+        op: 'in',
+        values: [4],
+        attributeReference: new AttributeReference('legs'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+
+    it.each<LDContext>([
+      { key: 'x', name: 'Bob' },
+      { kind: 'user', key: 'x', name: 'Bob' },
+      { kind: 'multi', user: { key: 'x', name: 'Bob' } },
+    ])('can have a negated clause', async (user) => {
+      const clause: Clause = {
+        attribute: 'name',
+        op: 'in',
+        values: ['Bob'],
+        negate: true,
+        attributeReference: new AttributeReference('name'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+
+    // An equivalent test existed in the previous suite. I see no reason that the
+    // current code could encounter such a situation, but this will help ensure
+    // it never does.
+    it('does not overflow the call stack when evaluating a huge number of clauses', async () => {
+      const user = { key: 'user' };
+      const clauseCount = 5000;
+      const flag: Flag = {
+        key: 'flag',
+        targets: [],
+        on: true,
+        variations: [false, true],
+        fallthrough: { variation: 0 },
+        version: 1,
+      };
+      // Note, for this test to be meaningful, the clauses must all match the user, since we
+      // stop evaluating clauses on the first non-match.
+      const clause = makeClauseThatMatchesUser(user);
+      const clauses = [];
+      for (let i = 0; i < clauseCount; i += 1) {
+        clauses.push(clause);
+      }
+      const rule: FlagRule = { id: '1234', clauses, variation: 1 };
+      flag.rules = [rule];
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('matches kind of implicit user', async () => {
+      const user = { key: 'x', name: 'Bob' };
+      const clause: Clause = {
+        attribute: 'kind',
+        op: 'in',
+        values: ['user'],
+        attributeReference: new AttributeReference('kind'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('implicit user kind does not match rules for non-user kinds', async () => {
+      const user = { key: 'x', name: 'Bob' };
+      const clause: Clause = {
+        attribute: 'key',
+        op: 'in',
+        values: ['userkey'],
+        contextKind: 'org',
+        attributeReference: new AttributeReference('key'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext(user);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+  });
+
+  describe('given non-user single-kind contexts', () => {
+    it('does not match implicit user clauses to non-user contexts', async () => {
+      const clause: Clause = {
+        attribute: 'name',
+        op: 'in',
+        values: ['Bob'],
+        attributeReference: new AttributeReference('name'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+
+    it('cannot use an object attribute for a match.', async () => {
+      const clause: Clause = {
+        attribute: 'complex',
+        op: 'in',
+        values: [{ thing: true }],
+        contextKind: 'org',
+        attributeReference: new AttributeReference('complex'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext({
+        kind: 'org',
+        name: 'Bob',
+        key: 'bobkey',
+        complex: { thing: true },
+      });
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+
+    it('does match clauses for the correct context kind', async () => {
+      const clause: Clause = {
+        attribute: 'name',
+        op: 'in',
+        values: ['Bob'],
+        contextKind: 'org',
+        attributeReference: new AttributeReference('name'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('matches clauses for the kind attribute', async () => {
+      // The context kind here should not matter, but the 'kind' attribute should.
+      const clause: Clause = {
+        attribute: 'kind',
+        op: 'in',
+        values: ['org'],
+        contextKind: 'potato',
+        attributeReference: new AttributeReference('kind'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('does not match clauses for the kind attribute if the kind does not match', async () => {
+      // The context kind here should not matter, but the 'kind' attribute should.
+      const clause: Clause = {
+        attribute: 'kind',
+        op: 'in',
+        values: ['org'],
+        contextKind: 'potato',
+        attributeReference: new AttributeReference('kind'),
+      };
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const context = Context.fromLDContext({ kind: 'party', name: 'Bob', key: 'bobkey' });
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+  });
+
+  describe('given multi-kind contexts', () => {
+    it('does match clauses correctly with multiple contexts', async () => {
+      const clause1: Clause = {
+        attribute: 'region',
+        op: 'in',
+        values: ['north'],
+        contextKind: 'park',
+        attributeReference: new AttributeReference('region'),
+      };
+      const clause2: Clause = {
+        attribute: 'count',
+        op: 'in',
+        values: [5],
+        contextKind: 'party',
+        attributeReference: new AttributeReference('count'),
+      };
+
+      const context = Context.fromLDContext({
+        kind: 'multi',
+        park: {
+          key: 'park',
+          region: 'north',
+        },
+        party: {
+          key: 'party',
+          count: 5,
+        },
+      });
+
+      const flag = makeBooleanFlagWithRules([
+        { id: '1234', clauses: [clause1, clause2], variation: 1 },
+      ]);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('does not match the values from the wrong contexts', async () => {
+      const clause1: Clause = {
+        attribute: 'region',
+        op: 'in',
+        values: ['north'],
+        contextKind: 'park',
+        attributeReference: new AttributeReference('region'),
+      };
+      const clause2: Clause = {
+        attribute: 'count',
+        op: 'in',
+        values: [5],
+        contextKind: 'party',
+        attributeReference: new AttributeReference('count'),
+      };
+
+      const context = Context.fromLDContext({
+        kind: 'multi',
+        park: {
+          key: 'park',
+          count: 5,
+        },
+        party: {
+          key: 'party',
+          region: 'north',
+        },
+      });
+
+      const flag = makeBooleanFlagWithRules([
+        { id: '1234', clauses: [clause1, clause2], variation: 1 },
+      ]);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+
+    it('can check for the presence of contexts', async () => {
+      const clause: Clause = {
+        attribute: 'kind',
+        op: 'in',
+        values: ['party'],
+        attributeReference: new AttributeReference('kind'),
+      };
+
+      const context = Context.fromLDContext({
+        kind: 'multi',
+        park: {
+          key: 'park',
+          count: 5,
+        },
+        party: {
+          key: 'party',
+          region: 'north',
+        },
+      });
+
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(true);
+    });
+
+    it('does not match if the kind is not in the context', async () => {
+      const clause: Clause = {
+        attribute: 'kind',
+        op: 'in',
+        values: ['zoo'],
+        attributeReference: new AttributeReference('kind'),
+      };
+
+      const context = Context.fromLDContext({
+        kind: 'multi',
+        park: {
+          key: 'park',
+          count: 5,
+        },
+        party: {
+          key: 'party',
+          region: 'north',
+        },
+      });
+
+      const flag = makeBooleanFlagWithOneClause(clause);
+      const res = await evaluator.evaluate(flag, context!);
+      expect(res.detail.value).toBe(false);
+    });
+  });
+
+  it('handles clauses with malformed attribute references', async () => {
+    const clause: Clause = {
+      attribute: '//region',
+      op: 'in',
+      values: ['north'],
+      contextKind: 'park',
+      attributeReference: new AttributeReference('//region'),
+    };
+
+    const context = Context.fromLDContext({
+      kind: 'multi',
+      park: {
+        key: 'park',
+        region: 'north',
+      },
+      party: {
+        key: 'party',
+        count: 5,
+      },
+    });
+
+    const flag = makeBooleanFlagWithRules([{ id: '1234', clauses: [clause], variation: 1 }]);
+    const res = await evaluator.evaluate(flag, context!);
+    expect(res.detail.reason).toEqual({ kind: 'ERROR', errorKind: 'MALFORMED_FLAG' });
+    expect(res.detail.value).toBe(null);
+  });
+
+  describe.each([
+    ['lessThan', 99, 99.0001],
+    ['lessThanOrEqual', 99, 99.0001],
+    ['greaterThan', 99.0001, 99],
+    ['greaterThanOrEqual', 99.0001, 99],
+
+    // string comparisons
+    ['startsWith', 'xyz', 'x'],
+    ['endsWith', 'xyz', 'z'],
+    ['contains', 'xyz', 'y'],
+
+    // regex
+    ['matches', 'hello world', 'hello.*rld'],
+
+    // dates
+    ['before', 0, 1],
+    ['after', '1970-01-01T00:00:02.500Z', 1000],
+
+    // semver
+    ['semVerLessThan', '2.0.0', '2.0.1'],
+    ['semVerGreaterThan', '2.0.1', '2.0.0'],
+  ])(
+    'executes operations with the clause value and context value correctly',
+    (operator, contextValue, clauseValue) => {
+      const clause: Clause = {
+        attribute: 'value',
+        // @ts-ignore
+        op: operator,
+        values: [clauseValue],
+        contextKind: 'potato',
+        attributeReference: new AttributeReference('value'),
+      };
+
+      const context = Context.fromLDContext({
+        kind: 'potato',
+        key: 'potato',
+        value: contextValue,
+      });
+
+      const contextWArray = Context.fromLDContext({
+        kind: 'potato',
+        key: 'potato',
+        value: [contextValue],
+      });
+
+      it(`Operator ${operator} with ${contextValue} and ${clauseValue} should be true`, async () => {
+        const flag = makeBooleanFlagWithOneClause(clause);
+        const res = await evaluator.evaluate(flag, context);
+        expect(res.detail.value).toBe(true);
+
+        const res2 = await evaluator.evaluate(flag, contextWArray);
+        expect(res2.detail.value).toBe(true);
+      });
     },
   );
-
-  it.each<LDContext>([
-    { key: 'x', name: 'Bob' },
-    { kind: 'user', key: 'x', name: 'Bob' },
-    { kind: 'multi', user: { key: 'x', name: 'Bob' } },
-  ])('does not match missing attribute', async (user) => {
-    const clause: Clause = {
-      attribute: 'legs',
-      op: 'in',
-      values: [4],
-      attributeReference: new AttributeReference('legs'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-
-  it.each<LDContext>([
-    { key: 'x', name: 'Bob' },
-    { kind: 'user', key: 'x', name: 'Bob' },
-    { kind: 'multi', user: { key: 'x', name: 'Bob' } },
-  ])('can have a negated clause', async (user) => {
-    const clause: Clause = {
-      attribute: 'name',
-      op: 'in',
-      values: ['Bob'],
-      negate: true,
-      attributeReference: new AttributeReference('name'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-
-  // An equivalent test existed in the previous suite. I see no reason that the
-  // current code could encounter such a situation, but this will help ensure
-  // it never does.
-  it('does not overflow the call stack when evaluating a huge number of clauses', async () => {
-    const user = { key: 'user' };
-    const clauseCount = 5000;
-    const flag: Flag = {
-      key: 'flag',
-      targets: [],
-      on: true,
-      variations: [false, true],
-      fallthrough: { variation: 0 },
-      version: 1,
-    };
-    // Note, for this test to be meaningful, the clauses must all match the user, since we
-    // stop evaluating clauses on the first non-match.
-    const clause = makeClauseThatMatchesUser(user);
-    const clauses = [];
-    for (let i = 0; i < clauseCount; i += 1) {
-      clauses.push(clause);
-    }
-    const rule: FlagRule = { id: '1234', clauses, variation: 1 };
-    flag.rules = [rule];
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('matches kind of implicit user', async () => {
-    const user = { key: 'x', name: 'Bob' };
-    const clause: Clause = {
-      attribute: 'kind',
-      op: 'in',
-      values: ['user'],
-      attributeReference: new AttributeReference('kind'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('implicit user kind does not match rules for non-user kinds', async () => {
-    const user = { key: 'x', name: 'Bob' };
-    const clause: Clause = {
-      attribute: 'key',
-      op: 'in',
-      values: ['userkey'],
-      contextKind: 'org',
-      attributeReference: new AttributeReference('key'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext(user);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
 });
-
-describe('given non-user single-kind contexts', () => {
-  it('does not match implicit user clauses to non-user contexts', async () => {
-    const clause: Clause = {
-      attribute: 'name',
-      op: 'in',
-      values: ['Bob'],
-      attributeReference: new AttributeReference('name'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-
-  it('cannot use an object attribute for a match.', async () => {
-    const clause: Clause = {
-      attribute: 'complex',
-      op: 'in',
-      values: [{ thing: true }],
-      contextKind: 'org',
-      attributeReference: new AttributeReference('complex'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext({
-      kind: 'org',
-      name: 'Bob',
-      key: 'bobkey',
-      complex: { thing: true },
-    });
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-
-  it('does match clauses for the correct context kind', async () => {
-    const clause: Clause = {
-      attribute: 'name',
-      op: 'in',
-      values: ['Bob'],
-      contextKind: 'org',
-      attributeReference: new AttributeReference('name'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('matches clauses for the kind attribute', async () => {
-    // The context kind here should not matter, but the 'kind' attribute should.
-    const clause: Clause = {
-      attribute: 'kind',
-      op: 'in',
-      values: ['org'],
-      contextKind: 'potato',
-      attributeReference: new AttributeReference('kind'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext({ kind: 'org', name: 'Bob', key: 'bobkey' });
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('does not match clauses for the kind attribute if the kind does not match', async () => {
-    // The context kind here should not matter, but the 'kind' attribute should.
-    const clause: Clause = {
-      attribute: 'kind',
-      op: 'in',
-      values: ['org'],
-      contextKind: 'potato',
-      attributeReference: new AttributeReference('kind'),
-    };
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const context = Context.fromLDContext({ kind: 'party', name: 'Bob', key: 'bobkey' });
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-});
-
-describe('given multi-kind contexts', () => {
-  it('does match clauses correctly with multiple contexts', async () => {
-    const clause1: Clause = {
-      attribute: 'region',
-      op: 'in',
-      values: ['north'],
-      contextKind: 'park',
-      attributeReference: new AttributeReference('region'),
-    };
-    const clause2: Clause = {
-      attribute: 'count',
-      op: 'in',
-      values: [5],
-      contextKind: 'party',
-      attributeReference: new AttributeReference('count'),
-    };
-
-    const context = Context.fromLDContext({
-      kind: 'multi',
-      park: {
-        key: 'park',
-        region: 'north',
-      },
-      party: {
-        key: 'party',
-        count: 5,
-      },
-    });
-
-    const flag = makeBooleanFlagWithRules([
-      { id: '1234', clauses: [clause1, clause2], variation: 1 },
-    ]);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('does not match the values from the wrong contexts', async () => {
-    const clause1: Clause = {
-      attribute: 'region',
-      op: 'in',
-      values: ['north'],
-      contextKind: 'park',
-      attributeReference: new AttributeReference('region'),
-    };
-    const clause2: Clause = {
-      attribute: 'count',
-      op: 'in',
-      values: [5],
-      contextKind: 'party',
-      attributeReference: new AttributeReference('count'),
-    };
-
-    const context = Context.fromLDContext({
-      kind: 'multi',
-      park: {
-        key: 'park',
-        count: 5,
-      },
-      party: {
-        key: 'party',
-        region: 'north',
-      },
-    });
-
-    const flag = makeBooleanFlagWithRules([
-      { id: '1234', clauses: [clause1, clause2], variation: 1 },
-    ]);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-
-  it('can check for the presence of contexts', async () => {
-    const clause: Clause = {
-      attribute: 'kind',
-      op: 'in',
-      values: ['party'],
-      attributeReference: new AttributeReference('kind'),
-    };
-
-    const context = Context.fromLDContext({
-      kind: 'multi',
-      park: {
-        key: 'park',
-        count: 5,
-      },
-      party: {
-        key: 'party',
-        region: 'north',
-      },
-    });
-
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(true);
-  });
-
-  it('does not match if the kind is not in the context', async () => {
-    const clause: Clause = {
-      attribute: 'kind',
-      op: 'in',
-      values: ['zoo'],
-      attributeReference: new AttributeReference('kind'),
-    };
-
-    const context = Context.fromLDContext({
-      kind: 'multi',
-      park: {
-        key: 'park',
-        count: 5,
-      },
-      party: {
-        key: 'party',
-        region: 'north',
-      },
-    });
-
-    const flag = makeBooleanFlagWithOneClause(clause);
-    const res = await evaluator.evaluate(flag, context!);
-    expect(res.detail.value).toBe(false);
-  });
-});
-
-it('handles clauses with malformed attribute references', async () => {
-  const clause: Clause = {
-    attribute: '//region',
-    op: 'in',
-    values: ['north'],
-    contextKind: 'park',
-    attributeReference: new AttributeReference('//region'),
-  };
-
-  const context = Context.fromLDContext({
-    kind: 'multi',
-    park: {
-      key: 'park',
-      region: 'north',
-    },
-    party: {
-      key: 'party',
-      count: 5,
-    },
-  });
-
-  const flag = makeBooleanFlagWithRules([{ id: '1234', clauses: [clause], variation: 1 }]);
-  const res = await evaluator.evaluate(flag, context!);
-  expect(res.detail.reason).toEqual({ kind: 'ERROR', errorKind: 'MALFORMED_FLAG' });
-  expect(res.detail.value).toBe(null);
-});
-
-describe.each([
-  ['lessThan', 99, 99.0001],
-  ['lessThanOrEqual', 99, 99.0001],
-  ['greaterThan', 99.0001, 99],
-  ['greaterThanOrEqual', 99.0001, 99],
-
-  // string comparisons
-  ['startsWith', 'xyz', 'x'],
-  ['endsWith', 'xyz', 'z'],
-  ['contains', 'xyz', 'y'],
-
-  // regex
-  ['matches', 'hello world', 'hello.*rld'],
-
-  // dates
-  ['before', 0, 1],
-  ['after', '1970-01-01T00:00:02.500Z', 1000],
-
-  // semver
-  ['semVerLessThan', '2.0.0', '2.0.1'],
-  ['semVerGreaterThan', '2.0.1', '2.0.0'],
-])(
-  'executes operations with the clause value and context value correctly',
-  (operator, contextValue, clauseValue) => {
-    const clause: Clause = {
-      attribute: 'value',
-      // @ts-ignore
-      op: operator,
-      values: [clauseValue],
-      contextKind: 'potato',
-      attributeReference: new AttributeReference('value'),
-    };
-
-    const context = Context.fromLDContext({
-      kind: 'potato',
-      key: 'potato',
-      value: contextValue,
-    });
-
-    const contextWArray = Context.fromLDContext({
-      kind: 'potato',
-      key: 'potato',
-      value: [contextValue],
-    });
-
-    it(`Operator ${operator} with ${contextValue} and ${clauseValue} should be true`, async () => {
-      const flag = makeBooleanFlagWithOneClause(clause);
-      const res = await evaluator.evaluate(flag, context);
-      expect(res.detail.value).toBe(true);
-
-      const res2 = await evaluator.evaluate(flag, contextWArray);
-      expect(res2.detail.value).toBe(true);
-    });
-  },
-);

--- a/packages/shared/sdk-server/__tests__/evaluation/Evaluator.rules.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Evaluator.rules.test.ts
@@ -18,166 +18,171 @@ const basicUser: LDContext = { key: 'userkey' };
 const basicSingleKindUser: LDContext = { kind: 'user', key: 'userkey' };
 const basicMultiKindUser: LDContext = { kind: 'multi', user: { key: 'userkey' } };
 
-const evaluator = new Evaluator(mocks.basicPlatform, noQueries);
+describe('Evaluator.rules', () => {
+  let evaluator: Evaluator;
+  beforeEach(() => {
+    evaluator = new Evaluator(mocks.basicPlatform, noQueries);
+  });
 
-describe('when evaluating user equivalent contexts', () => {
-  const matchClause = makeClauseThatMatchesUser(basicUser);
-  const noMatchClause = makeClauseThatDoesNotMatchUser(basicUser);
+  describe('when evaluating user equivalent contexts', () => {
+    const matchClause = makeClauseThatMatchesUser(basicUser);
+    const noMatchClause = makeClauseThatDoesNotMatchUser(basicUser);
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'matches user from rules',
-    async (userToTest) => {
-      const rule0: FlagRule = {
-        id: 'id0',
-        clauses: [noMatchClause],
-        variation: 1,
-      };
-      const rule1: FlagRule = {
-        id: 'id1',
-        clauses: [matchClause],
-        variation: 2,
-      };
-      const flag = makeFlagWithRules([rule0, rule1]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.detail).toMatchObject({
-        value: 'c',
-        variationIndex: 2,
-        reason: { kind: 'RULE_MATCH', ruleIndex: 1, ruleId: 'id1' },
-      });
-    },
-  );
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'matches user from rules',
+      async (userToTest) => {
+        const rule0: FlagRule = {
+          id: 'id0',
+          clauses: [noMatchClause],
+          variation: 1,
+        };
+        const rule1: FlagRule = {
+          id: 'id1',
+          clauses: [matchClause],
+          variation: 2,
+        };
+        const flag = makeFlagWithRules([rule0, rule1]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.detail).toMatchObject({
+          value: 'c',
+          variationIndex: 2,
+          reason: { kind: 'RULE_MATCH', ruleIndex: 1, ruleId: 'id1' },
+        });
+      },
+    );
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'returns error if rule variation is too high',
-    async (userToTest) => {
-      const rule: FlagRule = { id: 'id', clauses: [matchClause], variation: 99 };
-      const flag = makeFlagWithRules([rule]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.isError).toBeTruthy();
-      expect(res.message).toEqual('Invalid variation index in flag');
-      expect(res.detail).toMatchObject({
-        value: null,
-        variationIndex: null,
-        reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
-      });
-    },
-  );
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'returns error if rule variation is too high',
+      async (userToTest) => {
+        const rule: FlagRule = { id: 'id', clauses: [matchClause], variation: 99 };
+        const flag = makeFlagWithRules([rule]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.isError).toBeTruthy();
+        expect(res.message).toEqual('Invalid variation index in flag');
+        expect(res.detail).toMatchObject({
+          value: null,
+          variationIndex: null,
+          reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
+        });
+      },
+    );
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'returns error if rule variation is negative',
-    async (userToTest) => {
-      const rule: FlagRule = { id: 'id', clauses: [matchClause], variation: -1 };
-      const flag = makeFlagWithRules([rule]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.isError).toBeTruthy();
-      expect(res.message).toEqual('Invalid variation index in flag');
-      expect(res.detail).toMatchObject({
-        value: null,
-        variationIndex: null,
-        reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
-      });
-    },
-  );
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'returns error if rule variation is negative',
+      async (userToTest) => {
+        const rule: FlagRule = { id: 'id', clauses: [matchClause], variation: -1 };
+        const flag = makeFlagWithRules([rule]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.isError).toBeTruthy();
+        expect(res.message).toEqual('Invalid variation index in flag');
+        expect(res.detail).toMatchObject({
+          value: null,
+          variationIndex: null,
+          reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
+        });
+      },
+    );
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'returns error if rule has no variation or rollout',
-    async (userToTest) => {
-      const rule: FlagRule = { id: 'id', clauses: [matchClause] };
-      const flag = makeFlagWithRules([rule]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.isError).toBeTruthy();
-      expect(res.message).toEqual('Variation/rollout object with no variation or rollout');
-      expect(res.detail).toMatchObject({
-        value: null,
-        variationIndex: null,
-        reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
-      });
-    },
-  );
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'returns error if rule has no variation or rollout',
+      async (userToTest) => {
+        const rule: FlagRule = { id: 'id', clauses: [matchClause] };
+        const flag = makeFlagWithRules([rule]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.isError).toBeTruthy();
+        expect(res.message).toEqual('Variation/rollout object with no variation or rollout');
+        expect(res.detail).toMatchObject({
+          value: null,
+          variationIndex: null,
+          reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
+        });
+      },
+    );
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'returns error if rule has rollout with no variations',
-    async (userToTest) => {
-      const rule: FlagRule = { id: 'id', clauses: [matchClause], rollout: { variations: [] } };
-      const flag = makeFlagWithRules([rule]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.isError).toBeTruthy();
-      expect(res.message).toEqual('Variation/rollout object with no variation or rollout');
-      expect(res.detail).toMatchObject({
-        value: null,
-        variationIndex: null,
-        reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
-      });
-    },
-  );
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'returns error if rule has rollout with no variations',
+      async (userToTest) => {
+        const rule: FlagRule = { id: 'id', clauses: [matchClause], rollout: { variations: [] } };
+        const flag = makeFlagWithRules([rule]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.isError).toBeTruthy();
+        expect(res.message).toEqual('Variation/rollout object with no variation or rollout');
+        expect(res.detail).toMatchObject({
+          value: null,
+          variationIndex: null,
+          reason: { kind: 'ERROR', errorKind: 'MALFORMED_FLAG' },
+        });
+      },
+    );
 
-  it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
-    'does not overflow the call stack when evaluating a huge number of rules',
-    async (userToTest) => {
-      const ruleCount = 5000;
-      const flag: Flag = {
-        key: 'flag',
-        targets: [],
-        on: true,
-        variations: [false, true],
-        fallthrough: { variation: 0 },
-        version: 1,
-      };
-      // Note, for this test to be meaningful, the rules must *not* match the user, since we
-      // stop evaluating rules on the first match.
-      const rules: FlagRule[] = [];
-      for (let i = 0; i < ruleCount; i += 1) {
-        rules.push({ id: '1234', clauses: [noMatchClause], variation: 1 });
-      }
-      flag.rules = rules;
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
-      expect(res.isError).toBeFalsy();
-      expect(res.detail.value).toEqual(false);
-    },
-  );
-});
+    it.each<LDContext>([basicUser, basicSingleKindUser, basicMultiKindUser])(
+      'does not overflow the call stack when evaluating a huge number of rules',
+      async (userToTest) => {
+        const ruleCount = 5000;
+        const flag: Flag = {
+          key: 'flag',
+          targets: [],
+          on: true,
+          variations: [false, true],
+          fallthrough: { variation: 0 },
+          version: 1,
+        };
+        // Note, for this test to be meaningful, the rules must *not* match the user, since we
+        // stop evaluating rules on the first match.
+        const rules: FlagRule[] = [];
+        for (let i = 0; i < ruleCount; i += 1) {
+          rules.push({ id: '1234', clauses: [noMatchClause], variation: 1 });
+        }
+        flag.rules = rules;
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(userToTest));
+        expect(res.isError).toBeFalsy();
+        expect(res.detail.value).toEqual(false);
+      },
+    );
+  });
 
-describe('when evaluating non-user contexts', () => {
-  const targetKey = 'targetKey';
-  const targetContextKind = 'org';
-  const matchClause: Clause = {
-    attribute: 'key',
-    op: 'in',
-    values: [targetKey],
-    contextKind: targetContextKind,
-    attributeReference: new AttributeReference('key'),
-  };
-  const noMatchClause: Clause = {
-    attribute: 'key',
-    op: 'in',
-    values: [`not-${targetKey}`],
-    contextKind: targetContextKind,
-    attributeReference: new AttributeReference('key'),
-  };
+  describe('when evaluating non-user contexts', () => {
+    const targetKey = 'targetKey';
+    const targetContextKind = 'org';
+    const matchClause: Clause = {
+      attribute: 'key',
+      op: 'in',
+      values: [targetKey],
+      contextKind: targetContextKind,
+      attributeReference: new AttributeReference('key'),
+    };
+    const noMatchClause: Clause = {
+      attribute: 'key',
+      op: 'in',
+      values: [`not-${targetKey}`],
+      contextKind: targetContextKind,
+      attributeReference: new AttributeReference('key'),
+    };
 
-  const singleKindContext: LDContext = {
-    kind: targetContextKind,
-    key: targetKey,
-  };
-  const multiKindContext: LDContext = {
-    kind: 'multi',
-  };
-  multiKindContext[targetContextKind] = {
-    key: targetKey,
-  };
+    const singleKindContext: LDContext = {
+      kind: targetContextKind,
+      key: targetKey,
+    };
+    const multiKindContext: LDContext = {
+      kind: 'multi',
+    };
+    multiKindContext[targetContextKind] = {
+      key: targetKey,
+    };
 
-  it.each([singleKindContext, multiKindContext])(
-    'matches user from rules',
-    async (contextToTest) => {
-      const rule0: FlagRule = { id: 'id0', clauses: [noMatchClause], variation: 1 };
-      const rule1: FlagRule = { id: 'id1', clauses: [matchClause], variation: 2 };
-      const flag = makeFlagWithRules([rule0, rule1]);
-      const res = await evaluator.evaluate(flag, Context.fromLDContext(contextToTest));
-      expect(res.detail).toMatchObject({
-        value: 'c',
-        variationIndex: 2,
-        reason: { kind: 'RULE_MATCH', ruleIndex: 1, ruleId: 'id1' },
-      });
-    },
-  );
+    it.each([singleKindContext, multiKindContext])(
+      'matches user from rules',
+      async (contextToTest) => {
+        const rule0: FlagRule = { id: 'id0', clauses: [noMatchClause], variation: 1 };
+        const rule1: FlagRule = { id: 'id1', clauses: [matchClause], variation: 2 };
+        const flag = makeFlagWithRules([rule0, rule1]);
+        const res = await evaluator.evaluate(flag, Context.fromLDContext(contextToTest));
+        expect(res.detail).toMatchObject({
+          value: 'c',
+          variationIndex: 2,
+          reason: { kind: 'RULE_MATCH', ruleIndex: 1, ruleId: 'id1' },
+        });
+      },
+    );
+  });
 });

--- a/packages/shared/sdk-server/__tests__/evaluation/Evaluator.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Evaluator.test.ts
@@ -15,139 +15,143 @@ const offBaseFlag = {
   variations: ['zero', 'one', 'two'],
 };
 
-describe.each<[Flag, LDContext, EvalResult | undefined]>([
-  [
-    {
-      ...offBaseFlag,
-    },
-    { key: 'user-key' },
-    EvalResult.forSuccess(null, Reasons.Off, undefined),
-  ],
-  [
-    {
-      ...offBaseFlag,
-      offVariation: 2,
-    },
-    { key: 'user-key' },
-    EvalResult.forSuccess('two', Reasons.Off, 2),
-  ],
-])('Given off flags and an evaluator', (flag, context, expected) => {
-  const evaluator = new Evaluator(mocks.basicPlatform, noQueries);
-
-  it(`produces the expected evaluation result for context: ${context.key} ${
-    // @ts-ignore
-    context.kind
-  } targets: ${flag.targets?.map(
-    (t) => `${t.values}, ${t.variation}`,
-  )} context targets: ${flag.contextTargets?.map(
-    (t) => `${t.contextKind}: ${t.values}, ${t.variation}`,
-  )}`, async () => {
-    const result = await evaluator.evaluate(flag, Context.fromLDContext(context));
-    expect(result?.isError).toEqual(expected?.isError);
-    expect(result?.detail).toStrictEqual(expected?.detail);
-    expect(result?.message).toEqual(expected?.message);
+describe('Evaluator.test', () => {
+  let evaluator: Evaluator;
+  beforeEach(() => {
+    evaluator = new Evaluator(mocks.basicPlatform, noQueries);
   });
-});
 
-const targetBaseFlag = {
-  key: 'feature0',
-  version: 1,
-  on: true,
-  fallthrough: { variation: 1 },
-  variations: ['zero', 'one', 'two'],
-};
+  describe.each<[Flag, LDContext, EvalResult | undefined]>([
+    [
+      {
+        ...offBaseFlag,
+      },
+      { key: 'user-key' },
+      EvalResult.forSuccess(null, Reasons.Off, undefined),
+    ],
+    [
+      {
+        ...offBaseFlag,
+        offVariation: 2,
+      },
+      { key: 'user-key' },
+      EvalResult.forSuccess('two', Reasons.Off, 2),
+    ],
+  ])('Given off flags and an evaluator', (flag, context, expected) => {
+    it(`produces the expected evaluation result for context: ${context.key} ${
+      // @ts-ignore
+      context.kind
+    } targets: ${flag.targets?.map(
+      (t) => `${t.values}, ${t.variation}`,
+    )} context targets: ${flag.contextTargets?.map(
+      (t) => `${t.contextKind}: ${t.values}, ${t.variation}`,
+    )}`, async () => {
+      const result = await evaluator.evaluate(flag, Context.fromLDContext(context));
+      expect(result?.isError).toEqual(expected?.isError);
+      expect(result?.detail).toStrictEqual(expected?.detail);
+      expect(result?.message).toEqual(expected?.message);
+    });
+  });
 
-describe.each<[Flag, LDContext, EvalResult | undefined]>([
-  [
-    {
-      ...targetBaseFlag,
-      targets: [
-        {
-          values: ['user-key'],
-          variation: 0,
-        },
-      ],
-    },
-    { key: 'user-key' },
-    EvalResult.forSuccess('zero', Reasons.TargetMatch, 0),
-  ],
-  [
-    {
-      ...targetBaseFlag,
-      targets: [
-        {
-          values: ['user-key'],
-          variation: 0,
-        },
-        {
-          values: ['user-key2'],
-          variation: 2,
-        },
-      ],
-    },
-    { key: 'user-key2' },
-    EvalResult.forSuccess('two', Reasons.TargetMatch, 2),
-  ],
-  [
-    {
-      ...targetBaseFlag,
-      targets: [
-        {
-          values: ['user-key'],
-          variation: 0,
-        },
-        {
-          values: ['user-key2'],
-          variation: 2,
-        },
-      ],
-      contextTargets: [
-        {
-          values: [],
-          variation: 2,
-        },
-      ],
-    },
-    { key: 'user-key2' },
-    EvalResult.forSuccess('two', Reasons.TargetMatch, 2),
-  ],
-  [
-    {
-      ...targetBaseFlag,
-      targets: [
-        {
-          values: ['user-key'],
-          variation: 0,
-        },
-        {
-          values: ['user-key2'],
-          variation: 2,
-        },
-      ],
-      contextTargets: [
-        {
-          contextKind: 'org',
-          values: ['org-key'],
-          variation: 1,
-        },
-      ],
-    },
-    { kind: 'org', key: 'org-key' },
-    EvalResult.forSuccess('one', Reasons.TargetMatch, 1),
-  ],
-])('given flag configurations with different targets that match', (flag, context, expected) => {
-  const evaluator = new Evaluator(mocks.basicPlatform, noQueries);
-  it(`produces the expected evaluation result for context: ${context.key} ${
-    // @ts-ignore
-    context.kind
-  } targets: ${flag.targets?.map(
-    (t) => `${t.values}, ${t.variation}`,
-  )} context targets: ${flag.contextTargets?.map(
-    (t) => `${t.contextKind}: ${t.values}, ${t.variation}`,
-  )}`, async () => {
-    const result = await evaluator.evaluate(flag, Context.fromLDContext(context));
-    expect(result?.isError).toEqual(expected?.isError);
-    expect(result?.detail).toStrictEqual(expected?.detail);
-    expect(result?.message).toEqual(expected?.message);
+  const targetBaseFlag = {
+    key: 'feature0',
+    version: 1,
+    on: true,
+    fallthrough: { variation: 1 },
+    variations: ['zero', 'one', 'two'],
+  };
+
+  describe.each<[Flag, LDContext, EvalResult | undefined]>([
+    [
+      {
+        ...targetBaseFlag,
+        targets: [
+          {
+            values: ['user-key'],
+            variation: 0,
+          },
+        ],
+      },
+      { key: 'user-key' },
+      EvalResult.forSuccess('zero', Reasons.TargetMatch, 0),
+    ],
+    [
+      {
+        ...targetBaseFlag,
+        targets: [
+          {
+            values: ['user-key'],
+            variation: 0,
+          },
+          {
+            values: ['user-key2'],
+            variation: 2,
+          },
+        ],
+      },
+      { key: 'user-key2' },
+      EvalResult.forSuccess('two', Reasons.TargetMatch, 2),
+    ],
+    [
+      {
+        ...targetBaseFlag,
+        targets: [
+          {
+            values: ['user-key'],
+            variation: 0,
+          },
+          {
+            values: ['user-key2'],
+            variation: 2,
+          },
+        ],
+        contextTargets: [
+          {
+            values: [],
+            variation: 2,
+          },
+        ],
+      },
+      { key: 'user-key2' },
+      EvalResult.forSuccess('two', Reasons.TargetMatch, 2),
+    ],
+    [
+      {
+        ...targetBaseFlag,
+        targets: [
+          {
+            values: ['user-key'],
+            variation: 0,
+          },
+          {
+            values: ['user-key2'],
+            variation: 2,
+          },
+        ],
+        contextTargets: [
+          {
+            contextKind: 'org',
+            values: ['org-key'],
+            variation: 1,
+          },
+        ],
+      },
+      { kind: 'org', key: 'org-key' },
+      EvalResult.forSuccess('one', Reasons.TargetMatch, 1),
+    ],
+  ])('given flag configurations with different targets that match', (flag, context, expected) => {
+    it(`produces the expected evaluation result for context: ${context.key} ${
+      // @ts-ignore
+      context.kind
+    } targets: ${flag.targets?.map(
+      (t) => `${t.values}, ${t.variation}`,
+    )} context targets: ${flag.contextTargets?.map(
+      (t) => `${t.contextKind}: ${t.values}, ${t.variation}`,
+    )}`, async () => {
+      const result = await evaluator.evaluate(flag, Context.fromLDContext(context));
+      expect(result?.isError).toEqual(expected?.isError);
+      expect(result?.detail).toStrictEqual(expected?.detail);
+      expect(result?.message).toEqual(expected?.message);
+    });
   });
 });

--- a/packages/shared/sdk-server/jest.config.js
+++ b/packages/shared/sdk-server/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverageFrom: ['src/**/*.ts'],
+  setupFilesAfterEnv: ['@launchdarkly/private-js-mocks/setup'],
 };


### PR DESCRIPTION
This is a follow up to #355. This PR implements client-sdk support for auto env. In addition, the mocks internal api have been updated to work better with crypto and mock resets. Server sdks are impacted by the mocks api changes so these are fixed in this PR as well.