### PR TITLE
chore: Skip lib check for browser adapter.

### DIFF
--- a/packages/sdk/browser/contract-tests/adapter/tsconfig.json
+++ b/packages/sdk/browser/contract-tests/adapter/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": true
   },
   "lib": ["ES6"],
   "exclude": ["**/*.test.ts", "dist", "node_modules"]


### PR DESCRIPTION
There are some dependencies which have a conflict in type definitions. This only affects the adapter for the contract tests, and doesn't affect runtime, so I am disabling lib checks on that project for the moment. I'll also try to track down what changed.