### PR TITLE
fix: Fix field visibility.

### DIFF
--- a/packages/sdk/react-native/src/RNOptions.ts
+++ b/packages/sdk/react-native/src/RNOptions.ts
@@ -1,0 +1,28 @@
+import { LDOptions } from '@launchdarkly/js-client-sdk-common';
+
+export default interface RNOptions extends LDOptions {
+  /**
+   * Some platforms (windows, web, mac, linux) can continue executing code
+   * in the background.
+   *
+   * Defaults to false.
+   */
+  readonly runInBackground?: boolean;
+
+  /**
+   * Enable handling of network availability. When this is true the
+   * connection state will automatically change when network
+   * availability changes.
+   *
+   * Defaults to true.
+   */
+  readonly automaticNetworkHandling?: boolean;
+
+  /**
+   * Enable handling associated with transitioning between the foreground
+   * and background.
+   *
+   * Defaults to true.
+   */
+  readonly automaticBackgroundHandling?: boolean;
+}

--- a/packages/sdk/react-native/src/ReactNativeLDClient.test.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.test.ts
@@ -1,32 +1,209 @@
-import { AutoEnvAttributes, type LDContext } from '@launchdarkly/js-client-sdk-common';
+import {
+  AutoEnvAttributes,
+  BasicLogger,
+  type LDContext,
+  LDLogger,
+  Response,
+} from '@launchdarkly/js-client-sdk-common';
 
+import createPlatform from './platform';
+import PlatformCrypto from './platform/crypto';
+import PlatformEncoding from './platform/PlatformEncoding';
+import PlatformInfo from './platform/PlatformInfo';
+import PlatformStorage from './platform/PlatformStorage';
 import ReactNativeLDClient from './ReactNativeLDClient';
 
