### PR TITLE
fix: Configure max backoff and jitter ratio to ensure exponential backoff.

### DIFF
--- a/packages/sdk/server-node/src/platform/NodeRequests.ts
+++ b/packages/sdk/server-node/src/platform/NodeRequests.ts
@@ -152,6 +152,8 @@ export default class NodeRequests implements platform.Requests {
       ...eventSourceInitDict,
       agent: this.agent,
       tlsParams: this.tlsOptions,
+      maxBackoffMillis: 30 * 1000,
+      jitterRatio: 0.5,
     };
     return new LDEventSource(url, expandedOptions);
   }


### PR DESCRIPTION
Without these set the event source retries every second, which is not the desired behavior.