### PR TITLE
fix: Update sdk-client rollup configuration to match common

### DIFF
--- a/packages/shared/common/package.json
+++ b/packages/shared/common/package.json
@@ -19,8 +19,14 @@
     "client"
   ],
   "exports": {
-    "require": { "types": "./dist/cjs/index.d.ts", "default": "./dist/cjs/index.cjs"},
-    "import": { "types": "./dist/esm/index.d.ts", "default": "./dist/esm/index.mjs"}
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.cjs"
+    },
+    "import": {
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.mjs"
+    }
   },
   "scripts": {
     "test": "npx jest --ci",

--- a/packages/shared/sdk-client/package.json
+++ b/packages/shared/sdk-client/package.json
@@ -2,8 +2,8 @@
   "name": "@launchdarkly/js-client-sdk-common",
   "version": "1.9.0",
   "type": "module",
-  "main": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/esm/index.mjs",
+  "types": "./dist/esm/index.d.ts",
   "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/shared/sdk-client",
   "repository": {
     "type": "git",
@@ -19,14 +19,22 @@
     "client"
   ],
   "exports": {
-    "types": "./dist/index.d.ts",
-    "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.cjs"
+    },
+    "import": {
+      "types": "./dist/esm/index.d.ts",
+      "default": "./dist/esm/index.mjs"
+    }
   },
   "scripts": {
     "doc": "../../../scripts/build-doc.sh .",
     "test": "npx jest --ci",
-    "build": "tsc --noEmit && rollup -c rollup.config.js",
+    "make-cjs-package-json": "echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "make-esm-package-json": "echo '{\"type\":\"module\"}' > dist/esm/package.json",
+    "make-package-jsons": "npm run make-cjs-package-json && npm run make-esm-package-json",
+    "build": "npx tsc --noEmit && rollup -c rollup.config.js && npm run make-package-jsons",
     "clean": "rimraf dist",
     "lint": "npx eslint . --ext .ts",
     "lint:fix": "yarn run lint -- --fix",

--- a/packages/shared/sdk-client/rollup.config.js
+++ b/packages/shared/sdk-client/rollup.config.js
@@ -21,7 +21,7 @@ const getSharedConfig = (format, file) => ({
 
 export default [
   {
-    ...getSharedConfig('es', 'dist/index.mjs'),
+    ...getSharedConfig('es', 'dist/esm/index.mjs'),
     plugins: [
       typescript({
         module: 'esnext',
@@ -37,7 +37,7 @@ export default [
     ],
   },
   {
-    ...getSharedConfig('cjs', 'dist/index.cjs'),
-    plugins: [typescript({ tsconfig: './tsconfig.json' }), common(), resolve(), json()],
+    ...getSharedConfig('cjs', 'dist/cjs/index.cjs'),
+    plugins: [typescript({ tsconfig: './tsconfig.json', outputToFilesystem: true, }), common(), resolve(), json()],
   },
 ];


### PR DESCRIPTION
This applies the same fixes to `sdk-client` that were applied to `common`.

This resolves issues with using CJS+Typescript with RN. Our existing test project doesn't use node16/nodenext module resolution.

Can be tested with our example project with this tsconfig.
```
{
  "extends": "@react-native/typescript-config/tsconfig.json",
  "compilerOptions": {
    "allowSyntheticDefaultImports": true,
    "jsx": "react-native",
    "lib": ["dom", "esnext"],
    "module": "nodenext",
    "moduleResolution": "nodenext",
    "noEmit": true,
    "skipLibCheck": true,
    "resolveJsonModule": true,
    "removeComments": true,
    "sourceMap": true,
    "strict": true,
    "forceConsistentCasingInFileNames": true
  },
  "exclude": ["e2e"]
}
```

Required installing the base config:
```
yarn add -D @react-native/typescript-config
```