-describe('ReactNativeLDClient', () => {
-  let ldc: ReactNativeLDClient;
+function mockResponse(value: string, statusCode: number) {
+  const response: Response = {
+    headers: {
+      get: jest.fn(),
+      keys: jest.fn(),
+      values: jest.fn(),
+      entries: jest.fn(),
+      has: jest.fn(),
+    },
+    status: statusCode,
+    text: () => Promise.resolve(value),
+    json: () => Promise.resolve(JSON.parse(value)),
+  };
+  return Promise.resolve(response);
+}
 
-  beforeEach(() => {
-    ldc = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, { sendEvents: false });
+/**
+ * Mocks basicPlatform fetch. Returns the fetch jest.Mock object.
+ * @param remoteJson
+ * @param statusCode
+ */
+function mockFetch(value: string, statusCode: number = 200) {
+  const f = jest.fn();
+  f.mockResolvedValue(mockResponse(value, statusCode));
+  return f;
+}
+
+jest.mock('./platform', () => ({
+  __esModule: true,
+  default: jest.fn((logger: LDLogger) => ({
+    crypto: new PlatformCrypto(),
+    info: new PlatformInfo(logger),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: jest.fn(),
+    },
+    encoding: new PlatformEncoding(),
+    storage: new PlatformStorage(logger),
+  })),
+  // default: (logger: LDLogger) => ({
+  //   crypto: new PlatformCrypto(),
+  //   info: new PlatformInfo(logger),
+  //   requests: {
+  //     createEventSource: jest.fn(),
+  //     fetch: jest.fn(),
+  //   },
+  //   encoding: new PlatformEncoding(),
+  //   storage: new PlatformStorage(logger),
+  // }),
+}));
+
+// let ldc: ReactNativeLDClient;
+
+// beforeEach(() => {
+//   ldc = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, { sendEvents: false });
+// });
+
+// test('constructing a new client', () => {
+//   expect(ldc.highTimeoutThreshold).toEqual(15);
+//   expect(ldc.sdkKey).toEqual('mobile-key');
+//   expect(ldc.config.serviceEndpoints).toEqual({
+//     analyticsEventPath: '/mobile',
+//     diagnosticEventPath: '/mobile/events/diagnostic',
+//     events: 'https://events.launchdarkly.com',
+//     includeAuthorizationHeader: true,
+//     polling: 'https://clientsdk.launchdarkly.com',
+//     streaming: 'https://clientstream.launchdarkly.com',
+//   });
+// });
+
+it('uses correct default diagnostic url', () => {
+  const mockedFetch = jest.fn();
+  const logger: LDLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+  (createPlatform as jest.Mock).mockReturnValue({
+    crypto: new PlatformCrypto(),
+    info: new PlatformInfo(logger),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+    },
+    encoding: new PlatformEncoding(),
+    storage: new PlatformStorage(logger),
   });
+  const client = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled);
 
-  test('constructing a new client', () => {
-    expect(ldc.highTimeoutThreshold).toEqual(15);
-    expect(ldc.sdkKey).toEqual('mobile-key');
-    expect(ldc.config.serviceEndpoints).toEqual({
-      analyticsEventPath: '/mobile',
-      diagnosticEventPath: '/mobile/events/diagnostic',
-      events: 'https://events.launchdarkly.com',
-      includeAuthorizationHeader: true,
-      polling: 'https://clientsdk.launchdarkly.com',
-      streaming: 'https://clientstream.launchdarkly.com',
-    });
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/mobile/events/diagnostic',
+    expect.anything(),
+  );
+  client.close();
+});
+
+it('uses correct default analytics event url', async () => {
+  const mockedFetch = jest.fn();
+  const logger: LDLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+  (createPlatform as jest.Mock).mockReturnValue({
+    crypto: new PlatformCrypto(),
+    info: new PlatformInfo(logger),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+    },
+    encoding: new PlatformEncoding(),
+    storage: new PlatformStorage(logger),
   });
-
-  test('createStreamUriPath', () => {
-    const context: LDContext = { kind: 'user', key: 'test-user-key-1' };
-
-    expect(ldc.createStreamUriPath(context)).toEqual(
-      '/meval/eyJraW5kIjoidXNlciIsImtleSI6InRlc3QtdXNlci1rZXktMSJ9',
-    );
+  const client = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, {
+    diagnosticOptOut: true,
   });
+  await client.identify({ kind: 'user', key: 'bob' });
+  await client.flush();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/mobile',
+    expect.anything(),
+  );
+});
+
+it('uses correct default polling url', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  const logger: LDLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+  (createPlatform as jest.Mock).mockReturnValue({
+    crypto: new PlatformCrypto(),
+    info: new PlatformInfo(logger),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+    },
+    encoding: new PlatformEncoding(),
+    storage: new PlatformStorage(logger),
+  });
+  const client = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, {
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'polling',
+    automaticBackgroundHandling: false,
+  });
+  await client.identify({ kind: 'user', key: 'bob' });
+
+  const regex = /https:\/\/clientsdk.launchdarkly.com\/msdk\/evalx\/contexts\/.*/;
+  expect(mockedFetch).toHaveBeenCalledWith(expect.stringMatching(regex), expect.anything());
+});
+
+it('uses correct default streaming url', () => {});
+
+it('includes authorization header', () => {});
+
+it('identify with too high of a timeout', () => {
+  const logger: LDLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+  const client = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, {
+    sendEvents: false,
+    initialConnectionMode: 'offline',
+    logger,
+  });
+  client.identify({ key: 'potato', kind: 'user' }, { timeout: 16 });
+  expect(logger.warn).toHaveBeenCalledWith(
+    'The identify function was called with a timeout greater than 15 seconds. We recommend a timeout of less than 15 seconds.',
+  );
+});
+
+it('identify timeout equal to threshold', () => {
+  const logger: LDLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+  const client = new ReactNativeLDClient('mobile-key', AutoEnvAttributes.Enabled, {
+    sendEvents: false,
+    initialConnectionMode: 'offline',
+    logger,
+  });
+  client.identify({ key: 'potato', kind: 'user' }, { timeout: 15 });
+  expect(logger.warn).not.toHaveBeenCalled();
 });

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -7,11 +7,11 @@ import {
   internal,
   LDClientImpl,
   type LDContext,
-  type LDOptions,
 } from '@launchdarkly/js-client-sdk-common';
 
 import createPlatform from './platform';
 import { ConnectionDestination, ConnectionManager } from './platform/ConnectionManager';
