### PR TITLE
fix: Added iOS SettingsManager null check.

### DIFF
--- a/packages/sdk/react-native/src/platform/locale.ts
+++ b/packages/sdk/react-native/src/platform/locale.ts
@@ -6,7 +6,7 @@ import { NativeModules, Platform } from 'react-native';
  */
 const locale =
   Platform.OS === 'ios'
-    ? NativeModules.SettingsManager.settings.AppleLocale // iOS
+    ? NativeModules.SettingsManager?.settings.AppleLocale // iOS
     : NativeModules.I18nManager?.localeIdentifier;
 
 export default locale;


### PR DESCRIPTION
Fixes this [gh issue](https://github.com/launchdarkly/js-core/issues/462).

Enabling new architecture in react native project produces runtime errors while trying to access nullable `NativeModules.SettingsManager`.