### PR TITLE
fix: Include name and version in platform.

### DIFF
--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -1,7 +1,7 @@
 import type { Info, PlatformData, SdkData } from '@launchdarkly/js-server-sdk-common-edge';
 
-const name = "@launchdarkly/cloudflare-server-sdk";
-const version = "2.5.3"; // x-release-please-version
+const name = '@launchdarkly/cloudflare-server-sdk';
+const version = '2.5.3'; // x-release-please-version
 
 class CloudflarePlatformInfo implements Info {
   platformData(): PlatformData {

--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -19,6 +19,6 @@ class CloudflarePlatformInfo implements Info {
   }
 }
 
-const createPlatformInfo = (): CloudflarePlatformInfo => new CloudflarePlatformInfo()
+const createPlatformInfo = (): CloudflarePlatformInfo => new CloudflarePlatformInfo();
 
 export default createPlatformInfo;

--- a/packages/sdk/cloudflare/src/createPlatformInfo.ts
+++ b/packages/sdk/cloudflare/src/createPlatformInfo.ts
@@ -1,10 +1,7 @@
 import type { Info, PlatformData, SdkData } from '@launchdarkly/js-server-sdk-common-edge';
 
-// @ts-ignore
-// eslint-disable-next-line prettier/prettier
-import * as packageJson from '../package.json' assert { type: "json" }
-
-const { name, version } = packageJson
+const name = "@launchdarkly/cloudflare-server-sdk";
+const version = "2.5.3"; // x-release-please-version
 
 class CloudflarePlatformInfo implements Info {
   platformData(): PlatformData {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
           "type": "json",
           "path": "jsr.json",
           "jsonpath": "$.version"
-        }
+        },
+        "src/createPlatformInfo.ts"
       ]
     },
     "packages/sdk/react-native": {},


### PR DESCRIPTION
This embeds the package name and version directly into the source instead of attempting to import the package.json. This has greater compatibility and depends on release-please to update the version.