### PR TITLE
build(deps): Update react-native example to newer expo and react-native.

### DIFF
--- a/packages/sdk/react-native/example/package.json
+++ b/packages/sdk/react-native/example/package.json
@@ -26,7 +26,7 @@
     "expo": "51.0.28",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.75.0",
+    "react-native": "0.74.5",
     "react-native-dotenv": "^3.4.9"
   },
   "devDependencies": {

--- a/packages/sdk/react-native/example/package.json
+++ b/packages/sdk/react-native/example/package.json
@@ -23,10 +23,10 @@
   "dependencies": {
     "@launchdarkly/react-native-client-sdk": "workspace:^",
     "@react-native-async-storage/async-storage": "^1.21.0",
-    "expo": "51.0.21",
+    "expo": "51.0.28",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.74.3",
+    "react-native": "0.75.0",
     "react-native-dotenv": "^3.4.9"
   },
   "devDependencies": {


### PR DESCRIPTION
There have been some changes to expo that cause the current versions to fail. (Even though the versions in the package.json did not change.)

Related expo issue: https://github.com/expo/expo/issues/31005