### PR TITLE
fix: Improvements and fixes from docs review.

### DIFF
--- a/packages/sdk/react-native/example/App.tsx
+++ b/packages/sdk/react-native/example/App.tsx
@@ -8,7 +8,13 @@ import {
 
 import Welcome from './src/welcome';
 
-const featureClient = new ReactNativeLDClient(MOBILE_KEY, AutoEnvAttributes.Enabled);
+const featureClient = new ReactNativeLDClient(MOBILE_KEY, AutoEnvAttributes.Enabled, {
+  debug: true,
+  applicationInfo: {
+    id: 'ld-rn-test-app',
+    version: '0.0.1',
+  },
+});
 
 const App = () => {
   return (

--- a/packages/sdk/react-native/example/tsconfig.json
+++ b/packages/sdk/react-native/example/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "strict": true,
-    "typeRoots": ["./types"]
+    "typeRoots": ["./types"],
   },
-  "exclude": ["e2e"]
+  "exclude": ["e2e"],
 }

--- a/packages/sdk/react-native/src/ReactNativeLDClient.test.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.test.ts
@@ -16,7 +16,7 @@ describe('ReactNativeLDClient', () => {
       diagnosticEventPath: '/mobile/events/diagnostic',
       events: 'https://events.launchdarkly.com',
       includeAuthorizationHeader: true,
-      polling: 'https://sdk.launchdarkly.com',
+      polling: 'https://clientsdk.launchdarkly.com',
       streaming: 'https://clientstream.launchdarkly.com',
     });
   });

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -35,10 +35,11 @@ export default class ReactNativeLDClient extends LDClientImpl {
    * @param options {@link LDOptions} to initialize the client with.
    */
   constructor(sdkKey: string, autoEnvAttributes: AutoEnvAttributes, options: LDOptions = {}) {
+    const { logger: customLogger, debug } = options;
     const logger =
-      options.logger ??
+      customLogger ??
       new BasicLogger({
-        level: 'debug',
+        level: debug ? 'debug' : 'info',
         // eslint-disable-next-line no-console
         destination: console.log,
       });

--- a/packages/sdk/react-native/src/platform/autoEnv.ts
+++ b/packages/sdk/react-native/src/platform/autoEnv.ts
@@ -5,20 +5,22 @@ import type { LDApplication, LDDevice } from '@launchdarkly/js-client-sdk-common
 import locale from './locale';
 
 export const ldApplication: LDApplication = {
-  // key is populated by client common sdk
+  // key is populated by common/client-sdk
   key: '',
   envAttributesVersion: '1.0',
 
-  // TODO: populate application ID, name, version, versionName
+  locale,
+
+  // These are not automatically generated. Use LDOptions.applicationInfo
+  // to specify these values.
   id: '',
   name: '',
   version: '',
   versionName: '',
-  locale,
 };
 
 export const ldDevice: LDDevice = {
-  // key is populated by client common sdk
+  // key is populated by common/client-sdk
   key: '',
   envAttributesVersion: '1.0',
   manufacturer: Platform.select({

--- a/packages/sdk/react-native/src/provider/LDProvider.test.tsx
+++ b/packages/sdk/react-native/src/provider/LDProvider.test.tsx
@@ -23,7 +23,6 @@ const TestApp = () => {
 };
 describe('LDProvider', () => {
   let ldc: ReactNativeLDClient;
-  let context: LDContext;
   const mockSetupListeners = setupListeners as jest.Mock;
 
   beforeEach(() => {
@@ -51,7 +50,6 @@ describe('LDProvider', () => {
       setState({ client });
     });
     ldc = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled);
-    context = { kind: 'user', key: 'test-user-key-1' };
   });
 
   afterEach(() => {
@@ -68,32 +66,5 @@ describe('LDProvider', () => {
     expect(getByText(/ldclient defined/i)).toBeTruthy();
     expect(getByText(/mobilekey mobile-key/i)).toBeTruthy();
     expect(getByText(/context undefined/i)).toBeTruthy();
-  });
-
-  test('specified context is identified', async () => {
-    const { getByText } = render(
-      <LDProvider client={ldc} context={context}>
-        <TestApp />
-      </LDProvider>,
-    );
-
-    expect(mockSetupListeners).toHaveBeenCalledWith(ldc, expect.any(Function));
-    expect(ldc.identify).toHaveBeenCalledWith(context);
-    expect(ldc.getContext()).toEqual(context);
-    expect(getByText(/context defined/i)).toBeTruthy();
-  });
-
-  test('identify errors are caught', async () => {
-    (ldc.identify as jest.Mock).mockImplementation(() =>
-      Promise.reject(new Error('faking error when identifying')),
-    );
-    render(
-      <LDProvider client={ldc} context={context}>
-        <TestApp />
-      </LDProvider>,
-    );
-    await jest.runAllTimersAsync();
-
-    expect(ldc.logger.debug).toHaveBeenCalledWith(expect.stringMatching(/identify error/));
   });
 });

--- a/packages/sdk/react-native/src/provider/LDProvider.tsx
+++ b/packages/sdk/react-native/src/provider/LDProvider.tsx
@@ -1,7 +1,5 @@
 import React, { PropsWithChildren, useEffect, useState } from 'react';
 
-import { type LDContext } from '@launchdarkly/js-client-sdk-common';
-
 import ReactNativeLDClient from '../ReactNativeLDClient';
 import { Provider, ReactContext } from './reactContext';
 import setupListeners from './setupListeners';
@@ -9,7 +7,6 @@ import useAppState from './useAppState';
 
 type LDProps = {
   client: ReactNativeLDClient;
-  context?: LDContext;
 };
 
 /**
@@ -18,25 +15,15 @@ type LDProps = {
  *
  * @param client The ReactNativeLDClient object. Initialize this object separately
  * and then set this prop when declaring the LDProvider.
- * @param context Optional. The LDContext object. If set, the LDProvider will
- * `identify` this context on application mount. If not set, default flag values
- * will be returned. You can run `identify` at a later time.
  * @param children
+ *
  * @constructor
  */
-const LDProvider = ({ client, context, children }: PropsWithChildren<LDProps>) => {
+const LDProvider = ({ client, children }: PropsWithChildren<LDProps>) => {
   const [state, setState] = useState<ReactContext>({ client });
 
   useEffect(() => {
     setupListeners(client, setState);
-
-    if (context) {
-      client
-        .identify(context)
-        .catch((e: any) =>
-          client.logger.debug(`LaunchDarkly React Native Sdk identify error: ${e}`),
-        );
-    }
   }, []);
 
   useAppState(client);

--- a/packages/shared/sdk-client/src/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.test.ts
@@ -69,7 +69,7 @@ describe('sdk-client object', () => {
 
     expect(ldc.config).toMatchObject({
       allAttributesPrivate: false,
-      baseUri: 'https://sdk.launchdarkly.com',
+      baseUri: 'https://clientsdk.launchdarkly.com',
       capacity: 100,
       diagnosticOptOut: false,
       diagnosticRecordingInterval: 900,
@@ -87,7 +87,7 @@ describe('sdk-client object', () => {
       sendLDHeaders: true,
       serviceEndpoints: {
         events: 'https://events.launchdarkly.com',
-        polling: 'https://sdk.launchdarkly.com',
+        polling: 'https://clientsdk.launchdarkly.com',
         streaming: 'https://clientstream.launchdarkly.com',
       },
       streamInitialReconnectDelay: 1,

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -78,6 +78,11 @@ export default class LDClientImpl implements LDClient {
     this.emitter = new LDEmitter();
   }
 
+  /**
+   * Sets the SDK connection mode.
+   *
+   * @param mode - One of supported {@link ConnectionMode}. Default is 'streaming'.
+   */
   async setConnectionMode(mode: ConnectionMode): Promise<void> {
     if (this.config.connectionMode === mode) {
       this.logger.debug(`setConnectionMode ignored. Mode is already '${mode}'.`);
@@ -106,6 +111,13 @@ export default class LDClientImpl implements LDClient {
     }
 
     return Promise.resolve();
+  }
+
+  /**
+   * Gets the SDK connection mode.
+   */
+  getConnectionMode(): ConnectionMode {
+    return this.config.connectionMode;
   }
 
   isOffline() {
@@ -270,7 +282,7 @@ export default class LDClientImpl implements LDClient {
     return f ? JSON.parse(f) : undefined;
   }
 
-  async identify(pristineContext: LDContext, _hash?: string): Promise<void> {
+  async identify(pristineContext: LDContext): Promise<void> {
     let context = await ensureKey(pristineContext, this.platform);
 
     if (this.autoEnvAttributes === AutoEnvAttributes.Enabled) {

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -100,12 +100,10 @@ export interface LDClient {
    *
    * @param context
    *   The LDContext object.
-   * @param hash
-   *   The signed context key if you are using [Secure Mode](https://docs.launchdarkly.com/sdk/features/secure-mode#configuring-secure-mode-in-the-javascript-client-side-sdk).
    * @returns
    *   A Promise which resolves when the flag values for the specified context are available.
    */
-  identify(context: LDContext, hash?: string): Promise<void>;
+  identify(context: LDContext): Promise<void>;
 
   /**
    * Determines the json variation of a feature flag.

--- a/packages/shared/sdk-client/src/api/LDOptions.ts
+++ b/packages/shared/sdk-client/src/api/LDOptions.ts
@@ -81,6 +81,13 @@ export interface LDOptions {
   capacity?: number;
 
   /**
+   * Enables logging for debugging.
+   *
+   * The default value is false.
+   */
+  debug?: boolean;
+
+  /**
    * Set to true to opt out of sending diagnostics data.
    *
    * Unless `diagnosticOptOut` is set to true, the client will send some diagnostics data to the LaunchDarkly

--- a/packages/shared/sdk-client/src/api/LDOptions.ts
+++ b/packages/shared/sdk-client/src/api/LDOptions.ts
@@ -81,7 +81,7 @@ export interface LDOptions {
   capacity?: number;
 
   /**
-   * Enables logging for debugging.
+   * Enables debug logging.
    *
    * The default value is false.
    */

--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -12,8 +12,9 @@ describe('Configuration', () => {
 
     expect(config).toMatchObject({
       allAttributesPrivate: false,
-      baseUri: 'https://sdk.launchdarkly.com',
+      baseUri: 'https://clientsdk.launchdarkly.com',
       capacity: 100,
+      debug: false,
       diagnosticOptOut: false,
       diagnosticRecordingInterval: 900,
       withReasons: false,

--- a/packages/shared/sdk-client/src/configuration/Configuration.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.ts
@@ -14,7 +14,7 @@ import { LDInspection } from '../api/LDInspection';
 import validators from './validators';
 
 export default class Configuration {
-  public static DEFAULT_POLLING = 'https://sdk.launchdarkly.com';
+  public static DEFAULT_POLLING = 'https://clientsdk.launchdarkly.com';
   public static DEFAULT_STREAM = 'https://clientstream.launchdarkly.com';
 
   public readonly logger = createSafeLogger();
@@ -29,6 +29,7 @@ export default class Configuration {
   public readonly streamInitialReconnectDelay = 1;
 
   public readonly allAttributesPrivate = false;
+  public readonly debug = false;
   public readonly diagnosticOptOut = false;
   public readonly sendEvents = true;
   public readonly sendLDHeaders = true;

--- a/packages/shared/sdk-client/src/configuration/validators.ts
+++ b/packages/shared/sdk-client/src/configuration/validators.ts
@@ -38,6 +38,7 @@ const validators: Record<keyof LDOptions, TypeValidator> = {
   streamInitialReconnectDelay: TypeValidators.numberWithMin(0),
 
   allAttributesPrivate: TypeValidators.Boolean,
+  debug: TypeValidators.Boolean,
   diagnosticOptOut: TypeValidators.Boolean,
   withReasons: TypeValidators.Boolean,
   sendEvents: TypeValidators.Boolean,

--- a/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
+++ b/packages/shared/sdk-client/src/evaluation/fetchFlags.test.ts
@@ -32,7 +32,7 @@ describe('fetchFeatures', () => {
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
     expect(platformFetch).toHaveBeenCalledWith(
-      'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9',
+      'https://clientsdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9',
       {
         method: 'GET',
         headers: getHeaders,
@@ -47,7 +47,7 @@ describe('fetchFeatures', () => {
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
     expect(platformFetch).toHaveBeenCalledWith(
-      'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?withReasons=true',
+      'https://clientsdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?withReasons=true',
       {
         method: 'GET',
         headers: getHeaders,
@@ -61,7 +61,7 @@ describe('fetchFeatures', () => {
     const json = await fetchFlags(sdkKey, context, config, basicPlatform);
 
     expect(platformFetch).toHaveBeenCalledWith(
-      'https://sdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?h=test-hash',
+      'https://clientsdk.launchdarkly.com/sdk/evalx/testSdkKey1/contexts/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9?h=test-hash',
       {
         method: 'GET',
         headers: getHeaders,


### PR DESCRIPTION
These are discovered after the docs PR review:

* Client sdk default baseUri should be clientsdk.launchdarkly instead of sdk.launchdarkly.
* Add getConnectionMode.
* Remove identify hash arg.
* Change rn default logging to info.
* Add debug config option.
* Add comments about autoEnv applicationInfo.
* Remove LDProvider context prop.