### PR TITLE
fix: Use consistent session id for session replay.

### DIFF
--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -101,7 +101,9 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
       this.collectors.push(new KeypressCollector());
     }
 
-    this.collectors.forEach((collector) => collector.register(this as BrowserTelemetry));
+    this.collectors.forEach((collector) =>
+      collector.register(this as BrowserTelemetry, this.sessionId),
+    );
 
     const impl = this;
     const inspectors: LDInspection[] = [];

--- a/packages/telemetry/browser-telemetry/src/api/Collector.ts
+++ b/packages/telemetry/browser-telemetry/src/api/Collector.ts
@@ -3,7 +3,7 @@ import { type LDContext, type LDEvaluationDetail } from 'launchdarkly-js-client-
 import { BrowserTelemetry } from './BrowserTelemetry';
 
 export interface Collector {
-  register(telemetry: BrowserTelemetry): void;
+  register(telemetry: BrowserTelemetry, sessionId: string): void;
   unregister(): void;
 
   handleFlagUsed?(flagKey: string, flagDetail: LDEvaluationDetail, _context: LDContext): void;

--- a/packages/telemetry/browser-telemetry/src/collectors/dom/ClickCollector.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/dom/ClickCollector.ts
@@ -30,7 +30,7 @@ export default class ClickCollector implements Collector {
     );
   }
 
-  register(telemetry: BrowserTelemetry): void {
+  register(telemetry: BrowserTelemetry, _sessionId: string): void {
     this.destination = telemetry;
   }
   unregister(): void {

--- a/packages/telemetry/browser-telemetry/src/collectors/dom/KeypressCollector.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/dom/KeypressCollector.ts
@@ -45,7 +45,7 @@ export default class KeypressCollector implements Collector {
     );
   }
 
-  register(telemetry: BrowserTelemetry): void {
+  register(telemetry: BrowserTelemetry, _sessionId: string): void {
     this.destination = telemetry;
   }
   unregister(): void {

--- a/packages/telemetry/browser-telemetry/src/collectors/http/fetch.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/http/fetch.ts
@@ -17,7 +17,7 @@ export default class FetchCollector implements Collector {
     });
   }
 
-  register(telemetry: BrowserTelemetry): void {
+  register(telemetry: BrowserTelemetry, _sessionId: string): void {
     this.destination = telemetry;
   }
 

--- a/packages/telemetry/browser-telemetry/src/collectors/http/xhr.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/http/xhr.ts
@@ -18,7 +18,7 @@ export default class XhrCollector implements Collector {
     });
   }
 
-  register(telemetry: BrowserTelemetry): void {
+  register(telemetry: BrowserTelemetry, _sessionId: string): void {
     this.destination = telemetry;
   }
 

--- a/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplay.ts
+++ b/packages/telemetry/browser-telemetry/src/collectors/rrweb/SessionReplay.ts
@@ -35,8 +35,8 @@ export default class SessionReplay implements Collector {
     }
   }
 
-  register(telemetry: BrowserTelemetry): void {
-    this.impl.register(telemetry);
+  register(telemetry: BrowserTelemetry, sessionId: string): void {
+    this.impl.register(telemetry, sessionId);
   }
 
   unregister(): void {


### PR DESCRIPTION
Ensure that the session replay session ID is the same as the error events.

This is prototype code.