### PR TITLE
feat: Make timeout optional in LDIdentifyOptions.

### DIFF
--- a/packages/shared/sdk-client/src/api/LDIdentifyOptions.ts
+++ b/packages/shared/sdk-client/src/api/LDIdentifyOptions.ts
@@ -7,7 +7,7 @@ export interface LDIdentifyOptions {
    *
    * Defaults to 5 seconds.
    */
-  timeout: number;
+  timeout?: number;
 
   /**
    * When true indicates that the SDK will attempt to wait for values from


### PR DESCRIPTION
In the strictest sense this would be a breaking change, but in the practical I think it is not likely to be.

The way this would be breaking is if someone was using this for something other than just passing to the identify function. This would be somewhat unusual.

Example:
```
interface MyOptions: {
  timeout: number;
}

let myOptions: MyOptions = someLdIdentifyOptions;
```

For standard usage this will not be breaking. 

I am tagging this as a feat instead of a fix to prevent any breakage for someone floating patches and also doing unusual things with the type.