### PR TITLE
fix: Fix Detox e2e tests broken after 0.73 update.

### DIFF
--- a/packages/sdk/react-native/example/README.md
+++ b/packages/sdk/react-native/example/README.md
@@ -52,11 +52,5 @@ MOBILE_KEY=abcdef12456
 4. In the example folder, on a terminal:
 
 ```shell
-yarn && yarn expo-prebuild && yarn start
-```
-
-5. Still in the example folder but on another terminal:
-
-```shell
-yarn detox-ios
+yarn test
 ```

--- a/packages/sdk/react-native/example/build-run-detox.sh
+++ b/packages/sdk/react-native/example/build-run-detox.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "===== Installing all dependencies"
+yarn
+
+echo "===== Building native code"
+yarn expo-prebuild
+
+# HACK: This is needed to solve xcode build error:
+# "[CP-User] [Hermes] Replace Hermes for the right configuration, if needed"
+# https://github.com/facebook/react-native/issues/42112#issuecomment-1884536225
+echo "===== Delete .xcode.env.local"
+rm -rf ./ios/.xcode.env.local
+
+echo "===== Start metro in background"
+yarn start &
+
+echo "===== Run ios tests"
+yarn detox-ios
+
+echo "===== Exit"
+kill -9 $(lsof -t -i:8081)

--- a/packages/sdk/react-native/example/e2e/starter.test.ts
+++ b/packages/sdk/react-native/example/e2e/starter.test.ts
@@ -15,6 +15,10 @@ describe('Example', () => {
   //   await device.reloadReactNative();
   // });
 
+  afterAll(async () => {
+    await device.terminateApp();
+  });
+
   test('app loads and renders correctly', async () => {
     await expect(element(by.text(/welcome to launchdarkly/i))).toBeVisible();
     await expect(element(by.text(/my-boolean-flag-1: false/i))).toBeVisible();

--- a/packages/sdk/react-native/example/package.json
+++ b/packages/sdk/react-native/example/package.json
@@ -19,7 +19,8 @@
     "postinstall": "yarn link-dev",
     "detox-build-ios": "detox build -c ios.sim.debug",
     "detox-run-ios": "detox test -c ios.sim.debug",
-    "detox-ios": "yarn detox-build-ios && yarn detox-run-ios"
+    "detox-ios": "yarn detox-build-ios && yarn detox-run-ios",
+    "test": "./build-run-detox.sh"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.21.0",
@@ -37,7 +38,7 @@
     "@types/node": "^20.10.5",
     "@types/react": "~18.2.55",
     "@types/react-native-dotenv": "^0.2.1",
-    "detox": "^20.14.7",
+    "detox": "^20.17.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"

--- a/packages/sdk/react-native/example/yarn.lock
+++ b/packages/sdk/react-native/example/yarn.lock
@@ -4851,7 +4851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detox@npm:*, detox@npm:^20.14.7":
+"detox@npm:*":
   version: 20.14.7
   resolution: "detox@npm:20.14.7"
   dependencies:
@@ -4898,6 +4898,56 @@ __metadata:
   bin:
     detox: local-cli/cli.js
   checksum: b5129ffae28cb4eb458a641fb2ca937de2f04cf729a34d6ab07eeba0ef7ef963c0e3d57fcd1d527625d1158a1029dc0397327d8dfb978dbeb15e5fa6a5e95b07
+  languageName: node
+  linkType: hard
+
+"detox@npm:^20.17.1":
+  version: 20.17.1
+  resolution: "detox@npm:20.17.1"
+  dependencies:
+    ajv: ^8.6.3
+    bunyan: ^1.8.12
+    bunyan-debug-stream: ^3.1.0
+    caf: ^15.0.1
+    chalk: ^4.0.0
+    child-process-promise: ^2.2.0
+    execa: ^5.1.1
+    find-up: ^5.0.0
+    fs-extra: ^11.0.0
+    funpermaproxy: ^1.1.0
+    glob: ^8.0.3
+    ini: ^1.3.4
+    jest-environment-emit: ^1.0.5
+    json-cycle: ^1.3.0
+    lodash: ^4.17.11
+    multi-sort-stream: ^1.0.3
+    multipipe: ^4.0.0
+    node-ipc: 9.2.1
+    proper-lockfile: ^3.0.2
+    resolve-from: ^5.0.0
+    sanitize-filename: ^1.6.1
+    semver: ^7.0.0
+    serialize-error: ^8.0.1
+    shell-quote: ^1.7.2
+    signal-exit: ^3.0.3
+    stream-json: ^1.7.4
+    strip-ansi: ^6.0.1
+    telnet-client: 1.2.8
+    tempfile: ^2.0.0
+    trace-event-lib: ^1.3.1
+    which: ^1.3.1
+    ws: ^7.0.0
+    yargs: ^17.0.0
+    yargs-parser: ^21.0.0
+    yargs-unparser: ^2.0.0
+  peerDependencies:
+    jest: 29.x.x || 28.x.x || ^27.2.5
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  bin:
+    detox: local-cli/cli.js
+  checksum: 4c12b20e2adfff650f39e21d84028dfe1941370a24f5d9a7c59cb1742d849e7448f513a52200ab22507ece1199f8cf16f049760235ac5d450d22dca4db13bb8b
   languageName: node
   linkType: hard
 
@@ -8953,7 +9003,7 @@ __metadata:
     "@types/node": ^20.10.5
     "@types/react": ~18.2.55
     "@types/react-native-dotenv": ^0.2.1
-    detox: ^20.14.7
+    detox: ^20.17.1
     expo: ~50.0.6
     expo-splash-screen: ~0.26.4
     expo-status-bar: ~1.11.1


### PR DESCRIPTION
Detox was broken after upgrading the example app to RN0.73. The error was very cryptic and the solution equally so:

```
[CP-User] [Hermes] Replace Hermes for the right configuration, if needed
```

Solution: Delete `ios/.xcode.env.local`. https://github.com/facebook/react-native/issues/42112#issuecomment-1884536225