### PR TITLE
chore: Allow dirty for jsr publish.

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -81,6 +81,7 @@ jobs:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/npm/token = NODE_AUTH_TOKEN'
       - name: Setup .yarnrc.yml
+        if: ${{ inputs.package_registry == 'npm' }}
         shell: bash
         run: |
           yarn config set npmScopes.launchdarkly.npmRegistryServer "https://registry.npmjs.org"

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ coverage
 **/*/CHANGELOG.md
 packages/sdk/akamai-edgekv/src/edgekv/edgekv.js
 packages/sdk/cloudflare/src/createPlatformInfo.ts
+.yarnrc.yml

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,3 @@ coverage
 **/*/CHANGELOG.md
 packages/sdk/akamai-edgekv/src/edgekv/edgekv.js
 packages/sdk/cloudflare/src/createPlatformInfo.ts
-.yarnrc.yml

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -5,10 +5,10 @@ if [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
   git diff HEAD
   if $LD_RELEASE_IS_DRYRUN ; then
     echo "Doing a dry run of jsr publishing."
-    npx jsr publish --dry-run || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish --dry-run --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
   elif [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
     echo "Publishing to jsr."
-    npx jsr publish || { echo "jsr publish failed" >&2; exit 1; }
+    npx jsr publish --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }
   fi
 else
   echo "Skipping jsr."

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -2,7 +2,7 @@
 
 if [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
   cd $WORKSPACE_PATH
-  git diff HEAD
+  
   if $LD_RELEASE_IS_DRYRUN ; then
     echo "Doing a dry run of jsr publishing."
     npx jsr publish --dry-run --allow-dirty || { echo "jsr publish failed" >&2; exit 1; }

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -2,7 +2,7 @@
 
 if [ -f "./$WORKSPACE_PATH/jsr.json" ]; then
   cd $WORKSPACE_PATH
-  
+  git diff HEAD
   if $LD_RELEASE_IS_DRYRUN ; then
     echo "Doing a dry run of jsr publishing."
     npx jsr publish --dry-run || { echo "jsr publish failed" >&2; exit 1; }


### PR DESCRIPTION
The root cause is .yarnrc.yml being modified because of the addition of npmRegistryServer:

```shell
Publishing jsr: @launchdarkly/cloudflare-server-sdk
diff --git a/.yarnrc.yml b/.yarnrc.yml
index 5a857be..7cbcb75 100644
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,10 +4,14 @@ npmPublishAccess: public
 
 npmScopes:
   jsr:
-    npmRegistryServer: 'https://npm.jsr.io/'
+    npmRegistryServer: "https://npm.jsr.io/"
+  launchdarkly:
+    npmAlwaysAuth: true
+    npmAuthToken: ***
+    npmRegistryServer: "https://registry.npmjs.org/"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: '@yarnpkg/plugin-workspace-tools'
+    spec: "@yarnpkg/plugin-workspace-tools"
```