### PR TITLE
feat: Update expo and RN version used in example.

### DIFF
--- a/packages/sdk/react-native/README.md
+++ b/packages/sdk/react-native/README.md
@@ -27,7 +27,7 @@ The SDK uses SSE streaming to get flag data and in React Native versions with Fl
 
 Expo also includes network debugging, which interfered with streaming responses before the above patch.
 
-When running with `expo start`, which will run with Expo Go by default, the Expo Go binary includes the native expo code.
+When running with `expo start`, which will run with Expo Go by default, the Expo Go binary includes the native expo code. This is why an Expo Go version which contains the relevant patch must be used.
 
 If older versions of expo and RN are used, then a release build configuration can be used to work around this issue.
 

--- a/packages/sdk/react-native/README.md
+++ b/packages/sdk/react-native/README.md
@@ -17,17 +17,19 @@ For more information, see the [complete reference guide for this SDK](https://do
 
 ## Known Android identify issue
 
-On Android, Flipper interferes with the SDK's streaming connections. As a result the `identify` call never resolves. The long term solution is the removal of Flipper from react-native. The Facebook team are [working on this](https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks#flipper--react-native-integration).
+With Expo versions less than `51.0.21` and React Native versions less than `0.74.3`, the identify operation will not be complete in a debug configuration. If using Expo Go, you must ensure you have version `2.31.2` or greater.
 
-In the meantime, we recommend one of these workarounds:
+This is the expo PR that resolved this issue: https://github.com/expo/expo/pull/30062
 
-- If you are using Expo, you'll need to do a native build in release `expo run:android --variant release`.
+If you are using expo after that release, as well as a React Native version without flipper, then the SDK should be able to identify in debug mode. We specifically tried Expo version `51.0.21 ` with React Native `0.74.3`, but some other patch version combinations may work.
 
-- If you are using Expo and want to debug and hot reload, you'll need to do a native build in debug `expo run:android --variant debug` and then go to the `android` folder and manually find and remove all references to flipper. This is a [reported issue](https://github.com/facebook/flipper/issues/1326#issuecomment-652946496) in the Flipper repo.
+The SDK uses SSE streaming to get flag data and in React Native versions with Flipper, the network capture interferes with HTTP requests that are streamed through HTTP.
 
-- If you are using the expo-go app on Android, unfortunately there is no known easy way to disable Flipper in Expo Go. Please use one of two previous native build options.
+Expo also includes network debugging, which interferes with streaming responses as well.
 
-- If you are not using Expo, go to the `android` folder and manually find and remove all references to flipper.
+When running with `expo start`, which will run with Expo Go by default, the Expo Go binary includes the native expo code.
+
+If older versions of expo and RN are used, then a release build configuration can be used to work around this issue.
 
 ## Install
 

--- a/packages/sdk/react-native/README.md
+++ b/packages/sdk/react-native/README.md
@@ -25,7 +25,7 @@ If you are using expo after that release, as well as a React Native version with
 
 The SDK uses SSE streaming to get flag data and in React Native versions with Flipper, the network capture interferes with HTTP requests that are streamed through HTTP.
 
-Expo also includes network debugging, which interferes with streaming responses as well.
+Expo also includes network debugging, which interfered with streaming responses before the above patch.
 
 When running with `expo start`, which will run with Expo Go by default, the Expo Go binary includes the native expo code.
 

--- a/packages/sdk/react-native/example/README.md
+++ b/packages/sdk/react-native/example/README.md
@@ -19,14 +19,13 @@ MOBILE_KEY=abcdef12456
 4. Run the app:
 
 ```shell
-# Note for android, there's an issue with Flipper interfering with streaming connections
-# so please run the release build. There's no such issues with ios.
-
 # ios
-yarn && yarn ios-go
+yarn && yarn ios
 
 # android
-yarn && yarn android-release
+yarn && yarn android
+
+# Note: If you downgrade the React Native or Expo versions used by this example the android build may not work in debug.
 ```
 
 ## Running Detox e2e tests

--- a/packages/sdk/react-native/example/package.json
+++ b/packages/sdk/react-native/example/package.json
@@ -23,11 +23,10 @@
   "dependencies": {
     "@launchdarkly/react-native-client-sdk": "workspace:^",
     "@react-native-async-storage/async-storage": "^1.21.0",
-    "expo": "~50.0.6",
-    "expo-splash-screen": "~0.26.4",
+    "expo": "51.0.21",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.73.4",
+    "react-native": "0.74.3",
     "react-native-dotenv": "^3.4.9"
   },
   "devDependencies": {


### PR DESCRIPTION
After this PR the example React Native app will work correctly with Android. Most of the PR is documentation.