### PR TITLE
fix: Fix common package to work with node16 module resolution.

### DIFF
--- a/packages/shared/common/package.json
+++ b/packages/shared/common/package.json
@@ -2,8 +2,8 @@
   "name": "@launchdarkly/js-sdk-common",
   "version": "2.10.0",
   "type": "module",
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/esm/index.mjs",
+  "types": "./dist/esm/index.d.ts",
   "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/shared/common",
   "repository": {
     "type": "git",
@@ -19,13 +19,15 @@
     "client"
   ],
   "exports": {
-    "types": "./dist/index.d.ts",
-    "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    "require": { "types": "./dist/cjs/index.d.ts", "default": "./dist/cjs/index.cjs"},
+    "import": { "types": "./dist/esm/index.d.ts", "default": "./dist/esm/index.mjs"}
   },
   "scripts": {
     "test": "npx jest --ci",
-    "build": "npx tsc --noEmit && rollup -c rollup.config.js",
+    "make-cjs-package-json": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "make-esm-package-json": "echo '{\"type\":\"module\"}' > dist/esm/package.json",
+    "make-package-jsons": "npm run make-cjs-package-json && npm run make-esm-package-json",
+    "build": "npx tsc --noEmit && rollup -c rollup.config.js && npm run make-package-jsons",
     "clean": "rimraf dist",
     "lint": "npx eslint . --ext .ts",
     "lint:fix": "yarn run lint --fix",

--- a/packages/shared/common/rollup.config.js
+++ b/packages/shared/common/rollup.config.js
@@ -20,7 +20,7 @@ const getSharedConfig = (format, file) => ({
 
 export default [
   {
-    ...getSharedConfig('es', 'dist/index.mjs'),
+    ...getSharedConfig('es', 'dist/esm/index.mjs'),
     plugins: [
       typescript({
         module: 'esnext',
@@ -35,7 +35,7 @@ export default [
     ],
   },
   {
-    ...getSharedConfig('cjs', 'dist/index.cjs'),
-    plugins: [typescript({ tsconfig: './tsconfig.json' }), common(), json()],
+    ...getSharedConfig('cjs', 'dist/cjs/index.cjs'),
+    plugins: [typescript({ tsconfig: './tsconfig.json', outputToFilesystem: true, }), common(), json()],
   },
 ];

--- a/packages/shared/common/tsconfig.json
+++ b/packages/shared/common/tsconfig.json
@@ -13,8 +13,7 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source
-    "stripInternal": true,
-    "composite": true
+    "stripInternal": true
   },
   "include": ["src"],
   "exclude": ["**/*.test.ts", "dist", "node_modules", "__tests__"]

--- a/packages/shared/sdk-client/src/DataManager.ts
+++ b/packages/shared/sdk-client/src/DataManager.ts
@@ -9,7 +9,6 @@ import {
   ProcessStreamResponse,
   subsystem,
 } from '@launchdarkly/js-sdk-common';
-import { LDStreamProcessor } from '@launchdarkly/js-sdk-common/dist/api/subsystem';
 
 import { LDIdentifyOptions } from './api/LDIdentifyOptions';
 import { Configuration } from './configuration/Configuration';
@@ -203,9 +202,9 @@ export abstract class BaseDataManager implements DataManager {
   }
 
   private _decorateProcessorWithStatusReporting(
-    processor: LDStreamProcessor,
+    processor: subsystem.LDStreamProcessor,
     statusManager: DataSourceStatusManager,
-  ): LDStreamProcessor {
+  ): subsystem.LDStreamProcessor {
     return {
       start: () => {
         // update status before starting processor to ensure potential errors are reported after initializing


### PR DESCRIPTION
When using typescript with moduleResolution set to "node16" types were not loading which are part of the common package.

This relates to changes to the default was in which file resolution occurs. 

This PR will address this, but we will want a better long-term fix. In this PR we convince node that the `.d.ts` files are the correct extension by making a small `package.json` that sets the module type.

In the future we would want the `.d.ts` files to instead be `.d.cts`.

Potentially we can move to tsup: https://tsup.egoist.dev/

But the changes were too extensive for this fix.

Testing:

tsconfig.json
```
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "_version": "20.1.0",

  "compilerOptions": {
    "lib": ["es2023"],
    "module": "node16",
    "target": "es2022",
    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "moduleResolution": "node16"
  }
}
```
package.json
```
{
  "name": "hello-node-typescript",
  "version": "1.0.0",
  "description": "Hello LaunchDarkly for Node.js with TypeScript",
  "main": "index.ts",
  "scripts": {
    "start": "ts-node ./index.ts"
  },
  "author": "LaunchDarkly <team@launchdarkly.com>",
  "license": "Apache-2.0",
  "devDependencies": {
    "@types/node": "*",
    "ts-node": "*",
    "typescript": "*"
  },
  "dependencies": {
    "@launchdarkly/node-server-sdk": "../js-core/packages/sdk/server-node",
    "@launchdarkly/js-server-sdk-common": "../js-core/packages/shared/sdk-server",
    "@launchdarkly/js-sdk-common": "../js-core/packages/shared/common"
  }
}
```
Code:
```
import { init } from '@launchdarkly/node-server-sdk';
import type { LDSingleKindContext, LDLogger, LDOptions } from '@launchdarkly/node-server-sdk';

// Set sdkKey to your LaunchDarkly SDK key.
const sdkKey = "";

function showMessage(s: string) {
  console.log("*** " + s);
  console.log("");
}

const logger: LDLogger = {
  debug: console.debug,
  info: console.info,
  warn: console.warn,
  error: console.error,
};
const options: LDOptions = {
  logger
};

const client = init(sdkKey, options);

client.once('ready', async function () {
  showMessage("SDK successfully initialized!");
  const context: LDSingleKindContext = {kind: 'user', key: 'bob'};
  const res = await client.variation('my-boolean-flag', context, false);
  console.log("The result", res);
});

```

This uses a few types, such as the context, logger, and options to ensure they are resolving correctly.
