### PR TITLE
chore: Skip yarn pack for jsr publish.

### DIFF
--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
 if [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
-  yarn workspace $WORKSPACE pack
   cd $WORKSPACE_PATH
   
   if $LD_RELEASE_IS_DRYRUN ; then
     echo "Doing a dry run of jsr publishing."
-    npx jsr publish --dry-run --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish --dry-run || { echo "jsr publish failed" >&2; exit 1; }
   elif [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
     echo "Publishing to jsr."
-    npx jsr publish --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish || { echo "jsr publish failed" >&2; exit 1; }
   fi
 else
   echo "Skipping jsr."

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -6,10 +6,10 @@ if [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
   
   if $LD_RELEASE_IS_DRYRUN ; then
     echo "Doing a dry run of jsr publishing."
-    npx jsr publish --dry-run || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish --dry-run --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
   elif [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
     echo "Publishing to jsr."
-    npx jsr publish || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
   fi
 else
   echo "Skipping jsr."


### PR DESCRIPTION
This is needed otherwise the gha [fails](https://github.com/launchdarkly/js-core/actions/runs/8758581209/job/24039697071#step:10:51):

```bash
npm WARN exec The following package was not found and will be installed: jsr@0.12.2
Downloading JSR binary...
Download completed
Checking for slow types in the public API...
error: Aborting due to uncommitted changes. Check in source code or run with --allow-dirty
Child process exited with: 1
jsr publish failed
Error: Process completed with exit code 1.
```