### PR TITLE
chore: Apply linting to root of project.

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -5,10 +5,7 @@
       "name": "Akamai SDK",
       "type": "edge",
       "path": "packages/sdk/akamai-base",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "akamai-server-base-sdk-"
       }
@@ -17,10 +14,7 @@
       "name": "Akamai SDK for EdgeKV",
       "type": "edge",
       "path": "packages/sdk/akamai-edgekv",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "akamai-server-edgekv-sdk-"
       }
@@ -29,10 +23,7 @@
       "name": "Cloudflare SDK",
       "type": "edge",
       "path": "packages/sdk/cloudflare",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "cloudflare-server-sdk-"
       }
@@ -41,10 +32,7 @@
       "name": "React Native SDK",
       "type": "client-side",
       "path": "packages/sdk/react-native",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "react-native-client-sdk-"
       }
@@ -53,10 +41,7 @@
       "name": "Node.js Server SDK",
       "type": "server-side",
       "path": "packages/sdk/server-node",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "node-server-sdk-"
       }
@@ -65,10 +50,7 @@
       "name": "Vercel Edge SDK",
       "type": "edge",
       "path": "packages/sdk/vercel",
-      "languages": [
-        "JavaScript",
-        "TypeScript"
-      ],
+      "languages": ["JavaScript", "TypeScript"],
       "releases": {
         "tag-prefix": "vercel-server-sdk-"
       }

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -2,6 +2,6 @@
 
 LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
-As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance attestations about our SDK package builds to npm for distribution alongside our packages. 
+As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance attestations about our SDK package builds to npm for distribution alongside our packages.
 
