### PR TITLE
fix: Update launchdarkly-eventsource to 2.0.3.

### DIFF
--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@launchdarkly/js-server-sdk-common": "2.4.1",
     "https-proxy-agent": "^5.0.1",
-    "launchdarkly-eventsource": "2.0.2"
+    "launchdarkly-eventsource": "2.0.3"
   },
   "devDependencies": {
     "@launchdarkly/private-js-mocks": "0.0.1",


### PR DESCRIPTION
This version includes fixes which improve error handling and shutdown of SSE streams.

Fixes #458