### PR TITLE
fix: Ensure flag-detail-changed is called for deleted flags.

### DIFF
--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -509,6 +509,14 @@ export default class LDClientImpl implements LDClient {
       if (item?.flag && !item.flag.deleted) {
         const { reason, value, variation } = item.flag;
         details[flagKey] = createSuccessEvaluationDetail(value, variation, reason);
+      } else {
+        details[flagKey] = {
+          value: undefined,
+          // For backwards compatibility purposes reason and variationIndex are null instead of
+          // being undefined.
+          reason: null,
+          variationIndex: null,
+        };
       }
     });
     if (type === 'init') {

--- a/packages/shared/sdk-client/src/api/LDInspection.ts
+++ b/packages/shared/sdk-client/src/api/LDInspection.ts
@@ -71,6 +71,8 @@ export interface LDInspectionFlagDetailsChangedHandler {
  *
  * This interface should not be used by the application to access flags for the purpose of controlling application
  * flow. It is intended for monitoring, analytics, or debugging purposes.
+ *
+ * When a flag is deleted the `value` in the {@link LDEvaluationDetail} will be `undefined`.
  */
 export interface LDInspectionFlagDetailChangedHandler {
   type: 'flag-detail-changed';


### PR DESCRIPTION
Noticed this difference in behavior when auditing the code for browser telemetry.