### PR TITLE
chore: Do not publish docs on maintenance branch.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,3 +36,5 @@ jobs:
         with:
           workspace_path: packages/sdk/server-node
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          # Only publish docs on the default branch.
+          publish_docs: ${{ github.ref_name == github.event.repository.default_branch }}

--- a/actions/full-release/action.yml
+++ b/actions/full-release/action.yml
@@ -7,6 +7,10 @@ inputs:
   aws_assume_role:
     description: 'The ARN of an AWS IAM role to assume. Used to auth with AWS to upload results to S3.'
     required: true
+  publish_docs: # This is useful for previous major versions to avoid overwriting current docs.
+    description: 'Should this release publish documentation?'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -37,5 +41,6 @@ runs:
         prerelease: false
         dry_run: false
     - uses: ./actions/publish-docs
+      if: ${{ inputs.publish_docs == 'true' }}
       with:
         workspace_path: ${{ inputs.workspace_path }}


### PR DESCRIPTION
This PR is to prevent 8.x docs from overwriting 9.x docs.

In the future we may want to consider docs for multiple versions, but we do not currently support that.