### PR TITLE
fix: Add RN SDK offline support through ConnectionMode.

### DIFF
--- a/packages/sdk/react-native/example/e2e/starter.test.ts
+++ b/packages/sdk/react-native/example/e2e/starter.test.ts
@@ -31,7 +31,6 @@ describe('Example', () => {
 
   test('variation', async () => {
     await element(by.id('flagKey')).replaceText('my-boolean-flag-2');
-    await element(by.text(/get flag value/i)).tap();
 
     await waitFor(element(by.text(/my-boolean-flag-2: true/i)))
       .toBeVisible()

--- a/packages/sdk/react-native/example/src/welcome.tsx
+++ b/packages/sdk/react-native/example/src/welcome.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
+import { ConnectionMode } from '@launchdarkly/js-client-sdk-common';
 import { useBoolVariation, useLDClient } from '@launchdarkly/react-native-client-sdk';
 
 export default function Welcome() {
@@ -13,6 +14,10 @@ export default function Welcome() {
     ldc
       .identify({ kind: 'user', key: userKey })
       .catch((e: any) => console.error(`error identifying ${userKey}: ${e}`));
+  };
+
+  const setConnectionMode = (m: ConnectionMode) => {
+    ldc.setConnectionMode(m);
   };
 
   return (
@@ -40,8 +45,14 @@ export default function Welcome() {
         value={flagKey}
         testID="flagKey"
       />
-      <TouchableOpacity style={styles.buttonContainer}>
-        <Text style={styles.buttonText}>get flag value</Text>
+      <TouchableOpacity style={styles.buttonContainer} onPress={() => setConnectionMode('offline')}>
+        <Text style={styles.buttonText}>Set offline</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.buttonContainer}
+        onPress={() => setConnectionMode('streaming')}
+      >
+        <Text style={styles.buttonText}>Set online</Text>
       </TouchableOpacity>
     </View>
   );

--- a/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
+++ b/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
@@ -686,10 +686,11 @@ describe('given an event processor', () => {
     eventProcessor.sendEvent(new InputIdentifyEvent(Context.fromLDContext(user)));
     await jest.advanceTimersByTimeAsync(eventProcessorConfig.flushInterval * 1000);
 
-    expect(mockConsole).toBeCalledTimes(2);
-    expect(mockConsole).toHaveBeenNthCalledWith(1, 'debug: [LaunchDarkly] Flushing 1 events');
+    expect(mockConsole).toHaveBeenCalledTimes(3);
+    expect(mockConsole).toHaveBeenNthCalledWith(1, 'debug: [LaunchDarkly] Started EventProcessor.');
+    expect(mockConsole).toHaveBeenNthCalledWith(2, 'debug: [LaunchDarkly] Flushing 1 events');
     expect(mockConsole).toHaveBeenNthCalledWith(
-      2,
+      3,
       'debug: [LaunchDarkly] Flush failed: Error: some error',
     );
   });

--- a/packages/shared/common/src/internal/events/EventProcessor.ts
+++ b/packages/shared/common/src/internal/events/EventProcessor.ts
@@ -108,6 +108,7 @@ export default class EventProcessor implements LDEventProcessor {
     clientContext: ClientContext,
     private readonly contextDeduplicator?: LDContextDeduplicator,
     private readonly diagnosticsManager?: DiagnosticsManager,
+    start: boolean = true,
   ) {
     this.capacity = config.eventsCapacity;
     this.logger = clientContext.basicConfiguration.logger;
@@ -118,7 +119,9 @@ export default class EventProcessor implements LDEventProcessor {
       config.privateAttributes.map((ref) => new AttributeReference(ref)),
     );
 
-    this.start();
+    if (start) {
+      this.start();
+    }
   }
 
   start() {
@@ -154,6 +157,8 @@ export default class EventProcessor implements LDEventProcessor {
         this.postDiagnosticEvent(statsEvent);
       }, this.config.diagnosticRecordingInterval * 1000);
     }
+
+    this.logger?.debug('Started EventProcessor.');
   }
 
   private postDiagnosticEvent(event: DiagnosticEvent) {

--- a/packages/shared/common/src/internal/events/EventProcessor.ts
+++ b/packages/shared/common/src/internal/events/EventProcessor.ts
@@ -104,7 +104,7 @@ export default class EventProcessor implements LDEventProcessor {
   private flushUsersTimer: any = null;
 
   constructor(
-    config: EventProcessorOptions,
+    private readonly config: EventProcessorOptions,
     clientContext: ClientContext,
     private readonly contextDeduplicator?: LDContextDeduplicator,
     private readonly diagnosticsManager?: DiagnosticsManager,
@@ -118,6 +118,10 @@ export default class EventProcessor implements LDEventProcessor {
       config.privateAttributes.map((ref) => new AttributeReference(ref)),
     );
 
+    this.start();
+  }
+
+  start() {
     if (this.contextDeduplicator?.flushInterval !== undefined) {
       this.flushUsersTimer = setInterval(() => {
         this.contextDeduplicator?.flush();
@@ -131,10 +135,10 @@ export default class EventProcessor implements LDEventProcessor {
         // Log errors and swallow them
         this.logger?.debug(`Flush failed: ${e}`);
       }
-    }, config.flushInterval * 1000);
+    }, this.config.flushInterval * 1000);
 
     if (this.diagnosticsManager) {
-      const initEvent = diagnosticsManager!.createInitEvent();
+      const initEvent = this.diagnosticsManager!.createInitEvent();
       this.postDiagnosticEvent(initEvent);
 
       this.diagnosticsTimer = setInterval(() => {
@@ -148,7 +152,7 @@ export default class EventProcessor implements LDEventProcessor {
         this.deduplicatedUsers = 0;
 
         this.postDiagnosticEvent(statsEvent);
-      }, config.diagnosticRecordingInterval * 1000);
+      }, this.config.diagnosticRecordingInterval * 1000);
     }
   }
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -14,11 +14,10 @@ import {
   Platform,
   ProcessStreamResponse,
   EventName as StreamEventName,
-  subsystem,
   TypeValidators,
 } from '@launchdarkly/js-sdk-common';
 
-import { LDClient, type LDOptions } from './api';
+import { ConnectionMode, LDClient, type LDOptions } from './api';
 import LDEmitter, { EventName } from './api/LDEmitter';
 import Configuration from './configuration';
 import createDiagnosticsManager from './diagnostics/createDiagnosticsManager';
@@ -34,9 +33,9 @@ export default class LDClientImpl implements LDClient {
   config: Configuration;
   context?: LDContext;
   diagnosticsManager?: internal.DiagnosticsManager;
-  eventProcessor: subsystem.LDEventProcessor;
-  streamer?: internal.StreamingProcessor;
+  eventProcessor?: internal.EventProcessor;
   logger: LDLogger;
+  streamer?: internal.StreamingProcessor;
 
   private eventFactoryDefault = new EventFactory(false);
   private eventFactoryWithReasons = new EventFactory(true);
@@ -68,14 +67,51 @@ export default class LDClientImpl implements LDClient {
     this.config = new Configuration(options, internalOptions);
     this.clientContext = new ClientContext(sdkKey, this.config, platform);
     this.logger = this.config.logger;
-    this.diagnosticsManager = createDiagnosticsManager(sdkKey, this.config, platform);
+    this.emitter = new LDEmitter();
+
+    this.initEventProcessor();
+  }
+
+  initEventProcessor() {
+    this.diagnosticsManager = createDiagnosticsManager(this.sdkKey, this.config, this.platform);
     this.eventProcessor = createEventProcessor(
-      sdkKey,
+      this.sdkKey,
       this.config,
-      platform,
+      this.platform,
       this.diagnosticsManager,
     );
-    this.emitter = new LDEmitter();
+  }
+
+  async setConnectionMode(mode: ConnectionMode): Promise<void> {
+    this.config.connectionMode = mode;
+
+    switch (mode) {
+      case 'offline':
+        // flush, close streamer & eventProcessor
+        return this.close();
+      case 'streaming':
+        if (!this.eventProcessor) {
+          this.initEventProcessor();
+        }
+        this.eventProcessor?.start();
+
+        // start streamer by calling identify
+        if (this.context) {
+          return this.identify(this.context);
+        }
+        break;
+      default:
+        this.logger.warn(
+          `Unknown ConnectionMode: ${mode}. Only 'offline' and 'streaming' are supported.`,
+        );
+        break;
+    }
+
+    return Promise.resolve();
+  }
+
+  isOffline() {
+    return this.config.connectionMode === 'offline';
   }
 
   allFlags(): LDFlagSet {
@@ -90,13 +126,13 @@ export default class LDClientImpl implements LDClient {
 
   async close(): Promise<void> {
     await this.flush();
-    this.eventProcessor.close();
+    this.eventProcessor?.close();
     this.streamer?.close();
   }
 
   async flush(): Promise<{ error?: Error; result: boolean }> {
     try {
-      await this.eventProcessor.flush();
+      await this.eventProcessor?.flush();
     } catch (e) {
       return { error: e as Error, result: false };
     }
@@ -262,19 +298,25 @@ export default class LDClientImpl implements LDClient {
       this.emitter.emit('change', context, changedKeys);
     }
 
-    this.streamer?.close();
-    this.streamer = new internal.StreamingProcessor(
-      this.sdkKey,
-      this.clientContext,
-      this.createStreamUriPath(context),
-      this.createStreamListeners(context, checkedContext.canonicalKey, identifyResolve),
-      this.diagnosticsManager,
-      (e) => {
-        this.logger.error(e);
-        this.emitter.emit('error', context, e);
-      },
-    );
-    this.streamer.start();
+    if (this.isOffline()) {
+      this.context = context;
+      this.flags = {};
+      identifyResolve();
+    } else {
+      this.streamer?.close();
+      this.streamer = new internal.StreamingProcessor(
+        this.sdkKey,
+        this.clientContext,
+        this.createStreamUriPath(context),
+        this.createStreamListeners(context, checkedContext.canonicalKey, identifyResolve),
+        this.diagnosticsManager,
+        (e) => {
+          this.logger.error(e);
+          this.emitter.emit('error', context, e);
+        },
+      );
+      this.streamer.start();
+    }
 
     return identifyPromise;
   }
@@ -298,7 +340,7 @@ export default class LDClientImpl implements LDClient {
       return;
     }
 
-    this.eventProcessor.sendEvent(
+    this.eventProcessor?.sendEvent(
       this.eventFactoryDefault.customEvent(key, checkedContext!, data, metricValue),
     );
   }
@@ -316,6 +358,18 @@ export default class LDClientImpl implements LDClient {
       return createErrorEvaluationDetail(ErrorKinds.UserNotSpecified, defaultValue);
     }
 
+    // TODO: Double check if we need to record diagnostics here
+    if (this.isOffline()) {
+      this.logger?.debug(
+        `Offline variation for "${flagKey}"; returning default value ${defaultValue}`,
+      );
+      return {
+        value: defaultValue,
+        variationIndex: null,
+        reason: null,
+      };
+    }
+
     const evalContext = Context.fromLDContext(this.context);
     const found = this.flags[flagKey];
 
@@ -326,7 +380,7 @@ export default class LDClientImpl implements LDClient {
       );
       this.logger.error(error);
       this.emitter.emit('error', this.context, error);
-      this.eventProcessor.sendEvent(
+      this.eventProcessor?.sendEvent(
         this.eventFactoryDefault.unknownFlagEvent(flagKey, defVal, evalContext),
       );
       return createErrorEvaluationDetail(ErrorKinds.FlagNotFound, defaultValue);
@@ -337,7 +391,7 @@ export default class LDClientImpl implements LDClient {
     if (typeChecker) {
       const [matched, type] = typeChecker(value);
       if (!matched) {
-        this.eventProcessor.sendEvent(
+        this.eventProcessor?.sendEvent(
           eventFactory.evalEventClient(
             flagKey,
             defaultValue, // track default value on type errors
@@ -361,7 +415,7 @@ export default class LDClientImpl implements LDClient {
       this.logger.debug('Result value is null in variation');
       successDetail.value = defaultValue;
     }
-    this.eventProcessor.sendEvent(
+    this.eventProcessor?.sendEvent(
       eventFactory.evalEventClient(flagKey, value, defaultValue, found, evalContext, reason),
     );
     return successDetail;

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -67,15 +67,15 @@ export default class LDClientImpl implements LDClient {
     this.config = new Configuration(options, internalOptions);
     this.clientContext = new ClientContext(sdkKey, this.config, platform);
     this.logger = this.config.logger;
-    this.emitter = new LDEmitter();
-    this.diagnosticsManager = createDiagnosticsManager(this.sdkKey, this.config, this.platform);
+    this.diagnosticsManager = createDiagnosticsManager(sdkKey, this.config, platform);
     this.eventProcessor = createEventProcessor(
-      this.sdkKey,
+      sdkKey,
       this.config,
-      this.platform,
+      platform,
       this.diagnosticsManager,
       !this.isOffline(),
     );
+    this.emitter = new LDEmitter();
   }
 
   async setConnectionMode(mode: ConnectionMode): Promise<void> {

--- a/packages/shared/sdk-client/src/api/ConnectionMode.ts
+++ b/packages/shared/sdk-client/src/api/ConnectionMode.ts
@@ -1,0 +1,15 @@
+/**
+ * The connection mode for the SDK to use.
+ *
+ * @remarks
+ *
+ * The following connection modes are supported:
+ *
+ * offline - When the SDK is set offline it will stop receiving updates and will stop sending
+ * analytic and diagnostic events.
+ *
+ * streaming - The SDK will use a streaming connection to receive updates from LaunchDarkly.
+ */
+type ConnectionMode = 'offline' | 'streaming';
+
+export default ConnectionMode;

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -7,6 +7,8 @@ import {
   LDLogger,
 } from '@launchdarkly/js-sdk-common';
 
+import ConnectionMode from './ConnectionMode';
+
 /**
  * The basic interface for the LaunchDarkly client. Platform-specific SDKs may add some methods of their own.
  *
@@ -212,6 +214,13 @@ export interface LDClient {
    *   receive parameters, depending on the type of event.
    */
   on(key: string, callback: (...args: any[]) => void): void;
+
+  /**
+   * Sets the SDK connection mode.
+   *
+   * @param mode - One of supported {@link ConnectionMode}. By default, the SDK uses 'streaming'.
+   */
+  setConnectionMode(mode: ConnectionMode): void;
 
   /**
    * Determines the string variation of a feature flag.

--- a/packages/shared/sdk-client/src/api/LDOptions.ts
+++ b/packages/shared/sdk-client/src/api/LDOptions.ts
@@ -1,5 +1,6 @@
 import type { LDFlagSet, LDLogger } from '@launchdarkly/js-sdk-common';
 
+import ConnectionMode from './ConnectionMode';
 import type { LDInspection } from './LDInspection';
 
 export interface LDOptions {
@@ -59,17 +60,11 @@ export interface LDOptions {
   baseUri?: string;
 
   /**
+   * TODO: bootstrap
    * The initial set of flags to use until the remote set is retrieved.
-   *
-   * If `"localStorage"` is specified, the flags will be saved and retrieved from browser local
-   * storage. Alternatively, an {@link LDFlagSet} can be specified which will be used as the initial
-   * source of flag values. In the latter case, the flag values will be available via {@link LDClient.variation}
-   * immediately after calling `initialize()` (normally they would not be available until the
-   * client signals that it is ready).
-   *
-   * For more information, see the [SDK Reference Guide](https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript).
+   * @alpha
    */
-  bootstrap?: 'localStorage' | LDFlagSet;
+  bootstrap?: LDFlagSet;
 
   /**
    * The capacity of the analytics events queue.
@@ -119,15 +114,23 @@ export interface LDOptions {
   flushInterval?: number;
 
   /**
+   * TODO: secure mode
    * The signed context key for Secure Mode.
-   *
-   * For more information, see the JavaScript SDK Reference Guide on
-   * [Secure mode](https://docs.launchdarkly.com/sdk/features/secure-mode#configuring-secure-mode-in-the-javascript-client-side-sdk).
+   * @alpha
    */
   hash?: string;
 
   /**
+   * Sets the mode to use for connections when the SDK is initialized.
+   *
+   * Defaults to streaming.
+   */
+  initialConnectionMode?: ConnectionMode;
+
+  /**
+   * TODO: inspectors
    * Inspectors can be used for collecting information for monitoring, analytics, and debugging.
+   * @alpha
    */
   inspectors?: LDInspection[];
 

--- a/packages/shared/sdk-client/src/api/index.ts
+++ b/packages/shared/sdk-client/src/api/index.ts
@@ -1,2 +1,6 @@
+import ConnectionMode from './ConnectionMode';
+
 export * from './LDOptions';
 export * from './LDClient';
+
+export { ConnectionMode };

--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -85,7 +85,7 @@ describe('Configuration', () => {
     expect(config.bootstrap).toBeUndefined();
     expect(console.error).toHaveBeenNthCalledWith(
       1,
-      expect.stringContaining(`should be of type 'localStorage' | LDFlagSet, got string`),
+      expect.stringMatching(/should be of type LDFlagSet, got string/i),
     );
   });
 });

--- a/packages/shared/sdk-client/src/configuration/Configuration.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.ts
@@ -9,7 +9,7 @@ import {
   TypeValidators,
 } from '@launchdarkly/js-sdk-common';
 
-import { type LDOptions } from '../api';
+import { ConnectionMode, type LDOptions } from '../api';
 import { LDInspection } from '../api/LDInspection';
 import validators from './validators';
 
@@ -30,13 +30,17 @@ export default class Configuration {
 
   public readonly allAttributesPrivate = false;
   public readonly diagnosticOptOut = false;
-  public readonly withReasons = false;
   public readonly sendEvents = true;
   public readonly sendLDHeaders = true;
+
   public readonly useReport = false;
+  public readonly withReasons = false;
 
   public readonly inspectors: LDInspection[] = [];
   public readonly privateAttributes: string[] = [];
+
+  public readonly initialConnectionMode: ConnectionMode = 'streaming';
+  public connectionMode: ConnectionMode;
 
   public readonly tags: ApplicationTags;
   public readonly applicationInfo?: {
@@ -45,7 +49,7 @@ export default class Configuration {
     name?: string;
     versionName?: string;
   };
-  public readonly bootstrap?: 'localStorage' | LDFlagSet;
+  public readonly bootstrap?: LDFlagSet;
 
   // TODO: implement requestHeaderTransform
   public readonly requestHeaderTransform?: (headers: Map<string, string>) => Map<string, string>;
@@ -72,6 +76,7 @@ export default class Configuration {
       internalOptions.includeAuthorizationHeader,
     );
     this.tags = new ApplicationTags({ application: this.applicationInfo, logger: this.logger });
+    this.connectionMode = this.initialConnectionMode;
   }
 
   validateTypesAndNames(pristineOptions: LDOptions): string[] {

--- a/packages/shared/sdk-client/src/configuration/validators.ts
+++ b/packages/shared/sdk-client/src/configuration/validators.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-classes-per-file
 import { noop, TypeValidator, TypeValidators } from '@launchdarkly/js-sdk-common';
 
 import { type LDOptions } from '../api';
@@ -5,15 +6,26 @@ import { LDInspection } from '../api/LDInspection';
 
 class BootStrapValidator implements TypeValidator {
   is(u: unknown): boolean {
-    return u === 'localStorage' || typeof u === 'object' || typeof u === 'undefined' || u === null;
+    return typeof u === 'object' || typeof u === 'undefined' || u === null;
   }
 
   getType(): string {
-    return `'localStorage' | LDFlagSet`;
+    return `LDFlagSet`;
+  }
+}
+
+class ConnectionModeValidator implements TypeValidator {
+  is(u: unknown): boolean {
+    return u === 'offline' || u === 'streaming';
+  }
+
+  getType(): string {
+    return `'offline' | streaming`;
   }
 }
 
 const validators: Record<keyof LDOptions, TypeValidator> = {
+  initialConnectionMode: new ConnectionModeValidator(),
   logger: TypeValidators.Object,
 
   baseUri: TypeValidators.String,

--- a/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.test.ts
+++ b/packages/shared/sdk-client/src/diagnostics/createDiagnosticsInitConfig.test.ts
@@ -39,7 +39,7 @@ describe('createDiagnosticsInitConfig', () => {
         diagnosticRecordingInterval: 4,
         allAttributesPrivate: true,
         hash: 'test-hash',
-        bootstrap: 'localStorage',
+        bootstrap: { testFlag: true },
       }),
     );
     expect(custom).toEqual({

--- a/packages/shared/sdk-client/src/diagnostics/createDiagnosticsManager.ts
+++ b/packages/shared/sdk-client/src/diagnostics/createDiagnosticsManager.ts
@@ -8,7 +8,7 @@ const createDiagnosticsManager = (
   config: Configuration,
   platform: Platform,
 ) => {
-  if (config.sendEvents && !config.diagnosticOptOut) {
+  if (config.sendEvents && config.connectionMode !== 'offline' && !config.diagnosticOptOut) {
     return new internal.DiagnosticsManager(
       clientSideID,
       platform,

--- a/packages/shared/sdk-client/src/diagnostics/createDiagnosticsManager.ts
+++ b/packages/shared/sdk-client/src/diagnostics/createDiagnosticsManager.ts
@@ -8,7 +8,7 @@ const createDiagnosticsManager = (
   config: Configuration,
   platform: Platform,
 ) => {
-  if (config.sendEvents && config.connectionMode !== 'offline' && !config.diagnosticOptOut) {
+  if (config.sendEvents && !config.diagnosticOptOut) {
     return new internal.DiagnosticsManager(
       clientSideID,
       platform,

--- a/packages/shared/sdk-client/src/events/createEventProcessor.ts
+++ b/packages/shared/sdk-client/src/events/createEventProcessor.ts
@@ -1,4 +1,5 @@
-import { ClientContext, internal, Platform, subsystem } from '@launchdarkly/js-sdk-common';
+import { ClientContext, internal, Platform } from '@launchdarkly/js-sdk-common';
+import { EventProcessor } from '@launchdarkly/js-sdk-common/dist/internal';
 
 import Configuration from '../configuration';
 
@@ -7,14 +8,14 @@ const createEventProcessor = (
   config: Configuration,
   platform: Platform,
   diagnosticsManager?: internal.DiagnosticsManager,
-): subsystem.LDEventProcessor =>
-  config.sendEvents
+): EventProcessor | undefined =>
+  config.sendEvents && config.connectionMode !== 'offline'
     ? new internal.EventProcessor(
         { ...config, eventsCapacity: config.capacity },
         new ClientContext(clientSideID, config, platform),
         undefined,
         diagnosticsManager,
       )
-    : new internal.NullEventProcessor();
+    : undefined;
 
 export default createEventProcessor;

--- a/packages/shared/sdk-client/src/events/createEventProcessor.ts
+++ b/packages/shared/sdk-client/src/events/createEventProcessor.ts
@@ -8,14 +8,19 @@ const createEventProcessor = (
   config: Configuration,
   platform: Platform,
   diagnosticsManager?: internal.DiagnosticsManager,
-): EventProcessor | undefined =>
-  config.sendEvents && config.connectionMode !== 'offline'
-    ? new internal.EventProcessor(
-        { ...config, eventsCapacity: config.capacity },
-        new ClientContext(clientSideID, config, platform),
-        undefined,
-        diagnosticsManager,
-      )
-    : undefined;
+  start: boolean = false,
+): EventProcessor | undefined => {
+  if (config.sendEvents) {
+    return new internal.EventProcessor(
+      { ...config, eventsCapacity: config.capacity },
+      new ClientContext(clientSideID, config, platform),
+      undefined,
+      diagnosticsManager,
+      start,
+    );
+  }
+
+  return undefined;
+};
 
 export default createEventProcessor;


### PR DESCRIPTION
This adds offline support for the RN SDK through ConnectionMode.

```tsx
  /**
   * Sets the mode to use for connections when the SDK is initialized.
   *
   * Defaults to streaming.
   */
  initialConnectionMode?: ConnectionMode; // in api/LDOptions.ts

  /**
   * Sets the SDK connection mode.
   *
   * @param mode - One of supported {@link ConnectionMode}. By default, the SDK uses 'streaming'.
   */
  setConnectionMode(mode: ConnectionMode): void; // in api/LDClient.ts
```