### PR TITLE
fix(types): LDClient.waitForInitialization resolves this

### DIFF
--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -103,13 +103,13 @@ export default class LDClientImpl implements LDClient {
 
   private evaluator: Evaluator;
 
-  private initResolve?: (value: LDClient | PromiseLike<LDClient>) => void;
+  private initResolve?: (value: this | PromiseLike<this>) => void;
 
   private initReject?: (err: Error) => void;
 
   private rejectionReason: Error | undefined;
 
-  private initializedPromise?: Promise<LDClient>;
+  private initializedPromise?: Promise<this>;
 
   private logger?: LDLogger;
 
@@ -253,7 +253,7 @@ export default class LDClientImpl implements LDClient {
     return this.initState === InitState.Initialized;
   }
 
-  waitForInitialization(options?: LDWaitForInitializationOptions): Promise<LDClient> {
+  waitForInitialization(options?: LDWaitForInitializationOptions): Promise<this> {
     // An initialization promise is only created if someone is going to use that promise.
     // If we always created an initialization promise, and there was no call waitForInitialization
     // by the time the promise was rejected, then that would result in an unhandled promise
@@ -906,10 +906,10 @@ export default class LDClientImpl implements LDClient {
    * @returns
    */
   private clientWithTimeout(
-    basePromise: Promise<LDClient>,
+    basePromise: Promise<this>,
     timeout?: number,
     logger?: LDLogger,
-  ): Promise<LDClient> {
+  ): Promise<this> {
     if (timeout) {
       const timeoutPromise = timedPromise(timeout, 'waitForInitialization');
       return Promise.race([basePromise, timeoutPromise.then(() => this)]).catch((reason) => {

--- a/packages/shared/sdk-server/src/api/LDClient.ts
+++ b/packages/shared/sdk-server/src/api/LDClient.ts
@@ -86,7 +86,7 @@ export interface LDClient {
    *   }
    * ```
    */
-  waitForInitialization(options?: LDWaitForInitializationOptions): Promise<LDClient>;
+  waitForInitialization(options?: LDWaitForInitializationOptions): Promise<this>;
 
   /**
    * Determines the variation of a feature flag for a context.


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/js-core/issues/324

**Describe the solution you've provided**

Type the return type with `this` keyword

**Describe alternatives you've considered**

**Additional context**

In my use case, the problem was that the return type of `waitForInitialization` is not compatible with `ld.LDClient`

```typescript
import * as ld from '@launchdarkly/node-server-sdk';

export function initLdClient(): Promise<ld.LDClient> {
  return ld.init(process.env.LAUNCH_DARKLY_SDK_KEY as string)
           .waitForInitialization(); // Type error
}
```