### PR TITLE
fix: Pin jsonc-parser to fix cloudflare rollup build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "typedoc": "0.25.0",
     "typescript": "5.1.6"
   },
-  "packageManager": "yarn@3.4.1"
+  "packageManager": "yarn@3.4.1",
+  "//": "Pin jsonc-parser because v3.3.0 breaks rollup-plugin-esbuild",
+  "resolutions": {
+    "jsonc-parser": "3.2.0"
+  }
 }


### PR DESCRIPTION
Seems like v3.3.0 of jsonc-parser causes an error in rollup-plugin-esbuild:

```bash
[!] SyntaxError: Named export 'parse' not found. The requested module 'jsonc-parser' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'jsonc-parser';
const { parse } = pkg;

/js-core/node_modules/rollup-plugin-esbuild/dist/index.mjs:11
import { parse } from "jsonc-parser";
         ^^^^^
```