### PR TITLE
chore: Remove unused function in common client-side LDClientImpl.

### DIFF
--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -11,8 +11,6 @@ import {
   LDHeaders,
   LDLogger,
   Platform,
-  ProcessStreamResponse,
-  EventName as StreamEventName,
   subsystem,
   timedPromise,
   TypeValidators,
@@ -33,9 +31,7 @@ import {
 import createEventProcessor from './events/createEventProcessor';
 import EventFactory from './events/EventFactory';
 import DefaultFlagManager, { FlagManager } from './flag-manager/FlagManager';
-import { ItemDescriptor } from './flag-manager/ItemDescriptor';
 import LDEmitter, { EventName } from './LDEmitter';
-import { DeleteFlag, Flags, PatchFlag } from './types';
 
 const { ClientMessages, ErrorKinds } = internal;
 


### PR DESCRIPTION
This code was orphaned in some refactoring and should be removed.