+import LDOptions from './RNOptions';
 import RNStateDetector from './RNStateDetector';
 
 /**
@@ -84,9 +84,10 @@ export default class ReactNativeLDClient extends LDClientImpl {
         initialConnectionMode,
         // TODO: Add the ability to configure connection management.
         // This is not yet added as the RN SDK needs package specific configuration added.
-        automaticNetworkHandling: true,
-        automaticBackgroundHandling: true,
-        runInBackground: false,
+        // TODO: Add RN config option validation beyond base options.
+        automaticNetworkHandling: options.automaticNetworkHandling ?? true,
+        automaticBackgroundHandling: options.automaticBackgroundHandling ?? true,
+        runInBackground: options.runInBackground ?? true,
       },
       destination,
       new RNStateDetector(),

--- a/packages/sdk/react-native/src/index.ts
+++ b/packages/sdk/react-native/src/index.ts
@@ -7,6 +7,7 @@
  */
 import { setupPolyfill } from './polyfills';
 import ReactNativeLDClient from './ReactNativeLDClient';
+import RNOptions from './RNOptions';
 
 setupPolyfill();
 
@@ -14,4 +15,4 @@ export * from '@launchdarkly/js-client-sdk-common';
 
 export * from './hooks';
 export * from './provider';
-export { ReactNativeLDClient };
+export { ReactNativeLDClient, RNOptions as LDOptions };

--- a/packages/sdk/react-native/src/platform/ConnectionManager.ts
+++ b/packages/sdk/react-native/src/platform/ConnectionManager.ts
@@ -52,17 +52,23 @@ export interface ConnectionManagerConfig {
   /// The initial connection mode the SDK should use.
   readonly initialConnectionMode: ConnectionMode;
 
-  /// Some platforms (windows, web, mac, linux) can continue executing code
-  /// in the background.
+  /**
+   * Some platforms (windows, web, mac, linux) can continue executing code
+   * in the background.
+   */
   readonly runInBackground: boolean;
 
-  /// Enable handling of network availability. When this is true the
-  /// connection state will automatically change when network
-  /// availability changes.
+  /**
+   * Enable handling of network availability. When this is true the
+   * connection state will automatically change when network
+   * availability changes.
+   */
   readonly automaticNetworkHandling: boolean;
 
-  /// Enable handling associated with transitioning between the foreground
-  /// and background.
+  /**
+   * Enable handling associated with transitioning between the foreground
+   * and background.
+   */
   readonly automaticBackgroundHandling: boolean;
 }
 

--- a/packages/sdk/react-native/src/platform/PlatformEncoding.ts
+++ b/packages/sdk/react-native/src/platform/PlatformEncoding.ts
@@ -1,0 +1,8 @@
+import type { Encoding } from '@launchdarkly/js-client-sdk-common';
+import { btoa } from '../polyfills';
+
+export default class PlatformEncoding implements Encoding {
+  btoa(data: string): string {
+    return btoa(data);
+  }
+}

--- a/packages/sdk/react-native/src/platform/PlatformEncoding.ts
+++ b/packages/sdk/react-native/src/platform/PlatformEncoding.ts
@@ -1,4 +1,5 @@
 import type { Encoding } from '@launchdarkly/js-client-sdk-common';
