### PR TITLE
chore: Update vercel examples to use workspace packages.

### DIFF
--- a/packages/sdk/vercel/examples/complete/package.json
+++ b/packages/sdk/vercel/examples/complete/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build-prod": "next build",
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start"

--- a/packages/sdk/vercel/examples/complete/package.json
+++ b/packages/sdk/vercel/examples/complete/package.json
@@ -10,7 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@launchdarkly/vercel-server-sdk": "1.3.0",
+    "@launchdarkly/vercel-server-sdk": "workspace:^",
     "@vercel/edge-config": "^1.1.0",
     "launchdarkly-js-client-sdk": "^3.1.3",
     "launchdarkly-react-client-sdk": "^3.0.6",

--- a/packages/sdk/vercel/examples/route-handler/package.json
+++ b/packages/sdk/vercel/examples/route-handler/package.json
@@ -4,7 +4,7 @@
   "packageManager": "yarn@3.4.1",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build-prod": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/packages/sdk/vercel/examples/route-handler/package.json
+++ b/packages/sdk/vercel/examples/route-handler/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@launchdarkly/vercel-server-sdk": "1.3.0",
+    "@launchdarkly/vercel-server-sdk": "workspace:^",
     "@vercel/edge-config": "^1.1.0",
     "next": "14.1.2",
     "react": "^18.2.0",


### PR DESCRIPTION
We updated @vercel/edge-config package to use the major version in this [pr](https://github.com/launchdarkly/js-core/pull/393) however I overlooked updating the corresponding example apps to use the workspace versions of our vercel sdk.