### PR TITLE
chore: Pin react types for react-universal.

### DIFF
--- a/packages/sdk/react-universal/example/package.json
+++ b/packages/sdk/react-universal/example/package.json
@@ -20,7 +20,7 @@
     "@next/eslint-plugin-next": "^14.2.4",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20",
-    "@types/react": "^18",
+    "@types/react": "18.3.13",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",

--- a/packages/sdk/react-universal/package.json
+++ b/packages/sdk/react-universal/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/jest": "^29.5.0",
-    "@types/react": "^18",
+    "@types/react": "18.3.13",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.45.0",


### PR DESCRIPTION
Newly released types do not compile. Pinning until that can be sorted.