### PR TITLE
feat: Add continuous session replay capture.

### DIFF
--- a/packages/telemetry/browser-telemetry/__tests__/SessionBuffer.test.ts
+++ b/packages/telemetry/browser-telemetry/__tests__/SessionBuffer.test.ts
@@ -1,9 +1,9 @@
-import SessionBuffer from '../src/collectors/rrweb/SessionBuffer';
+import RollingBuffer from '../src/collectors/rrweb/RollingBuffer';
 
 it('can fill the entire expected buffer size', () => {
   const bufferSize = 5;
   const numberBuffers = 4;
-  const buffer = new SessionBuffer(bufferSize, numberBuffers);
+  const buffer = new RollingBuffer(bufferSize, numberBuffers);
   const demoItems = Array.from(new Array(bufferSize * numberBuffers), (_, i) => i);
 
   demoItems.forEach(buffer.push.bind(buffer));
@@ -14,7 +14,7 @@ it('can fill the entire expected buffer size', () => {
 it('when the buffer is exceeded it will wrap around', () => {
   const bufferSize = 5;
   const numberBuffers = 4;
-  const buffer = new SessionBuffer(bufferSize, numberBuffers);
+  const buffer = new RollingBuffer(bufferSize, numberBuffers);
   const dropRatio = 1.5;
   const extraItems = Math.trunc(bufferSize * dropRatio);
   const itemsToMake = bufferSize * numberBuffers + extraItems;

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/ContinuousReplay.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/ContinuousReplay.ts
@@ -1,0 +1,80 @@
+import * as rrweb from 'rrweb';
+
+import { BrowserTelemetry } from '../../api/BrowserTelemetry';
+import { Collector } from '../../api/Collector';
+import { sessionId } from './patches';
+import { ContinuousCapture } from './SessionReplayOptions';
+
+export default class ContinuousReplay implements Collector {
+  private telemetry?: BrowserTelemetry;
+  // TODO: Use a better buffer.
+  private buffer: any[] = [];
+  private stopper?: () => void;
+  private visibilityHandler: any;
+  private timerHandle: any;
+  private index: number = 0;
+
+  constructor(private readonly options: ContinuousCapture) {
+    this.visibilityHandler = () => {
+      this.handleVisibilityChange();
+    };
+
+    document.addEventListener('visibilitychange', this.visibilityHandler, true);
+
+    this.timerHandle = setInterval(() => {
+      // If there are only 2 events, then we just have a snapshot.
+      // We can wait to capture until there is some activity.
+      if (this.buffer.length === 2) {
+        return;
+      }
+      this.recordCapture();
+      this.restartCapture();
+    }, options.intervalMs);
+
+    this.startCapture();
+  }
+
+  register(telemetry: BrowserTelemetry): void {
+    this.telemetry = telemetry;
+  }
+
+  unregister(): void {
+    this.stopper?.();
+    this.telemetry = undefined;
+    document.removeEventListener('visibilitychange', this.visibilityHandler);
+    clearInterval(this.timerHandle);
+  }
+
+  private handleVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      // When the visibility changes we want to be sure we record what we have, and then we
+      // restart recording in case this visibility change was not for the end of the session.
+      this.recordCapture();
+      this.restartCapture();
+    }
+  }
+
+  private recordCapture(): void {
+    this.telemetry?.captureSession({
+      id: sessionId,
+      events: [...this.buffer],
+      index: this.index,
+    });
+    this.index += 1;
+  }
+
+  private startCapture() {
+    const { buffer } = this;
+    this.stopper = rrweb.record({
+      emit: (event) => {
+        buffer.push(event);
+      },
+    });
+  }
+
+  private restartCapture() {
+    this.stopper?.();
+    this.buffer.length = 0;
+    this.startCapture();
+  }
+}

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/RollingBuffer.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/RollingBuffer.ts
@@ -9,7 +9,7 @@ import EventBuffer from './EventBuffer';
  * The buffer can continuously capture events while always remaining in a playable state
  * and dropping old events.
  */
-export default class SessionBuffer {
+export default class RollingBuffer {
   private buffers: EventBuffer[] = [];
   private writePointer: number = 0;
   private headPointer: number = 0;

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/RollingReplay.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/RollingReplay.ts
@@ -1,0 +1,40 @@
+import * as rrweb from 'rrweb';
+
+import { BrowserTelemetry } from '../../api/BrowserTelemetry';
+import { Collector } from '../../api/Collector';
+import RollingBuffer from './RollingBuffer';
+import { RollingCapture } from './SessionReplayOptions';
+
+export default class RollingReplay implements Collector {
+  private telemetry?: BrowserTelemetry;
+  private buffer: RollingBuffer;
+  private stopper?: () => void;
+
+  constructor(options: RollingCapture) {
+    this.buffer = new RollingBuffer(options.eventSegmentLength, options.segmentBufferLength);
+
+    const { buffer } = this;
+    this.stopper = rrweb.record({
+      checkoutEveryNth: options.eventSegmentLength,
+      emit(event) {
+        buffer.push(event);
+      },
+    });
+  }
+
+  register(telemetry: BrowserTelemetry): void {
+    this.telemetry = telemetry;
+  }
+
+  unregister(): void {
+    this.stopper?.();
+    this.telemetry = undefined;
+  }
+
+  capture(): void {
+    this.telemetry?.captureSession({
+      id: crypto.randomUUID(),
+      events: this.buffer.toArray(),
+    });
+  }
+}

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionBuffer.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionBuffer.ts
@@ -57,4 +57,10 @@ export default class SessionBuffer {
 
     return asArray;
   }
+
+  reset(): void {
+    this.writePointer = 0;
+    this.headPointer = 0;
+    this.buffers.forEach((buffer) => buffer.clear());
+  }
 }

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplay.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplay.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import * as rrweb from 'rrweb';
 
 import { BrowserTelemetry } from '../../api/BrowserTelemetry';
@@ -5,23 +6,39 @@ import { Collector } from '../../api/Collector';
 import applyPatches from './patches';
 import SessionBuffer from './SessionBuffer';
 
-/**
- * Experimental capture of sessions using rrweb.
- */
-export default class SessionReplay implements Collector {
+interface RollingCapture {
+  type: 'rolling';
+  eventSegmentLength: number;
+  segmentBufferLength: number;
+}
+
+interface ContinuousCapture {
+  type: 'continuous';
+  interval: number;
+}
+
+interface SessionReplayOptions {
+  capture?: RollingCapture | ContinuousCapture;
+}
+
+function isRollingCapture(capture: unknown): capture is RollingCapture {
+  return (capture as {type: string}).type === 'rolling';
+}
+
+function isContinuousCapture(capture: unknown): capture is ContinuousCapture {
+  return (capture as {type: string}).type === 'continuous';
+}
+
+class RollingReplay implements Collector {
   telemetry?: BrowserTelemetry;
   buffer: SessionBuffer;
+  stopper?: () => void;
 
-  constructor(checkoutEveryNth: number, numBuffers: number) {
+  constructor(options: RollingCapture) {
     applyPatches();
-    this.buffer = new SessionBuffer(checkoutEveryNth, numBuffers);
-    const { buffer } = this;
-    rrweb.record({
-      checkoutEveryNth,
-      emit(event) {
-        buffer.push(event);
-      },
-    });
+    this.buffer = new SessionBuffer(options.eventSegmentLength, options.segmentBufferLength);
+
+    this.startCapture();
   }
 
   register(telemetry: BrowserTelemetry): void {
@@ -37,5 +54,72 @@ export default class SessionReplay implements Collector {
       id: crypto.randomUUID(),
       events: this.buffer.toArray(),
     });
+  }
+
+  private startCapture() {
+    const { buffer, checkoutEveryNth } = this;
+    this.stopper = rrweb.record({
+      checkoutEveryNth,
+      emit(event) {
+        buffer.push(event);
+      },
+    });
+  }
+
+  private reset() {
+    this.stopper?.();
+    this.buffer.reset();
+    this.startCapture();
+  }
+}
+
+class ContinuousReplay implements Collector {}
+
+/**
+ * Experimental capture of sessions using rrweb.
+ */
+export default class SessionReplay implements Collector {
+  telemetry?: BrowserTelemetry;
+  buffer: SessionBuffer;
+  stopper?: () => void;
+
+  constructor(options: SessionReplayOptions) {
+    applyPatches();
+    this.buffer = new SessionBuffer(checkoutEveryNth, numBuffers);
+
+    this.startCapture();
+    if (continuous) {
+    }
+  }
+
+  register(telemetry: BrowserTelemetry): void {
+    this.telemetry = telemetry;
+  }
+
+  unregister(): void {
+    this.telemetry = undefined;
+  }
+
+  capture(): void {
+    this.telemetry?.captureSession({
+      id: crypto.randomUUID(),
+      events: this.buffer.toArray(),
+    });
+  }
+
+  private startCapture() {
+    const { buffer, checkoutEveryNth } = this;
+    this.stopper = rrweb.record({
+      checkoutEveryNth,
+      emit(event) {
+        buffer.push(event);
+      },
+    });
+  }
+
+  private reset() {
+    this.stopper?.();
+    this.buffer.reset();
+    this.startCapture();
   }
 }

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplayOptions.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplayOptions.ts
@@ -1,0 +1,14 @@
+export interface RollingCapture {
+  type: 'rolling';
+  eventSegmentLength: number;
+  segmentBufferLength: number;
+}
+
+export interface ContinuousCapture {
+  type: 'continuous';
+  intervalMs: number;
+}
+
+export interface SessionReplayOptions {
+  capture?: RollingCapture | ContinuousCapture;
+}

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/patches.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/patches.ts
@@ -1,7 +1,7 @@
 // This file contains temporary patches that will be accomplished
 // with SDK modifications in the future.
 
-const sessionId = crypto.randomUUID();
+export const sessionId = crypto.randomUUID();
 const sessionTag = `session-id/${sessionId}`;
 
 class HeaderModifyingXMLHttpRequest extends XMLHttpRequest {


### PR DESCRIPTION
Prototype code.

Usage:
```
  const session = new SessionReplay();
  const telemetry = initializeTelemetry({collectors: [session]});
  const client = initialize('client-side-id', {
    kind: 'user',
    key: 'example-user'
  }, {
    inspectors: telemetry.inspectors(),
  });
  telemetry.register(client);
```