### PR TITLE
feat: adds datasource status to sdk-client

### DIFF
--- a/packages/shared/common/src/errors.ts
+++ b/packages/shared/common/src/errors.ts
@@ -2,33 +2,6 @@
 // more complex, then they could be independent files.
 /* eslint-disable max-classes-per-file */
 
-export class LDFileDataSourceError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'LaunchDarklyFileDataSourceError';
-  }
-}
-
-export class LDPollingError extends Error {
-  public readonly status?: number;
-
-  constructor(message: string, status?: number) {
-    super(message);
-    this.status = status;
-    this.name = 'LaunchDarklyPollingError';
-  }
-}
-
-export class LDStreamingError extends Error {
-  public readonly code?: number;
-
-  constructor(message: string, code?: number) {
-    super(message);
-    this.code = code;
-    this.name = 'LaunchDarklyStreamingError';
-  }
-}
-
 export class LDUnexpectedResponseError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/shared/common/src/internal/datasource/DataSourceErrorKinds.ts
+++ b/packages/shared/common/src/internal/datasource/DataSourceErrorKinds.ts
@@ -1,0 +1,20 @@
+export enum DataSourceErrorKind {
+  /// An unexpected error, such as an uncaught exception, further
+  /// described by the error message.
+  Unknown,
+
+  /// An I/O error such as a dropped connection.
+  NetworkError,
+
+  /// The LaunchDarkly service returned an HTTP response with an error
+  /// status, available in the status code.
+  ErrorResponse,
+
+  /// The SDK received malformed data from the LaunchDarkly service.
+  InvalidData,
+
+  /// The data source itself is working, but when it tried to put an
+  /// update into the data store, the data store failed (so the SDK may
+  /// not have cached the latest data).
+  StoreError,
+}

--- a/packages/shared/common/src/internal/datasource/errors.ts
+++ b/packages/shared/common/src/internal/datasource/errors.ts
@@ -1,0 +1,39 @@
+/* eslint-disable max-classes-per-file */
+import { DataSourceErrorKind } from './DataSourceErrorKinds';
+
+export class LDFileDataSourceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LaunchDarklyFileDataSourceError';
+  }
+}
+
+export class LDPollingError extends Error {
+  public readonly kind: DataSourceErrorKind;
+  public readonly status?: number;
+  public readonly recoverable: boolean;
+
+  constructor(kind: DataSourceErrorKind, message: string, status?: number, recoverable = true) {
+    super(message);
+    this.kind = kind;
+    this.status = status;
+    this.name = 'LaunchDarklyPollingError';
+    this.recoverable = recoverable;
+  }
+}
+
+export class LDStreamingError extends Error {
+  public readonly kind: DataSourceErrorKind;
+  public readonly code?: number;
+  public readonly recoverable: boolean;
+
+  constructor(kind: DataSourceErrorKind, message: string, code?: number, recoverable = true) {
+    super(message);
+    this.kind = kind;
+    this.code = code;
+    this.name = 'LaunchDarklyStreamingError';
+    this.recoverable = recoverable;
+  }
+}
+
+export type StreamingErrorHandler = (err: LDStreamingError) => void;

--- a/packages/shared/common/src/internal/datasource/index.ts
+++ b/packages/shared/common/src/internal/datasource/index.ts
@@ -1,0 +1,15 @@
+import { DataSourceErrorKind } from './DataSourceErrorKinds';
+import {
+  LDFileDataSourceError,
+  LDPollingError,
+  LDStreamingError,
+  StreamingErrorHandler,
+} from './errors';
+
+export {
+  DataSourceErrorKind,
+  LDFileDataSourceError,
+  LDPollingError,
+  LDStreamingError,
+  StreamingErrorHandler,
+};

--- a/packages/shared/common/src/internal/index.ts
+++ b/packages/shared/common/src/internal/index.ts
@@ -1,5 +1,6 @@
+export * from './context';
+export * from './datasource';
 export * from './diagnostics';
 export * from './evaluation';
 export * from './events';
 export * from './stream';
-export * from './context';

