### PR TITLE
chore: adding max contexts validator

### DIFF
--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -89,4 +89,12 @@ describe('Configuration', () => {
       expect.stringMatching(/should be of type LDFlagSet, got string/i),
     );
   });
+
+  test('recognize max cached contexts', () => {
+    // @ts-ignore
+    const config = new Configuration({ maxCachedContexts: 3 });
+
+    expect(config.maxCachedContexts).toBeDefined();
+    expect(console.error).not.toHaveBeenCalled();
+  });
 });

--- a/packages/shared/sdk-client/src/configuration/Configuration.test.ts
+++ b/packages/shared/sdk-client/src/configuration/Configuration.test.ts
@@ -26,6 +26,7 @@ describe('Configuration', () => {
         logLevel: 1,
         name: 'LaunchDarkly',
       },
+      maxCachedContexts: 5,
       privateAttributes: [],
       sendEvents: true,
       sendLDHeaders: true,
@@ -69,7 +70,7 @@ describe('Configuration', () => {
     );
   });
 
-  test('enforce minimum', () => {
+  test('enforce minimum flushInterval', () => {
     const config = new Configuration({ flushInterval: 1 });
 
     expect(config.flushInterval).toEqual(2);
@@ -90,11 +91,20 @@ describe('Configuration', () => {
     );
   });
 
-  test('recognize max cached contexts', () => {
-    // @ts-ignore
+  test('recognize maxCachedContexts', () => {
     const config = new Configuration({ maxCachedContexts: 3 });
 
     expect(config.maxCachedContexts).toBeDefined();
     expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test('enforce minimum maxCachedContext', () => {
+    const config = new Configuration({ maxCachedContexts: -1 });
+
+    expect(config.maxCachedContexts).toBeDefined();
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('had invalid value of -1'),
+    );
   });
 });

--- a/packages/shared/sdk-client/src/configuration/validators.ts
+++ b/packages/shared/sdk-client/src/configuration/validators.ts
@@ -27,6 +27,7 @@ class ConnectionModeValidator implements TypeValidator {
 const validators: Record<keyof LDOptions, TypeValidator> = {
   initialConnectionMode: new ConnectionModeValidator(),
   logger: TypeValidators.Object,
+  maxCachedContexts: TypeValidators.Number,
 
   baseUri: TypeValidators.String,
   streamUri: TypeValidators.String,

--- a/packages/shared/sdk-client/src/configuration/validators.ts
+++ b/packages/shared/sdk-client/src/configuration/validators.ts
@@ -27,7 +27,7 @@ class ConnectionModeValidator implements TypeValidator {
 const validators: Record<keyof LDOptions, TypeValidator> = {
   initialConnectionMode: new ConnectionModeValidator(),
   logger: TypeValidators.Object,
-  maxCachedContexts: TypeValidators.Number,
+  maxCachedContexts: TypeValidators.numberWithMin(0),
 
   baseUri: TypeValidators.String,
   streamUri: TypeValidators.String,


### PR DESCRIPTION
**Additional context**

Forgot to add the max cached context to the validator and realized when bench testing.
