### PR TITLE
feat: Add support for conditional event source capabilities.

### DIFF
--- a/packages/sdk/react-native/src/platform/PlatformRequests.ts
+++ b/packages/sdk/react-native/src/platform/PlatformRequests.ts
@@ -1,6 +1,7 @@
 import type {
   EventName,
   EventSource,
+  EventSourceCapabilities,
   EventSourceInitDict,
   LDLogger,
   Options,
@@ -19,6 +20,14 @@ export default class PlatformRequests implements Requests {
       retryAndHandleError: eventSourceInitDict.errorFilter,
       logger: this.logger,
     });
+  }
+
+  getEventSourceCapabilities(): EventSourceCapabilities {
+    return {
+      readTimeout: false,
+      headers: true,
+      customMethod: true,
+    };
   }
 
   fetch(url: string, options?: Options): Promise<Response> {

--- a/packages/sdk/server-node/src/platform/NodeRequests.ts
+++ b/packages/sdk/server-node/src/platform/NodeRequests.ts
@@ -7,6 +7,7 @@ import { HttpsProxyAgentOptions } from 'https-proxy-agent';
 import { EventSource as LDEventSource } from 'launchdarkly-eventsource';
 
 import {
+  EventSourceCapabilities,
   LDLogger,
   LDProxyOptions,
   LDTLSOptions,
@@ -156,6 +157,14 @@ export default class NodeRequests implements platform.Requests {
       jitterRatio: 0.5,
     };
     return new LDEventSource(url, expandedOptions);
+  }
+
+  getEventSourceCapabilities(): EventSourceCapabilities {
+    return {
+      readTimeout: true,
+      headers: true,
+      customMethod: true,
+    };
   }
 
   usingProxy(): boolean {

--- a/packages/shared/common/src/api/platform/Requests.ts
+++ b/packages/shared/common/src/api/platform/Requests.ts
@@ -78,10 +78,30 @@ export interface Options {
   timeout?: number;
 }
 
+export interface EventSourceCapabilities {
+  /**
+   * If true the event source supports read timeouts.
+   */
+  readTimeout: boolean;
+
+  /**
+   * If true the event source supports customized verbs POST/REPORT instead of
+   * only the default GET.
+   */
+  customMethod: boolean;
+
+  /**
+   * If true the event source supports setting HTTP headers.
+   */
+  headers: boolean;
+}
+
 export interface Requests {
   fetch(url: string, options?: Options): Promise<Response>;
 
   createEventSource(url: string, eventSourceInitDict: EventSourceInitDict): EventSource;
+
+  getEventSourceCapabilities(): EventSourceCapabilities;
 
   /**
    * Returns true if a proxy is configured.


### PR DESCRIPTION
This adds the ability to specify what capabilities an even source supports.

The idea is, for something like report, the common code can check if the event source supports it. If it is configured, and the event source doesn't support it, then it can take appropriate action.

The browser SDK can calculate this at runtime by checking for a polyfill and filling out the appropriate capabilities.