### PR TITLE
chore: add 'server' to Node.js SDK name

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -50,7 +50,7 @@
       }
     },
     "node-server": {
-      "name": "Node.js SDK",
+      "name": "Node.js Server SDK",
       "type": "server-side",
       "path": "packages/sdk/server-node",
       "languages": [


### PR DESCRIPTION
Since we have a Node.js client SDK, it makes sense to have the names be:

Node.js Server SDK
Node.js Client SDK

(I think?)
