### PR TITLE
fix: Fix incompatibility with @types/node release.

### DIFF
--- a/packages/sdk/server-node/src/Emits.ts
+++ b/packages/sdk/server-node/src/Emits.ts
@@ -50,11 +50,11 @@ export function Emits<TBase extends Eventable>(Base: TBase) {
       return this.emitter.getMaxListeners();
     }
 
-    listeners(eventName: string | symbol): Function[] {
+    listeners(eventName: string | symbol): Array<() => void> {
       return this.emitter.listeners(eventName);
     }
 
-    rawListeners(eventName: string | symbol): Function[] {
+    rawListeners(eventName: string | symbol): Array<() => void> {
       return this.emitter.rawListeners(eventName);
     }
 


### PR DESCRIPTION
This change, https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69997, to the `@types/node` package made typings for the emitter stricter and break the builds. Functionally the code is the same.