--- a/packages/shared/common/src/internal/stream/StreamingProcessor.test.ts
+++ b/packages/shared/common/src/internal/stream/StreamingProcessor.test.ts
@@ -2,8 +2,9 @@ import { createBasicPlatform, createLogger } from '@launchdarkly/private-js-mock
 
 import { EventName, Info, LDLogger, ProcessStreamResponse } from '../../api';
 import { LDStreamProcessor } from '../../api/subsystem';
-import { LDStreamingError } from '../../errors';
 import { defaultHeaders } from '../../utils';
+import { DataSourceErrorKind } from '../datasource/DataSourceErrorKinds';
+import { LDStreamingError } from '../datasource/errors';
 import { DiagnosticsManager } from '../diagnostics';
 import StreamingProcessor from './StreamingProcessor';
 
@@ -260,7 +261,7 @@ describe('given a stream processor with mock event source', () => {
 
       expect(willRetry).toBeFalsy();
       expect(mockErrorHandler).toBeCalledWith(
-        new LDStreamingError(testError.message, testError.status),
+        new LDStreamingError(DataSourceErrorKind.Unknown, testError.message, testError.status),
       );
       expect(logger.error).toBeCalledWith(
         expect.stringMatching(new RegExp(`${status}.*permanently`)),

--- a/packages/shared/common/src/internal/stream/index.ts
+++ b/packages/shared/common/src/internal/stream/index.ts
@@ -1,5 +1,3 @@
 import StreamingProcessor from './StreamingProcessor';
-import type { StreamingErrorHandler } from './types';
 
 export { StreamingProcessor };
-export type { StreamingErrorHandler };

--- a/packages/shared/common/src/internal/stream/types.ts
+++ b/packages/shared/common/src/internal/stream/types.ts
@@ -1,3 +1,0 @@
-import { LDStreamingError } from '../../errors';
-
-export type StreamingErrorHandler = (err: LDStreamingError) => void;

--- a/packages/shared/mocks/src/streamingProcessor.ts
+++ b/packages/shared/mocks/src/streamingProcessor.ts
@@ -1,11 +1,6 @@
-import type {
-  ClientContext,
-  EventName,
-  internal,
-  LDHeaders,
-  LDStreamingError,
-  ProcessStreamResponse,
-} from '@common';
+import type { ClientContext, EventName, internal, LDHeaders, ProcessStreamResponse } from '@common';
+
+type LDStreamingError = internal.LDStreamingError;
 
 export const MockStreamingProcessor = jest.fn();
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.storage.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.storage.test.ts
@@ -89,8 +89,7 @@ describe('sdk-client storage', () => {
 
     expect(mockPlatform.storage.get).toHaveBeenCalledWith(flagStorageKey);
 
-    // 'change' should not have been emitted
-    expect(emitter.emit).toHaveBeenCalledTimes(2);
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
     expect(emitter.emit).toHaveBeenNthCalledWith(1, 'change', context, defaultFlagKeys);
     expect(emitter.emit).toHaveBeenNthCalledWith(
       2,
@@ -136,7 +135,7 @@ describe('sdk-client storage', () => {
     );
 
     // 'change' should not have been emitted
-    expect(emitter.emit).toHaveBeenCalledTimes(2);
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
     expect(emitter.emit).toHaveBeenNthCalledWith(
       1,
       'change',
@@ -376,7 +375,7 @@ describe('sdk-client storage', () => {
     );
 
     // we expect one change from the local storage init, but no further change from the PUT
-    expect(emitter.emit).toHaveBeenCalledTimes(1);
+    expect(emitter.emit).toHaveBeenCalledTimes(2);
     expect(emitter.emit).toHaveBeenNthCalledWith(1, 'change', context, defaultFlagKeys);
 
     // this is defaultPutResponse
@@ -448,7 +447,7 @@ describe('sdk-client storage', () => {
     expect(ldc.allFlags()).toMatchObject({ 'dev-test-flag': false });
     expect(mockPlatform.storage.set).toHaveBeenCalledTimes(4);
     expect(flagsInStorage['dev-test-flag'].version).toEqual(patchResponse.version);
-    expect(emitter.emit).toHaveBeenCalledTimes(2);
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
     expect(emitter.emit).toHaveBeenNthCalledWith(2, 'change', context, ['dev-test-flag']);
   });
 
@@ -480,7 +479,7 @@ describe('sdk-client storage', () => {
       expect.stringContaining(JSON.stringify(patchResponse)),
     );
     expect(flagsInStorage).toHaveProperty('another-dev-test-flag');
-    expect(emitter.emit).toHaveBeenCalledTimes(2);
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
     expect(emitter.emit).toHaveBeenNthCalledWith(2, 'change', context, ['another-dev-test-flag']);
   });
 
@@ -553,7 +552,7 @@ describe('sdk-client storage', () => {
       expect.stringContaining('dev-test-flag'),
     );
     expect(flagsInStorage['dev-test-flag']).toMatchObject({ ...deleteResponse, deleted: true });
-    expect(emitter.emit).toHaveBeenCalledTimes(2);
+    expect(emitter.emit).toHaveBeenCalledTimes(3);
     expect(emitter.emit).toHaveBeenNthCalledWith(2, 'change', context, ['dev-test-flag']);
   });
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
@@ -1,6 +1,7 @@
 import { AutoEnvAttributes, clone, Encoding, Hasher, LDContext } from '@launchdarkly/js-sdk-common';
 import { createBasicPlatform, createLogger } from '@launchdarkly/private-js-mocks';
 
+import { DataSourceState } from '../src/datasource/DataSourceStatus';
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import * as mockResponseJson from './evaluation/mockResponse.json';
@@ -31,6 +32,13 @@ describe('sdk-client object', () => {
   let defaultPutResponse: Flags;
   let mockPlatform: ReturnType<typeof createBasicPlatform>;
   let logger: ReturnType<typeof createLogger>;
+
+  const onDataSourceChangePromise = () =>
+    new Promise<string[]>((res) => {
+      ldc.on('dataSourceStatus', (_context: LDContext, changes: string[]) => {
+        res(changes);
+      });
+    });
 
   beforeEach(() => {
     mockPlatform = createBasicPlatform();
@@ -296,5 +304,65 @@ describe('sdk-client object', () => {
     await ldc.identify(context, { waitForNetworkResults: true, timeout: 5 });
 
     expect(logger.debug).not.toHaveBeenCalledWith('Identify completing with cached flags');
+  });
+
+  test('data source status emits valid when successful initialization', async () => {
+    const carContext: LDContext = { kind: 'car', key: 'test-car' };
+
+    mockPlatform.crypto.randomUUID.mockReturnValue('random1');
+
+    // need reference within test to run assertions against
+    const mockCreateEventSource = jest.fn((streamUri: string = '', options: any = {}) => {
+      mockEventSource = new MockEventSource(streamUri, options);
+      mockEventSource.simulateEvents('put', [{ data: JSON.stringify(defaultPutResponse) }]);
+      return mockEventSource;
+    });
+    mockPlatform.requests.createEventSource = mockCreateEventSource;
+
+    const spyListener = jest.fn();
+    ldc.on('dataSourceStatus', spyListener);
+    const changePromise = onDataSourceChangePromise();
+    await ldc.identify(carContext);
+    await changePromise;
+
+    expect(spyListener).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        state: DataSourceState.Valid,
+        stateSince: expect.any(Number),
+        lastError: undefined,
+      }),
+    );
+  });
+
+  test('data source status emits shutdown when initialization encounters unrecoverable error', async () => {
+    const carContext: LDContext = { kind: 'car', key: 'test-car' };
+
+    mockPlatform.crypto.randomUUID.mockReturnValue('random1');
+
+    // need reference within test to run assertions against
+    const mockCreateEventSource = jest.fn((streamUri: string = '', options: any = {}) => {
+      mockEventSource = new MockEventSource(streamUri, options);
+      mockEventSource.simulateError({ status: 404, message: 'test-error' }); // unrecoverable error
+      return mockEventSource;
+    });
+    mockPlatform.requests.createEventSource = mockCreateEventSource;
+
+    const spyListener = jest.fn();
+    ldc.on('dataSourceStatus', spyListener);
+    const changePromise = onDataSourceChangePromise();
+
+    await expect(ldc.identify(carContext)).rejects.toThrow('test-error');
+    await changePromise;
+
+    expect(spyListener).toHaveBeenCalledTimes(1);
+    expect(spyListener).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        state: DataSourceState.Shutdown,
+        stateSince: expect.any(Number),
+        lastError: expect.anything(),
+      }),
+    );
   });
 });

--- a/packages/shared/sdk-client/__tests__/datasource/DataSourceStatusManager.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/DataSourceStatusManager.test.ts
@@ -1,0 +1,109 @@
+import { DataSourceErrorKind } from '@launchdarkly/js-sdk-common/dist/internal';
+
+import { DataSourceState } from '../../src/datasource/DataSourceStatus';
+import DataSourceStatusManager from '../../src/datasource/DataSourceStatusManager';
+
+describe('DataSourceStatusManager', () => {
+  test('its first state is initializing', async () => {
+    const underTest = new DataSourceStatusManager();
+    expect(underTest.status.state).toEqual(DataSourceState.Initializing);
+  });
+
+  test('it stays at initializing if receives non shutdown error', async () => {
+    const underTest = new DataSourceStatusManager();
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 404, true);
+    expect(underTest.status.state).toEqual(DataSourceState.Initializing);
+  });
+
+  test('it moves to shutdown if receives shutdown error', async () => {
+    const underTest = new DataSourceStatusManager();
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 404, false);
+    expect(underTest.status.state).toEqual(DataSourceState.Shutdown);
+  });
+
+  test('it updates last error time with each error, but not stateSince', async () => {
+    let time = 0;
+    const stamper: () => number = () => time;
+    const underTest = new DataSourceStatusManager(stamper);
+
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 404, true);
+    expect(underTest.status.stateSince).toEqual(0);
+    expect(underTest.status.lastError?.time).toEqual(0);
+
+    time += 1;
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 404, true);
+    expect(underTest.status.stateSince).toEqual(0);
+    expect(underTest.status.lastError?.time).toEqual(1);
+
+    time += 1;
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 404, true);
+    expect(underTest.status.stateSince).toEqual(0);
+    expect(underTest.status.lastError?.time).toEqual(2);
+  });
+
+  test('it updates stateSince when transitioning', async () => {
+    let time = 0;
+    const stamper: () => number = () => time;
+
+    const underTest = new DataSourceStatusManager(stamper);
+    expect(underTest.status.state).toEqual(DataSourceState.Initializing);
+    expect(underTest.status.stateSince).toEqual(0);
+
+    time += 1;
+    underTest.setValid();
+    expect(underTest.status.stateSince).toEqual(1);
+
+    time += 1;
+    underTest.setShutdown();
+    expect(underTest.status.stateSince).toEqual(2);
+  });
+
+  test('it notifies listeners when state changes', async () => {
+    let time = 0;
+    const stamper: () => number = () => time;
+    const underTest = new DataSourceStatusManager(stamper);
+    const spyListener = jest.fn();
+    underTest.on(spyListener);
+
+    underTest.setOffline();
+    time += 1;
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 400, true);
+    time += 1;
+    underTest.setError(DataSourceErrorKind.ErrorResponse, 'womp', 400, true);
+    time += 1;
+    underTest.setShutdown();
+    expect(spyListener).toHaveBeenCalledTimes(4);
+    expect(spyListener).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        state: DataSourceState.SetOffline,
+        stateSince: 0,
+        lastError: undefined,
+      }),
+    );
+    expect(spyListener).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        state: DataSourceState.Interrupted,
+        stateSince: 1,
+        lastError: expect.anything(),
+      }),
+    );
+    expect(spyListener).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        state: DataSourceState.Interrupted,
+        stateSince: 1, // still in state interrupted
+        lastError: expect.anything(),
+      }),
+    );
+    expect(spyListener).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        state: DataSourceState.Shutdown,
+        stateSince: 3,
+        lastError: expect.anything(),
+      }),
+    );
+  });
+});

