### PR TITLE
chore: add .sdk_metadata.json to repo

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -2,6 +2,7 @@
   "version": 1,
   "sdks": {
     "akamai-base": {
+      "name": "Akamai SDK",
       "type": "edge",
       "path": "packages/sdk/akamai-base",
       "languages": [
@@ -13,6 +14,7 @@
       }
     },
     "akamai-edgekv": {
+      "name": "Akamai SDK for EdgeKV",
       "type": "edge",
       "path": "packages/sdk/akamai-edgekv",
       "languages": [
@@ -24,6 +26,7 @@
       }
     },
     "cloudflare": {
+      "name": "Cloudflare SDK",
       "type": "edge",
       "path": "packages/sdk/cloudflare",
       "languages": [
@@ -35,6 +38,7 @@
       }
     },
     "react-native": {
+      "name": "React Native SDK",
       "type": "client-side",
       "path": "packages/sdk/react-native",
       "languages": [
@@ -46,6 +50,7 @@
       }
     },
     "node-server": {
+      "name": "Node.js SDK",
       "type": "server-side",
       "path": "packages/sdk/server-node",
       "languages": [
@@ -57,6 +62,7 @@
       }
     },
     "vercel": {
+      "name": "Vercel Edge SDK",
       "type": "edge",
       "path": "packages/sdk/vercel",
       "languages": [

--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "sdks": {
+    "akamai-base": {
+      "type": "edge",
+      "path": "packages/sdk/akamai-base",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "akamai-server-base-sdk-"
+      }
+    },
+    "akamai-edgekv": {
+      "type": "edge",
+      "path": "packages/sdk/akamai-edgekv",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "akamai-server-edgekv-sdk-"
+      }
+    },
+    "cloudflare": {
+      "type": "edge",
+      "path": "packages/sdk/cloudflare",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "cloudflare-server-sdk-"
+      }
+    },
+    "react-native": {
+      "type": "client-side",
+      "path": "packages/sdk/react-native",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "react-native-client-sdk-"
+      }
+    },
+    "node-server": {
+      "type": "server-side",
+      "path": "packages/sdk/server-node",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "node-server-sdk-"
+      }
+    },
+    "vercel": {
+      "type": "edge",
+      "path": "packages/sdk/vercel",
+      "languages": [
+        "JavaScript",
+        "TypeScript"
+      ],
+      "releases": {
+        "tag-prefix": "vercel-server-sdk-"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a (prototype, subject to change) `.sdk_metadata.json` dotfile to the repo. 

It contains metadata about each of the SDKs present here. 

Things to think about:
- Filename, being a dotfile, ok?
- Location, root of repo, makes sense?
- Contents: how to tell the tool which releases belong to each SDK? (currently: specify the tag prefix, and the tool will filter based on that)