### PR TITLE
chore: Change Node server SDK to 9.3.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,9 @@
     "packages/shared/akamai-edgeworker-sdk": {},
     "packages/sdk/cloudflare": {},
     "packages/sdk/react-native": {},
-    "packages/sdk/server-node": {},
+    "packages/sdk/server-node": {
+      "release-as": "9.3.0"
+    },
     "packages/sdk/vercel": {
       "extra-files": ["src/createPlatformInfo.ts"]
     },


### PR DESCRIPTION
Update the version to 9.3.0 to reflect the addition of hooks.