+
 import { btoa } from '../polyfills';
 
 export default class PlatformEncoding implements Encoding {

--- a/packages/sdk/react-native/src/platform/PlatformInfo.ts
+++ b/packages/sdk/react-native/src/platform/PlatformInfo.ts
@@ -1,0 +1,30 @@
+import type { Info, LDLogger, PlatformData, SdkData } from '@launchdarkly/js-client-sdk-common';
+
+import { name, version } from '../../package.json';
+import { ldApplication, ldDevice } from './autoEnv';
+
+export default class PlatformInfo implements Info {
+  constructor(private readonly logger: LDLogger) {}
+
+  platformData(): PlatformData {
+    const data = {
+      name: 'React Native',
+      ld_application: ldApplication,
+      ld_device: ldDevice,
+    };
+
+    this.logger.debug(`platformData: ${JSON.stringify(data, null, 2)}`);
+    return data;
+  }
+
+  sdkData(): SdkData {
+    const data = {
+      name,
+      version,
+      userAgentBase: 'ReactNativeClient',
+    };
+
+    this.logger.debug(`sdkData: ${JSON.stringify(data, null, 2)}`);
+    return data;
+  }
+}

--- a/packages/sdk/react-native/src/platform/PlatformRequests.ts
+++ b/packages/sdk/react-native/src/platform/PlatformRequests.ts
@@ -1,0 +1,28 @@
+import type {
+  EventName,
+  EventSource,
+  EventSourceInitDict,
+  LDLogger,
+  Options,
+  Requests,
+  Response,
+} from '@launchdarkly/js-client-sdk-common';
+
+import RNEventSource from '../fromExternal/react-native-sse';
+
+export default class PlatformRequests implements Requests {
+  constructor(private readonly logger: LDLogger) {}
+
+  createEventSource(url: string, eventSourceInitDict: EventSourceInitDict): EventSource {
+    return new RNEventSource<EventName>(url, {
+      headers: eventSourceInitDict.headers,
+      retryAndHandleError: eventSourceInitDict.errorFilter,
+      logger: this.logger,
+    });
+  }
+
+  fetch(url: string, options?: Options): Promise<Response> {
+    // @ts-ignore
+    return fetch(url, options);
+  }
+}

--- a/packages/sdk/react-native/src/platform/PlatformStorage.ts
+++ b/packages/sdk/react-native/src/platform/PlatformStorage.ts
@@ -1,0 +1,33 @@
+import type {
+  LDLogger,
+  Storage,
+} from '@launchdarkly/js-client-sdk-common';
+
+import AsyncStorage from './ConditionalAsyncStorage';
+
+
+
+export default class PlatformStorage implements Storage {
+  constructor(private readonly logger: LDLogger) {}
+  async clear(key: string): Promise<void> {
+    await AsyncStorage.removeItem(key);
+  }
+
+  async get(key: string): Promise<string | null> {
+    try {
+      const value = await AsyncStorage.getItem(key);
+      return value ?? null;
+    } catch (error) {
+      this.logger.debug(`Error getting AsyncStorage key: ${key}, error: ${error}`);
+      return null;
+    }
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    try {
+      await AsyncStorage.setItem(key, value);
+    } catch (error) {
+      this.logger.debug(`Error saving AsyncStorage key: ${key}, value: ${value}, error: ${error}`);
+    }
+  }
+}

--- a/packages/sdk/react-native/src/platform/PlatformStorage.ts
+++ b/packages/sdk/react-native/src/platform/PlatformStorage.ts
@@ -1,11 +1,6 @@
-import type {
-  LDLogger,
-  Storage,
-} from '@launchdarkly/js-client-sdk-common';
+import type { LDLogger, Storage } from '@launchdarkly/js-client-sdk-common';
 
 import AsyncStorage from './ConditionalAsyncStorage';
-
-
 
 export default class PlatformStorage implements Storage {
   constructor(private readonly logger: LDLogger) {}

--- a/packages/sdk/react-native/src/platform/index.ts
+++ b/packages/sdk/react-native/src/platform/index.ts
@@ -1,100 +1,10 @@
-/* eslint-disable max-classes-per-file */
-import type {
-  Encoding,
-  EventName,
-  EventSource,
-  EventSourceInitDict,
-  Info,
-  LDLogger,
-  Options,
-  Platform,
-  PlatformData,
-  Requests,
-  Response,
-  SdkData,
-  Storage,
-} from '@launchdarkly/js-client-sdk-common';
+import { LDLogger, Platform } from '@launchdarkly/js-client-sdk-common';
 
-import { name, version } from '../../package.json';
-import RNEventSource from '../fromExternal/react-native-sse';
-import { btoa } from '../polyfills';
-import { ldApplication, ldDevice } from './autoEnv';
-import AsyncStorage from './ConditionalAsyncStorage';
 import PlatformCrypto from './crypto';
-
-export class PlatformRequests implements Requests {
-  constructor(private readonly logger: LDLogger) {}
-
-  createEventSource(url: string, eventSourceInitDict: EventSourceInitDict): EventSource {
-    return new RNEventSource<EventName>(url, {
-      headers: eventSourceInitDict.headers,
-      retryAndHandleError: eventSourceInitDict.errorFilter,
-      logger: this.logger,
-    });
-  }
-
-  fetch(url: string, options?: Options): Promise<Response> {
-    // @ts-ignore
-    return fetch(url, options);
-  }
-}
-
-class PlatformEncoding implements Encoding {
-  btoa(data: string): string {
-    return btoa(data);
-  }
-}
-
-class PlatformInfo implements Info {
-  constructor(private readonly logger: LDLogger) {}
-
-  platformData(): PlatformData {
-    const data = {
-      name: 'React Native',
-      ld_application: ldApplication,
-      ld_device: ldDevice,
-    };
-
-    this.logger.debug(`platformData: ${JSON.stringify(data, null, 2)}`);
-    return data;
-  }
-
-  sdkData(): SdkData {
-    const data = {
-      name,
-      version,
-      userAgentBase: 'ReactNativeClient',
-    };
-
-    this.logger.debug(`sdkData: ${JSON.stringify(data, null, 2)}`);
-    return data;
-  }
-}
-
-class PlatformStorage implements Storage {
-  constructor(private readonly logger: LDLogger) {}
-  async clear(key: string): Promise<void> {
-    await AsyncStorage.removeItem(key);
-  }
-
-  async get(key: string): Promise<string | null> {
-    try {
-      const value = await AsyncStorage.getItem(key);
-      return value ?? null;
-    } catch (error) {
-      this.logger.debug(`Error getting AsyncStorage key: ${key}, error: ${error}`);
-      return null;
-    }
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    try {
-      await AsyncStorage.setItem(key, value);
-    } catch (error) {
-      this.logger.debug(`Error saving AsyncStorage key: ${key}, value: ${value}, error: ${error}`);
-    }
-  }
-}
+import PlatformEncoding from './PlatformEncoding';
+import PlatformInfo from './PlatformInfo';
+import PlatformRequests from './PlatformRequests';
+import PlatformStorage from './PlatformStorage';
 
 const createPlatform = (logger: LDLogger): Platform => ({
   crypto: new PlatformCrypto(),

--- a/packages/shared/sdk-client/src/LDClientImpl.events.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.events.test.ts
@@ -1,11 +1,17 @@
-import { AutoEnvAttributes, ClientContext, clone, internal, LDContext, subsystem } from '@launchdarkly/js-sdk-common';
+import {
+  AutoEnvAttributes,
+  ClientContext,
+  clone,
+  internal,
+  LDContext,
+  subsystem,
+} from '@launchdarkly/js-sdk-common';
 import { InputCustomEvent, InputIdentifyEvent } from '@launchdarkly/js-sdk-common/dist/internal';
 import {
   basicPlatform,
   hasher,
   logger,
   MockEventProcessor,
-  setupMockEventProcessor,
   setupMockStreamingProcessor,
 } from '@launchdarkly/private-js-mocks';
 

--- a/packages/shared/sdk-client/src/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.test.ts
@@ -65,40 +65,6 @@ describe('sdk-client object', () => {
     jest.resetAllMocks();
   });
 
-  test('instantiate with blank options', () => {
-    ldc = new LDClientImpl(testSdkKey, AutoEnvAttributes.Enabled, basicPlatform, {});
-
-    expect(ldc.config).toMatchObject({
-      allAttributesPrivate: false,
-      baseUri: 'https://clientsdk.launchdarkly.com',
-      capacity: 100,
-      diagnosticOptOut: false,
-      diagnosticRecordingInterval: 900,
-      eventsUri: 'https://events.launchdarkly.com',
-      flushInterval: 30,
-      inspectors: [],
-      logger: {
-        destination: expect.any(Function),
-        formatter: expect.any(Function),
-        logLevel: 1,
-        name: 'LaunchDarkly',
-      },
-      privateAttributes: [],
-      sendEvents: true,
-      sendLDHeaders: true,
-      serviceEndpoints: {
-        events: 'https://events.launchdarkly.com',
-        polling: 'https://clientsdk.launchdarkly.com',
-        streaming: 'https://clientstream.launchdarkly.com',
-      },
-      streamInitialReconnectDelay: 1,
-      streamUri: 'https://clientstream.launchdarkly.com',
-      tags: {},
-      useReport: false,
-      withReasons: false,
-    });
-  });
-
   test('all flags', async () => {
     await ldc.identify(context);
     const all = ldc.allFlags();

--- a/packages/shared/sdk-client/src/LDClientImpl.timeout.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.timeout.test.ts
@@ -26,6 +26,8 @@ const carContext: LDContext = { kind: 'car', key: 'test-car' };
 let ldc: LDClientImpl;
 let defaultPutResponse: Flags;
 
+const DEFAULT_IDENTIFY_TIMEOUT = 5;
+
 describe('sdk-client identify timeout', () => {
   beforeAll(() => {
     jest.useFakeTimers();
@@ -52,7 +54,7 @@ describe('sdk-client identify timeout', () => {
 
   // streaming is setup to error in beforeEach to cause a timeout
   test('rejects with default timeout of 5s', async () => {
-    jest.advanceTimersByTimeAsync(ldc.identifyTimeout * 1000).then();
+    jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT * 1000).then();
     await expect(ldc.identify(carContext)).rejects.toThrow(/identify timed out/);
     expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/identify timed out/));
   });
@@ -66,7 +68,7 @@ describe('sdk-client identify timeout', () => {
 
   test('resolves with default timeout', async () => {
     setupMockStreamingProcessor(false, defaultPutResponse);
-    jest.advanceTimersByTimeAsync(ldc.identifyTimeout * 1000).then();
+    jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT * 1000).then();
 
     await expect(ldc.identify(carContext)).resolves.toBeUndefined();
 
@@ -120,7 +122,6 @@ describe('sdk-client identify timeout', () => {
     jest.advanceTimersByTimeAsync(customTimeout * 1000).then();
     await ldc.identify(carContext, { timeout: customTimeout });
 
-    expect(ldc.identifyTimeout).toEqual(10);
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringMatching(/timeout greater/));
   });
 
@@ -135,12 +136,10 @@ describe('sdk-client identify timeout', () => {
   });
 
   test('safe timeout should not warn', async () => {
-    const { identifyTimeout } = ldc;
-    const safeTimeout = identifyTimeout;
     setupMockStreamingProcessor(false, defaultPutResponse);
-    jest.advanceTimersByTimeAsync(identifyTimeout * 1000).then();
+    jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT * 1000).then();
 
-    await ldc.identify(carContext, { timeout: safeTimeout });
+    await ldc.identify(carContext, { timeout: DEFAULT_IDENTIFY_TIMEOUT });
 
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringMatching(/timeout greater/));
   });

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -307,7 +307,6 @@ export default class LDClientImpl implements LDClient {
       this.identifyTimeout = identifyOptions.timeout;
     }
 
-    console.log("A!!!!!!");
     if (this.identifyTimeout > this.highTimeoutThreshold) {
       this.logger.warn(
         'The identify function was called with a timeout greater than ' +
@@ -316,7 +315,6 @@ export default class LDClientImpl implements LDClient {
       );
     }
 
-    console.log("B!!!!!!");
     let context = await ensureKey(pristineContext, this.platform);
 
     if (this.autoEnvAttributes === AutoEnvAttributes.Enabled) {
@@ -329,7 +327,6 @@ export default class LDClientImpl implements LDClient {
       this.emitter.emit('error', context, error);
       return Promise.reject(error);
     }
-    console.log("C!!!!!!");
 
     this.eventProcessor?.sendEvent(this.eventFactoryDefault.identifyEvent(checkedContext));
     const { identifyPromise, identifyResolve, identifyReject } = this.createIdentifyPromise(
@@ -343,9 +340,7 @@ export default class LDClientImpl implements LDClient {
       this.onIdentifyResolve(identifyResolve, flagsStorage, context, 'identify storage');
     }
 
-    console.log("D!!!!!!");
     if (this.isOffline()) {
-      console.log("E!!!!!!");
       if (flagsStorage) {
         this.logger.debug('Offline identify using storage flags.');
       } else {
@@ -356,7 +351,6 @@ export default class LDClientImpl implements LDClient {
       }
     } else {
       this.updateProcessor?.close();
-      console.log("F!!!!!!", this.getConnectionMode());
       switch (this.getConnectionMode()) {
         case 'streaming':
           this.createStreamingProcessor(context, checkedContext, identifyResolve, identifyReject);
@@ -367,7 +361,6 @@ export default class LDClientImpl implements LDClient {
         default:
           break;
       }
-      console.log("G!!!!!!");
       this.updateProcessor!.start();
     }
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -307,14 +307,16 @@ export default class LDClientImpl implements LDClient {
       this.identifyTimeout = identifyOptions.timeout;
     }
 
+    console.log("A!!!!!!");
     if (this.identifyTimeout > this.highTimeoutThreshold) {
       this.logger.warn(
-        'The identify function was called with a timeout greater than' +
-          `${this.highTimeoutThreshold} seconds. We recommend a timeout of less than` +
+        'The identify function was called with a timeout greater than ' +
+          `${this.highTimeoutThreshold} seconds. We recommend a timeout of less than ` +
           `${this.highTimeoutThreshold} seconds.`,
       );
     }
 
+    console.log("B!!!!!!");
     let context = await ensureKey(pristineContext, this.platform);
 
     if (this.autoEnvAttributes === AutoEnvAttributes.Enabled) {
@@ -327,6 +329,7 @@ export default class LDClientImpl implements LDClient {
       this.emitter.emit('error', context, error);
       return Promise.reject(error);
     }
+    console.log("C!!!!!!");
 
     this.eventProcessor?.sendEvent(this.eventFactoryDefault.identifyEvent(checkedContext));
     const { identifyPromise, identifyResolve, identifyReject } = this.createIdentifyPromise(
@@ -340,7 +343,9 @@ export default class LDClientImpl implements LDClient {
       this.onIdentifyResolve(identifyResolve, flagsStorage, context, 'identify storage');
     }
 
+    console.log("D!!!!!!");
     if (this.isOffline()) {
+      console.log("E!!!!!!");
       if (flagsStorage) {
         this.logger.debug('Offline identify using storage flags.');
       } else {
@@ -351,7 +356,7 @@ export default class LDClientImpl implements LDClient {
       }
     } else {
       this.updateProcessor?.close();
-
+      console.log("F!!!!!!", this.getConnectionMode());
       switch (this.getConnectionMode()) {
         case 'streaming':
           this.createStreamingProcessor(context, checkedContext, identifyResolve, identifyReject);
@@ -362,6 +367,7 @@ export default class LDClientImpl implements LDClient {
         default:
           break;
       }
+      console.log("G!!!!!!");
       this.updateProcessor!.start();
     }
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -34,15 +34,15 @@ const { createErrorEvaluationDetail, createSuccessEvaluationDetail, ClientMessag
   internal;
 
 export default class LDClientImpl implements LDClient {
-  config: Configuration;
-  context?: LDContext;
-  diagnosticsManager?: internal.DiagnosticsManager;
-  eventProcessor?: internal.EventProcessor;
-  identifyTimeout: number = 5;
-  logger: LDLogger;
-  updateProcessor?: LDStreamProcessor;
+  private readonly config: Configuration;
+  private context?: LDContext;
+  private readonly diagnosticsManager?: internal.DiagnosticsManager;
+  private eventProcessor?: internal.EventProcessor;
+  private identifyTimeout: number = 5;
+  readonly logger: LDLogger;
+  private updateProcessor?: LDStreamProcessor;
 
-  readonly highTimeoutThreshold: number = 15;
+  private readonly highTimeoutThreshold: number = 15;
 
   private eventFactoryDefault = new EventFactory(false);
   private eventFactoryWithReasons = new EventFactory(true);

--- a/packages/shared/sdk-client/src/LDClientImpl.variation.test.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.variation.test.ts
@@ -50,8 +50,7 @@ describe('sdk-client object', () => {
   });
 
   test('variation flag not found', async () => {
-    // set context manually to pass validation
-    ldc.context = { kind: 'user', key: 'test-user' };
+    await ldc.identify({ kind: 'user', key: 'test-user' });
     const errorListener = jest.fn().mockName('errorListener');
     ldc.on('error', errorListener);
 

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -167,7 +167,7 @@ export interface LDClient {
    *
    * @returns The configured {@link LDLogger}.
    */
-  logger: LDLogger;
+  readonly logger: LDLogger;
 
   /**
    * Determines the numeric variation of a feature flag.


### PR DESCRIPTION
This fixes the field visibility on a number of what should have been private or readonly fields.

This is technically a breaking change because the implementation types were exposed, but they are not part of the interface.

One attribute that is in the interface is the logger, and it has been marked as readonly now, which is also a breaking change.

Setting or manipulating any of these fields would have resulted in potentially inconsistent internal state.