-For npm packages that are published with provenance, npm automatically [verifies the authenticity of the package using Sigstore](https://docs.npmjs.com/generating-provenance-statements#about-npm-provenance). 
+For npm packages that are published with provenance, npm automatically [verifies the authenticity of the package using Sigstore](https://docs.npmjs.com/generating-provenance-statements#about-npm-provenance).

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/node-server-sdk-redis](packages/store/node-server-sdk-redis/README.md)       | [![NPM][node-redis-npm-badge]][node-redis-npm-link]       | [Node Redis][node-redis-issues]       | [![Actions Status][node-redis-ci-badge]][node-redis-ci]       |
 | [@launchdarkly/node-server-sdk-dynamodb](packages/store/node-server-sdk-dynamodb/README.md) | [![NPM][node-dynamodb-npm-badge]][node-dynamodb-npm-link] | [Node DynamoDB][node-dynamodb-issues] | [![Actions Status][node-dynamodb-ci-badge]][node-dynamodb-ci] |
 
-| Telemetry Packages                                                                          | npm                                                       | issues                                | tests                                                         |
-| ------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------- |
-| [@launchdarkly/node-server-sdk-otel](packages/telemetry/node-server-sdk-otel/README.md)     | [![NPM][node-otel-npm-badge]][node-otel-npm-link]         | [Node OTel][node-otel-issues]         | [![Actions Status][node-otel-ci-badge]][node-otel-ci]         |
+| Telemetry Packages                                                                      | npm                                               | issues                        | tests                                                 |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------- | ----------------------------- | ----------------------------------------------------- |
+| [@launchdarkly/node-server-sdk-otel](packages/telemetry/node-server-sdk-otel/README.md) | [![NPM][node-otel-npm-badge]][node-otel-npm-link] | [Node OTel][node-otel-issues] | [![Actions Status][node-otel-ci-badge]][node-otel-ci] |
 
 ## Organization
 
@@ -62,7 +62,7 @@ We encourage pull requests and other contributions from the community. Check out
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/contract-tests/TestHook.js
+++ b/contract-tests/TestHook.js
@@ -24,7 +24,7 @@ export default class TestHook {
   }
 
   beforeEvaluation(hookContext, data) {
-    if(this._errors?.beforeEvaluation) {
+    if (this._errors?.beforeEvaluation) {
       throw new Error(this._errors.beforeEvaluation);
     }
     this._safePost({
@@ -36,7 +36,7 @@ export default class TestHook {
   }
 
   afterEvaluation(hookContext, data, detail) {
-    if(this._errors?.afterEvaluation) {
+    if (this._errors?.afterEvaluation) {
       throw new Error(this._errors.afterEvaluation);
     }
     this._safePost({
@@ -45,7 +45,6 @@ export default class TestHook {
       stage: 'afterEvaluation',
       evaluationDetail: detail,
     });
-
 
     return { ...data, ...(this._data?.['afterEvaluation'] || {}) };
   }

--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -35,7 +35,7 @@ app.get('/', (req, res) => {
       'inline-context',
       'anonymous-redaction',
       'evaluation-hooks',
-      'wrapper'
+      'wrapper',
     ],
   });
 });

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -68,10 +68,10 @@ export function makeSdkConfig(options, tag) {
     );
   }
   if (options.wrapper) {
-    if(options.wrapper.name) {
+    if (options.wrapper.name) {
       cf.wrapperName = options.wrapper.name;
     }
-    if(options.wrapper.version) {
+    if (options.wrapper.version) {
       cf.wrapperVersion = options.wrapper.version;
     }
   }
@@ -117,7 +117,7 @@ export async function newSdkClientEntity(options) {
     makeSdkConfig(options.configuration, options.tag),
   );
   try {
-    await client.waitForInitialization({timeout: timeout});
+    await client.waitForInitialization({ timeout: timeout });
   } catch (_) {
     // if waitForInitialization() rejects, the client failed to initialize, see next line
   }

--- a/packages/sdk/akamai-base/README.md
+++ b/packages/sdk/akamai-base/README.md
@@ -32,7 +32,7 @@ yarn test
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -40,7 +40,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/sdk/akamai-edgekv/README.md
+++ b/packages/sdk/akamai-edgekv/README.md
@@ -32,7 +32,7 @@ yarn test
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -40,7 +40,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/sdk/cloudflare/README.md
+++ b/packages/sdk/cloudflare/README.md
@@ -72,7 +72,7 @@ yarn test
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -80,7 +80,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/sdk/cloudflare/example/README.md
+++ b/packages/sdk/cloudflare/example/README.md
@@ -40,8 +40,8 @@ npx wrangler kv:key get --binding=LD_KV "LD-Env-test-client-side-id" --preview
 5. Edit [index.ts](https://github.com/launchdarkly/js-core/blob/main/packages/sdk/cloudflare/example/src/index.ts#L6) to use your clientSideID and a valid flag key from the test data you just inserted.
 
 ```ts
-    const clientSideID = 'test-client-side-id';
-    const flagKey = 'test-boolean-flag';
+const clientSideID = 'test-client-side-id';
+const flagKey = 'test-boolean-flag';
 ```
 
 6. Finally:

--- a/packages/sdk/cloudflare/jsr.json
+++ b/packages/sdk/cloudflare/jsr.json
@@ -3,15 +3,7 @@
   "version": "2.5.11",
   "exports": "./src/index.ts",
   "publish": {
-    "include": [
-      "LICENSE",
-      "README.md",
-      "package.json",
-      "jsr.json",
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "src/**/*.test.ts"
-    ]
+    "include": ["LICENSE", "README.md", "package.json", "jsr.json", "src/**/*.ts"],
+    "exclude": ["src/**/*.test.ts"]
   }
 }

--- a/packages/sdk/react-native/example/src/welcome.tsx
+++ b/packages/sdk/react-native/example/src/welcome.tsx
@@ -16,7 +16,6 @@ export default function Welcome() {
       .catch((e: any) => console.error(`error identifying ${userKey}: ${e}`));
   };
 
-
   const setConnectionMode = (m: ConnectionMode) => {
     ldc.setConnectionMode(m);
   };
@@ -51,7 +50,10 @@ export default function Welcome() {
         testID="flagKey"
       />
       <View style={styles.connectionModeContainer}>
-        <TouchableOpacity style={styles.buttonContainer} onPress={() => setConnectionMode('offline')}>
+        <TouchableOpacity
+          style={styles.buttonContainer}
+          onPress={() => setConnectionMode('offline')}
+        >
           <Text style={styles.buttonText}>Set offline</Text>
         </TouchableOpacity>
         <TouchableOpacity

--- a/packages/sdk/react-native/example/tsconfig.json
+++ b/packages/sdk/react-native/example/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "strict": true,
-    "typeRoots": ["./types"],
+    "typeRoots": ["./types"]
   },
-  "exclude": ["e2e"],
+  "exclude": ["e2e"]
 }

--- a/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.test.ts
+++ b/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.test.ts
@@ -24,14 +24,14 @@ describe('EventSource', () => {
       .mockImplementationOnce(() => 0.888)
       .mockImplementationOnce(() => 0.999);
 
-      mockXhr = {
-        open: jest.fn(),
-        send: jest.fn(),
-        setRequestHeader: jest.fn(),
-        abort: jest.fn(),
-      };
+    mockXhr = {
+      open: jest.fn(),
+      send: jest.fn(),
+      setRequestHeader: jest.fn(),
+      abort: jest.fn(),
+    };
 
-      jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => mockXhr as XMLHttpRequest);
+    jest.spyOn(window, 'XMLHttpRequest').mockImplementation(() => mockXhr as XMLHttpRequest);
 
     eventSource = new EventSource<EventName>(uri, { logger });
     eventSource.onclose = jest.fn();
@@ -84,7 +84,9 @@ describe('EventSource', () => {
   test('initial connection', () => {
     jest.runAllTimers();
 
-    expect(logger.debug).toHaveBeenCalledWith(expect.stringMatching(/\[EventSource\] opening new connection./));
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(/\[EventSource\] opening new connection./),
+    );
     expect(mockXhr.open).toHaveBeenCalledTimes(1);
     expect(eventSource.onclose).toHaveBeenCalledTimes(0);
   });

--- a/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.ts
+++ b/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.ts
@@ -91,7 +91,7 @@ export default class EventSource<E extends string = never> {
   private tryConnect(initialConnection: boolean = false) {
     let delay = initialConnection ? 0 : this.getNextRetryDelay();
     if (initialConnection) {
-      this.logger?.debug(`[EventSource] opening new connection.`)
+      this.logger?.debug(`[EventSource] opening new connection.`);
     } else {
       this.logger?.debug(`[EventSource] Will open new connection in ${delay} ms.`);
       this.dispatch('retry', { type: 'retry', delayMillis: delay });
@@ -138,7 +138,8 @@ export default class EventSource<E extends string = never> {
         }
 
         this.logger?.debug(
-          `[EventSource][onreadystatechange] ReadyState: ${XMLReadyStateMap[this.xhr.readyState] || 'Unknown'
+          `[EventSource][onreadystatechange] ReadyState: ${
+            XMLReadyStateMap[this.xhr.readyState] || 'Unknown'
           }(${this.xhr.readyState}), status: ${this.xhr.status}`,
         );
 
@@ -349,8 +350,8 @@ export default class EventSource<E extends string = never> {
     return this.status;
   }
 
-  onopen() { }
-  onclose() { }
-  onerror(_err: any) { }
-  onretrying(_e: any) { }
+  onopen() {}
+  onclose() {}
+  onerror(_err: any) {}
+  onretrying(_e: any) {}
 }

--- a/packages/sdk/server-node/README.md
+++ b/packages/sdk/server-node/README.md
@@ -38,7 +38,7 @@ We encourage pull requests and other contributions from the community. Check out
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -46,7 +46,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/sdk/vercel/README.md
+++ b/packages/sdk/vercel/README.md
@@ -49,13 +49,13 @@ const flagValue = await ldClient.variation('my-flag', ldContext, true);
 
 To learn more, see the [examples](examples/README.md) in this repository or head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/server-side/vercel).
 
-
 > **⚠️ experimental**
-> 
-> This SDK has experimental support for sending analytic events to LaunchDarkly. It can be enabled by setting `sendEvents` to `true` in the SDK options. 
->```typescript
->    const client = initLD(sdkKey, env.LD_KV, {sendEvents: true});
->```
+>
+> This SDK has experimental support for sending analytic events to LaunchDarkly. It can be enabled by setting `sendEvents` to `true` in the SDK options.
+>
+> ```typescript
+> const client = initLD(sdkKey, env.LD_KV, { sendEvents: true });
+> ```
 
 ## Developing this SDK
 
@@ -68,7 +68,7 @@ yarn test
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -76,7 +76,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/akamai-edgeworker-sdk/README.md
+++ b/packages/shared/akamai-edgeworker-sdk/README.md
@@ -12,7 +12,7 @@ See [Contributing](../CONTRIBUTING.md).
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/common/README.md
+++ b/packages/shared/common/README.md
@@ -12,7 +12,7 @@ See [Contributing](../CONTRIBUTING.md).
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -20,7 +20,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/mocks/README.md
+++ b/packages/shared/mocks/README.md
@@ -118,7 +118,7 @@ See [Contributing](../shared/CONTRIBUTING.md).
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/mocks/src/platform.ts
+++ b/packages/shared/mocks/src/platform.ts
@@ -1,10 +1,6 @@
-import type { Encoding, Platform, PlatformData, Requests, SdkData, Storage } from '@common';
+import type { PlatformData, SdkData } from '@common';
 
 import { setupCrypto } from './crypto';
-
-const encoding: Encoding = {
-  btoa: (s: string) => Buffer.from(s).toString('base64'),
-};
 
 const setupInfo = () => ({
   platformData: jest.fn(

--- a/packages/shared/sdk-client/README.md
+++ b/packages/shared/sdk-client/README.md
@@ -19,7 +19,7 @@ See [Contributing](../CONTRIBUTING.md).
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/sdk-server-edge/README.md
+++ b/packages/shared/sdk-server-edge/README.md
@@ -12,7 +12,7 @@ See [Contributing](../CONTRIBUTING.md).
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -20,7 +20,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/sdk-server/README.md
+++ b/packages/shared/sdk-server/README.md
@@ -12,7 +12,7 @@ See [Contributing](../CONTRIBUTING.md).
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -20,7 +20,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/shared/sdk-server/jest.config.js
+++ b/packages/shared/sdk-server/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   testMatch: ['**/*.test.ts?(x)'],
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  collectCoverageFrom: ['src/**/*.ts']
+  collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/store/node-server-sdk-dynamodb/README.md
+++ b/packages/store/node-server-sdk-dynamodb/README.md
@@ -93,7 +93,7 @@ We encourage pull requests and other contributions from the community. Check out
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -101,7 +101,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/store/node-server-sdk-redis/README.md
+++ b/packages/store/node-server-sdk-redis/README.md
@@ -68,7 +68,7 @@ We encourage pull requests and other contributions from the community. Check out
 
 ## Verifying SDK build provenance with the SLSA framework
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md). 
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 ## About LaunchDarkly
 
@@ -76,7 +76,7 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
   - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
   - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
-  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). 
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan).
   - Disable parts of your application to facilitate maintenance, without taking everything offline.
 - LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 - Explore LaunchDarkly

--- a/packages/telemetry/node-server-sdk-otel/README.md
+++ b/packages/telemetry/node-server-sdk-otel/README.md
@@ -41,7 +41,7 @@ import { TracingHook } from '@launchdarkly/node-server-sdk-otel';
 ```typescript
 import { init } from '@launchdarkly/node-server-sdk';
 
-const client = init('YOUR SDK KEY', {hooks: [new TracingHook()]});
+const client = init('YOUR SDK KEY', { hooks: [new TracingHook()] });
 ```
 
 ## Contributing

--- a/packages/telemetry/node-server-sdk-otel/jest.config.js
+++ b/packages/telemetry/node-server-sdk-otel/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   testMatch: ['**/*.test.ts?(x)'],
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  collectCoverageFrom: ['src/**/*.ts']
+  collectCoverageFrom: ['src/**/*.ts'],
 };

--- a/packages/telemetry/node-server-sdk-otel/tsconfig.json
+++ b/packages/telemetry/node-server-sdk-otel/tsconfig.json
@@ -12,7 +12,7 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source
-    "stripInternal": true,
+    "stripInternal": true
   },
   "include": ["src"],
   "exclude": ["**/*.test.ts", "dist", "node_modules", "__tests__"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,10 @@
 {
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "packageRules": [
     {
       "enabled": false,
       "matchDatasources": ["npm"],
-      "matchPackageNames": [
-        "*"
-      ]
+      "matchPackageNames": ["*"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
There is a `check` command at the root, it lints things that are out of scope of the individual linters. After this baseline we may want to consider updating some of the per-project linting rules.

This linting is in its own chore PR to prevent creating a release for these changes.