### PR TITLE
chore: Automatically update edge SDK example versions.

### DIFF
--- a/packages/sdk/akamai-base/example/package.json
+++ b/packages/sdk/akamai-base/example/package.json
@@ -32,6 +32,6 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@launchdarkly/akamai-server-base-sdk": "^1.0.0"
+    "@launchdarkly/akamai-server-base-sdk": "2.1.19"
   }
 }

--- a/packages/sdk/akamai-edgekv/example/package.json
+++ b/packages/sdk/akamai-edgekv/example/package.json
@@ -31,6 +31,6 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@launchdarkly/akamai-server-edgekv-sdk": "^1.0.0"
+    "@launchdarkly/akamai-server-edgekv-sdk": "1.2.1"
   }
 }

--- a/packages/sdk/cloudflare/example/package.json
+++ b/packages/sdk/cloudflare/example/package.json
@@ -5,7 +5,7 @@
   "module": "./dist/index.mjs",
   "packageManager": "yarn@3.4.1",
   "dependencies": {
-    "@launchdarkly/cloudflare-server-sdk": "2.2.3"
+    "@launchdarkly/cloudflare-server-sdk": "2.6.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230321.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
           "path": "jsr.json",
           "jsonpath": "$.version"
         },
+        {
+          "type": "json",
+          "path": "example/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/cloudflare-server-sdk']"
+        },
         "src/createPlatformInfo.ts"
       ]
     },
@@ -21,10 +26,24 @@
       "extra-files": ["src/createPlatformInfo.ts"]
     },
     "packages/sdk/akamai-base": {
-      "extra-files": ["src/index.ts"]
+      "extra-files": [
+        "src/index.ts",
+        {
+          "type": "json",
+          "path": "example/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/akamai-server-base-sdk']"
+        }
+      ]
     },
     "packages/sdk/akamai-edgekv": {
-      "extra-files": ["src/index.ts"]
+      "extra-files": [
+        "src/index.ts",
+        {
+          "type": "json",
+          "path": "example/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/akamai-server-edgekv-sdk']"
+        }
+      ]
     },
     "packages/store/node-server-sdk-dynamodb": {},
     "packages/store/node-server-sdk-redis": {},


### PR DESCRIPTION
Does not include updates to the vercel examples which currently require the workspace.