### PR TITLE
fix: Fix typings for big segment store factories.

### DIFF
--- a/packages/store/node-server-sdk-dynamodb/__tests__/LDClient.option.test.ts
+++ b/packages/store/node-server-sdk-dynamodb/__tests__/LDClient.option.test.ts
@@ -1,0 +1,11 @@
+import { LDOptions } from '@launchdarkly/node-server-sdk';
+import DynamoDBBigSegmentStoreFactory from '../src/DynamoDBBigSegmentStoreFactory';
+
+it('can construct options with a big segment store', () => {
+  // This is just a typescript test to ensure the typings match.
+  const _: LDOptions = {
+    bigSegments: {
+      store: DynamoDBBigSegmentStoreFactory("my-table")
+    }
+  }
+});

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBBigSegmentStoreFactory.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBBigSegmentStoreFactory.ts
@@ -1,4 +1,4 @@
-import { interfaces, LDOptions } from '@launchdarkly/node-server-sdk';
+import { interfaces, LDClientContext } from '@launchdarkly/node-server-sdk';
 
 import DynamoDBBigSegmentStore from './DynamoDBBigSegmentStore';
 import LDDynamoDBOptions from './LDDynamoDBOptions';
@@ -18,6 +18,7 @@ import LDDynamoDBOptions from './LDDynamoDBOptions';
 export default function DynamoDBBigSegmentStoreFactory(
   tableName: string,
   options?: LDDynamoDBOptions,
-): (config: LDOptions) => interfaces.BigSegmentStore {
-  return (config: LDOptions) => new DynamoDBBigSegmentStore(tableName, options, config.logger);
+): (config: LDClientContext) => interfaces.BigSegmentStore {
+  return (config: LDClientContext) =>
+    new DynamoDBBigSegmentStore(tableName, options, config.basicConfiguration.logger);
 }

--- a/packages/store/node-server-sdk-redis/__tests__/LDClient.option.test.ts
+++ b/packages/store/node-server-sdk-redis/__tests__/LDClient.option.test.ts
@@ -1,0 +1,11 @@
+import { LDOptions } from '@launchdarkly/node-server-sdk';
+import RedisBigSegmentStoreFactory from '../src/RedisBigSegmentStoreFactory';
+
+it('can construct options with a big segment store', () => {
+  // This is just a typescript test to ensure the typings match.
+  const _: LDOptions = {
+    bigSegments: {
+      store: RedisBigSegmentStoreFactory()
+    }
+  }
+});

--- a/packages/store/node-server-sdk-redis/src/RedisBigSegmentStoreFactory.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisBigSegmentStoreFactory.ts
@@ -1,4 +1,4 @@
-import { interfaces, LDOptions } from '@launchdarkly/node-server-sdk';
+import { interfaces, LDClientContext } from '@launchdarkly/node-server-sdk';
 
 import LDRedisOptions from './LDRedisOptions';
 import RedisBigSegmentStore from './RedisBigSegmentStore';
@@ -16,6 +16,7 @@ import RedisBigSegmentStore from './RedisBigSegmentStore';
  */
 export default function RedisBigSegmentStoreFactory(
   options?: LDRedisOptions,
-): (config: LDOptions) => interfaces.BigSegmentStore {
-  return (config: LDOptions) => new RedisBigSegmentStore(options, config.logger);
+): (config: LDClientContext) => interfaces.BigSegmentStore {
+  return (config: LDClientContext) =>
+    new RedisBigSegmentStore(options, config?.basicConfiguration.logger);
 }


### PR DESCRIPTION
The typings were incorrect for the factories. I am not making this a major version as internally the factories were being called with this type. Additionally the integrations don't use the logger which is what they access from these options.

The feature stores had the correct options.