### PR TITLE
chore: Update Cloudflare SDK version in jsr.json.

### DIFF
--- a/packages/sdk/cloudflare/jsr.json
+++ b/packages/sdk/cloudflare/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchdarkly/cloudflare-server-sdk",
-  "version": "0.0.3",
+  "version": "2.4.2",
   "exports": "./src/index.ts",
   "publish": {
     "include": ["LICENSE", "README.md", "package.json", "jsr.json", "src/**/*.ts"],


### PR DESCRIPTION
I'm manually updating the version in jsr.json and publishing for now since we are blocked by a github linking issue in the jsr portal.

https://jsr.io/@launchdarkly/cloudflare-server-sdk

<img width="637" alt="Screenshot 2024-04-04 at 10 12 26 AM" src="https://github.com/launchdarkly/js-core/assets/1593077/2dfeb043-fdce-40dd-bcd8-680342e75c4a">