--- a/packages/shared/sdk-client/__tests__/streaming/StreamingProcessor.test.ts
+++ b/packages/shared/sdk-client/__tests__/streaming/StreamingProcessor.test.ts
@@ -4,13 +4,14 @@ import {
   EventName,
   Info,
   internal,
-  LDStreamingError,
   Platform,
   ProcessStreamResponse,
 } from '@launchdarkly/js-sdk-common';
 import { createBasicPlatform, createLogger } from '@launchdarkly/private-js-mocks';
 
 import { StreamingDataSourceConfig, StreamingProcessor } from '../../src/streaming';
+
+const { DataSourceErrorKind, LDStreamingError } = internal;
 
 let logger: ReturnType<typeof createLogger>;
 
@@ -327,7 +328,7 @@ describe('given a stream processor', () => {
 
       expect(willRetry).toBeFalsy();
       expect(mockErrorHandler).toBeCalledWith(
-        new LDStreamingError(testError.message, testError.status),
+        new LDStreamingError(DataSourceErrorKind.Unknown, testError.message, testError.status),
       );
       expect(logger.error).toBeCalledWith(
         expect.stringMatching(new RegExp(`${status}.*permanently`)),

--- a/packages/shared/sdk-client/src/LDEmitter.ts
+++ b/packages/shared/sdk-client/src/LDEmitter.ts
@@ -1,6 +1,7 @@
 import { LDLogger } from '@launchdarkly/js-sdk-common';
 
-export type EventName = 'error' | 'change';
+// TODO: is one emitter with many event names what we want long term?
+export type EventName = 'error' | 'change' | 'dataSourceStatus';
 
 export default class LDEmitter {
   private listeners: Map<EventName, Function[]> = new Map();

--- a/packages/shared/sdk-client/src/datasource/DataSourceEventHandler.ts
+++ b/packages/shared/sdk-client/src/datasource/DataSourceEventHandler.ts
@@ -1,0 +1,66 @@
+import { Context, internal, LDLogger } from '@launchdarkly/js-sdk-common';
+
+import FlagManager from '../flag-manager/FlagManager';
+import { ItemDescriptor } from '../flag-manager/ItemDescriptor';
+import { DeleteFlag, Flags, PatchFlag } from '../types';
+import DataSourceStatusManager from './DataSourceStatusManager';
+
+type LDStreamingError = internal.LDStreamingError;
+type LDPollingError = internal.LDPollingError;
+
+export default class DataSourceEventHandler {
+  constructor(
+    private readonly flagManager: FlagManager,
+    private readonly statusManager: DataSourceStatusManager,
+    private readonly logger: LDLogger,
+  ) {}
+
+  async handlePut(context: Context, flags: Flags) {
+    this.logger.debug(`Got PUT: ${Object.keys(flags)}`);
+
+    // mapping flags to item descriptors
+    const descriptors = Object.entries(flags).reduce(
+      (acc: { [k: string]: ItemDescriptor }, [key, flag]) => {
+        acc[key] = { version: flag.version, flag };
+        return acc;
+      },
+      {},
+    );
+    await this.flagManager.init(context, descriptors).then();
+    this.statusManager.setValid();
+  }
+
+  async handlePatch(context: Context, patchFlag: PatchFlag) {
+    this.logger.debug(`Got PATCH ${JSON.stringify(patchFlag, null, 2)}`);
+    this.flagManager.upsert(context, patchFlag.key, {
+      version: patchFlag.version,
+      flag: patchFlag,
+    });
+  }
+
+  async handleDelete(context: Context, deleteFlag: DeleteFlag) {
+    this.logger.debug(`Got DELETE ${JSON.stringify(deleteFlag, null, 2)}`);
+
+    this.flagManager.upsert(context, deleteFlag.key, {
+      version: deleteFlag.version,
+      flag: {
+        ...deleteFlag,
+        deleted: true,
+        // props below are set to sensible defaults. they are irrelevant
+        // because this flag has been deleted.
+        flagVersion: 0,
+        value: undefined,
+        variation: 0,
+        trackEvents: false,
+      },
+    });
+  }
+
+  handleStreamingError(error: LDStreamingError) {
+    this.statusManager.setError(error.kind, error.message, error.code, error.recoverable);
+  }
+
+  handlePollingError(error: LDPollingError) {
+    this.statusManager.setError(error.kind, error.message, error.status, error.recoverable);
+  }
+}

--- a/packages/shared/sdk-client/src/datasource/DataSourceStatus.ts
+++ b/packages/shared/sdk-client/src/datasource/DataSourceStatus.ts
@@ -1,0 +1,47 @@
+import DataSourceStatusErrorInfo from './DataSourceStatusErrorInfo';
+
+export enum DataSourceState {
+  Initializing,
+  Valid,
+  Interrupted,
+  SetOffline,
+  Shutdown,
+  // TODO: SDK-702 - Implement network availability behaviors
+  // NetworkUnavailable,
+}
+
+export default interface DataSourceStatus {
+  /**
+   * An enumerated value representing the overall current state of the data source.
+   */
+  readonly state: DataSourceState;
+
+  /**
+   * The UNIX epoch timestamp in milliseconds that the value of State most recently changed.
+   *
+   * The meaning of this depends on the current state:
+   * For {@link DataSourceState.Initializing}, it is the time that the SDK started
+   * initializing.
+   *
+   * For {@link DataSourceState.Valid}, it is the time that the data source most
+   * recently entered a valid state, after previously having been
+   * {@link DataSourceStatus.Initializing} or an invalid state such as
+   * {@link DataSourceState.Interrupted}.
+   *
+   * - For {@linkDataSourceState.interrupted}, it is the time that the data source
+   * most recently entered an error state, after previously having been
+   * {@linkDataSourceState.valid}.
+   *
+   * For {@linkDataSourceState.shutdown}, it is the time that the data source
+   * encountered an unrecoverable error or that the datasource was explicitly shut down.
+   *
+   * For {@linkDataSourceState.networkUnavailable} it is the time that the SDK switched
+   * the data source off due to network unavailability.
+   */
+  readonly stateSince: number;
+
+  /**
+   * The last error encountered. May be absent after application restart.
+   */
+  readonly lastError?: DataSourceStatusErrorInfo;
+}

--- a/packages/shared/sdk-client/src/datasource/DataSourceStatus.ts
+++ b/packages/shared/sdk-client/src/datasource/DataSourceStatus.ts
@@ -28,15 +28,12 @@ export default interface DataSourceStatus {
    * {@link DataSourceStatus.Initializing} or an invalid state such as
    * {@link DataSourceState.Interrupted}.
    *
-   * - For {@linkDataSourceState.interrupted}, it is the time that the data source
+   * - For {@link DataSourceState.interrupted}, it is the time that the data source
    * most recently entered an error state, after previously having been
-   * {@linkDataSourceState.valid}.
+   * {@link DataSourceState.valid}.
    *
-   * For {@linkDataSourceState.shutdown}, it is the time that the data source
+   * For {@link DataSourceState.Shutdown}, it is the time that the data source
    * encountered an unrecoverable error or that the datasource was explicitly shut down.
-   *
-   * For {@linkDataSourceState.networkUnavailable} it is the time that the SDK switched
-   * the data source off due to network unavailability.
    */
   readonly stateSince: number;
 

--- a/packages/shared/sdk-client/src/datasource/DataSourceStatusErrorInfo.ts
+++ b/packages/shared/sdk-client/src/datasource/DataSourceStatusErrorInfo.ts
@@ -1,0 +1,21 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
+type DataSourceErrorKind = internal.DataSourceErrorKind;
+
+/// A description of an error condition that the data source encountered.
+export default interface DataSourceStatusErrorInfo {
+  /// An enumerated value representing the general category of the error.
+  readonly kind: DataSourceErrorKind;
+
+  /// Any additional human-readable information relevant to the error.
+  ///
+  /// The format is subject to change and should not be relied on
+  /// programmatically.
+  readonly message: string;
+
+  /// The UNIX epoch timestamp in milliseconds that the event occurred.
+  readonly time: number;
+
+  /// The HTTP status code if the error was [ErrorKind.errorResponse].
+  readonly statusCode?: number;
+}

--- a/packages/shared/sdk-client/src/datasource/DataSourceStatusManager.ts
+++ b/packages/shared/sdk-client/src/datasource/DataSourceStatusManager.ts
@@ -1,0 +1,93 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
+import LDEmitter from '../LDEmitter';
+import DataSourceStatus, { DataSourceState } from './DataSourceStatus';
+import DataSourceStatusErrorInfo from './DataSourceStatusErrorInfo';
+
+type DataSourceErrorKind = internal.DataSourceErrorKind;
+
+export type DataSourceStatusCallback = (status: DataSourceStatus) => void;
+
+export default class DataSourceStatusManager {
+  private state: DataSourceState;
+  private stateSinceMillis: number; // UNIX epoch timestamp in milliseconds
+  private errorInfo?: DataSourceStatusErrorInfo;
+  private timeStamper: () => number;
+
+  // TODO: at the moment the LDEmitter requires an event name internally, would be nice to not need to provide an event name,
+  // but perhaps also not worth refactoring/supporting another style
+  private emitter: LDEmitter;
+
+  constructor(timeStamper: () => number = () => Date.now()) {
+    this.state = DataSourceState.Initializing;
+    this.stateSinceMillis = timeStamper();
+    this.emitter = new LDEmitter();
+    this.timeStamper = timeStamper;
+  }
+
+  get status(): DataSourceStatus {
+    return {
+      state: this.state,
+      stateSince: this.stateSinceMillis,
+      lastError: this.errorInfo,
+    };
+  }
+
+  private updateState(requestedState: DataSourceState, isError = false) {
+    const newState =
+      requestedState === DataSourceState.Interrupted && this.state === DataSourceState.Initializing // don't go to interrupted from initializing (recoverable errors when initializing are not noteworthy)
+        ? DataSourceState.Initializing
+        : requestedState;
+
+    const changedState = this.state !== newState;
+    if (changedState) {
+      this.state = newState;
+      this.stateSinceMillis = this.timeStamper();
+    }
+
+    if (changedState || isError) {
+      this.emitter.emit('dataSourceStatus', this.status);
+    }
+  }
+
+  off(listener: DataSourceStatusCallback) {
+    this.emitter.off('dataSourceStatus', listener);
+  }
+
+  on(listener: DataSourceStatusCallback) {
+    this.emitter.on('dataSourceStatus', listener);
+  }
+
+  setValid() {
+    this.updateState(DataSourceState.Valid);
+  }
+
+  setOffline() {
+    this.updateState(DataSourceState.SetOffline);
+  }
+
+  // TODO: SDK-702 - Implement network availability behaviors
+  // setNetworkUnavailable() {
+  //   this.updateState(DataSourceState.NetworkUnavailable);
+  // }
+
+  setShutdown() {
+    this.updateState(DataSourceState.Shutdown);
+  }
+
+  setError(
+    kind: DataSourceErrorKind,
+    message: string,
+    statusCode?: number,
+    recoverable: boolean = false,
+  ) {
+    const errorInfo: DataSourceStatusErrorInfo = {
+      kind,
+      message,
+      statusCode,
+      time: this.timeStamper(),
+    };
+    this.errorInfo = errorInfo;
+    this.updateState(recoverable ? DataSourceState.Interrupted : DataSourceState.Shutdown, true);
+  }
+}

--- a/packages/shared/sdk-client/src/streaming/StreamingProcessor.ts
+++ b/packages/shared/sdk-client/src/streaming/StreamingProcessor.ts
@@ -7,7 +7,6 @@ import {
   HttpErrorResponse,
   internal,
   LDLogger,
-  LDStreamingError,
   ProcessStreamResponse,
   Requests,
   shouldRetry,
@@ -15,6 +14,9 @@ import {
 } from '@launchdarkly/js-sdk-common';
 
 import { StreamingDataSourceConfig } from './DataSourceConfig';
+
+// TODO: revisit usage of internal and figure out best practice
+const { DataSourceErrorKind, LDStreamingError } = internal;
 
 const reportJsonError = (
   type: string,
@@ -24,7 +26,9 @@ const reportJsonError = (
 ) => {
   logger?.error(`Stream received invalid data in "${type}" message`);
   logger?.debug(`Invalid JSON follows: ${data}`);
-  errorHandler?.(new LDStreamingError('Malformed JSON data in event stream'));
+  errorHandler?.(
+    new LDStreamingError(DataSourceErrorKind.InvalidData, 'Malformed JSON data in event stream'),
+  );
 };
 
 class StreamingProcessor implements subsystem.LDStreamProcessor {
@@ -94,7 +98,9 @@ class StreamingProcessor implements subsystem.LDStreamProcessor {
   private retryAndHandleError(err: HttpErrorResponse) {
     if (!shouldRetry(err)) {
       this.logConnectionResult(false);
-      this.errorHandler?.(new LDStreamingError(err.message, err.status));
+      this.errorHandler?.(
+        new LDStreamingError(DataSourceErrorKind.ErrorResponse, err.message, err.status, false),
+      );
       this.logger?.error(httpErrorMessage(err, 'streaming request'));
       return false;
     }
@@ -162,7 +168,12 @@ class StreamingProcessor implements subsystem.LDStreamProcessor {
           }
           processJson(dataJson);
         } else {
-          this.errorHandler?.(new LDStreamingError('Unexpected payload from event stream'));
+          this.errorHandler?.(
+            new LDStreamingError(
+              DataSourceErrorKind.InvalidData,
+              'Unexpected payload from event stream',
+            ),
+          );
         }
       });
     });

--- a/packages/shared/sdk-server/src/data_sources/FileDataSource.ts
+++ b/packages/shared/sdk-server/src/data_sources/FileDataSource.ts
@@ -1,6 +1,6 @@
 import {
   Filesystem,
-  LDFileDataSourceError,
+  internal,
   LDLogger,
   subsystem,
   VoidFunction,
@@ -14,6 +14,8 @@ import { processFlag, processSegment } from '../store/serialization';
 import VersionedDataKinds from '../store/VersionedDataKinds';
 import FileLoader from './FileLoader';
 
+// TODO: revisit usage of internal and figure out best practice
+type LDFileDataSourceError = internal.LDFileDataSourceError;
 export type FileDataSourceErrorHandler = (err: LDFileDataSourceError) => void;
 
 function makeFlagWithValue(key: string, value: any, version: number): Flag {

--- a/packages/shared/sdk-server/src/data_sources/Requestor.ts
+++ b/packages/shared/sdk-server/src/data_sources/Requestor.ts
@@ -1,7 +1,7 @@
 import {
   getPollingUri,
+  internal,
   LDHeaders,
-  LDStreamingError,
   Options,
   Requests,
   Response,
@@ -9,6 +9,10 @@ import {
 
 import { LDFeatureRequestor } from '../api/subsystems';
 import Configuration from '../options/Configuration';
+import { DataSourceErrorKind } from '@launchdarkly/js-sdk-common/dist/internal';
+
+// TODO: revisit usage of internal and figure out best practice
+const { LDPollingError } = internal;
 
 /**
  * @internal
@@ -77,7 +81,7 @@ export default class Requestor implements LDFeatureRequestor {
     try {
       const { res, body } = await this.requestWithETagCache(this.uri, options);
       if (res.status !== 200 && res.status !== 304) {
-        const err = new LDStreamingError(`Unexpected status code: ${res.status}`, res.status);
+        const err = new LDPollingError(DataSourceErrorKind.ErrorResponse, `Unexpected status code: ${res.status}`, res.status);
         return cb(err, undefined);
       }
       return cb(undefined, res.status === 304 ? null : body);


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

SDK-170

**Describe the solution you've provided**

Adds DataSourceStatusManager.
Refactors data source errors into common.
Adds DataSourceErrorKind to classify errors so manager can track state.