### PR TITLE
chore: preparation work for FDv2 feature store and persistence support

### DIFF
--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/index.ts
@@ -107,6 +107,15 @@ export class EdgeFeatureStore implements LDFeatureStore {
   }
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
+    this.applyChanges(true, allData, undefined, callback);
+  }
+
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String | undefined,
+    callback: () => void,
+  ): void {
     callback();
   }
 

--- a/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
+++ b/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
@@ -100,7 +100,7 @@ export class EdgeFeatureStore implements LDFeatureStore {
   }
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
-    callback();
+    this.applyChanges(true, allData, undefined, callback);
   }
 
   applyChanges(

--- a/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
+++ b/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
@@ -103,6 +103,15 @@ export class EdgeFeatureStore implements LDFeatureStore {
     callback();
   }
 
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String | undefined,
+    callback: () => void,
+  ): void {
+    callback();
+  }
+
   getDescription(): string {
     return this._description;
   }

--- a/packages/shared/sdk-server-edge/src/utils/mockFeatureStore.ts
+++ b/packages/shared/sdk-server-edge/src/utils/mockFeatureStore.ts
@@ -6,6 +6,7 @@ const mockFeatureStore: LDFeatureStore = {
   init: jest.fn(),
   initialized: jest.fn(),
   upsert: jest.fn(),
+  applyChanges: jest.fn(),
   get: jest.fn(),
   delete: jest.fn(),
 };

--- a/packages/shared/sdk-server/__tests__/data_sources/createPayloadListenersFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/createPayloadListenersFDv2.test.ts
@@ -88,6 +88,7 @@ describe('createPayloadListenerFDv2', () => {
     dataSourceUpdates = {
       init: jest.fn(),
       upsert: jest.fn(),
+      applyChanges: jest.fn(),
     };
     basisRecieved = jest.fn();
   });

--- a/packages/shared/sdk-server/__tests__/data_sources/createStreamListeners.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/createStreamListeners.test.ts
@@ -52,6 +52,7 @@ describe('createStreamListeners', () => {
     dataSourceUpdates = {
       init: jest.fn(),
       upsert: jest.fn(),
+      applyChanges: jest.fn(),
     };
     onPutCompleteHandler = jest.fn();
     onPatchCompleteHandler = jest.fn();

--- a/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
@@ -48,7 +48,7 @@ export interface LDDataSourceUpdates {
    * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
    * the value is an object that maps keys to entities. The actual type of this parameter is
    * `interfaces.FullDataSet<VersionedData>`.
-   * @param selector TODO
+   * @param selector opaque string that uniquely identifies the state that contains the changes
    * @param callback Will be called after the changes are applied.
    */
   applyChanges(

--- a/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
@@ -40,4 +40,11 @@ export interface LDDataSourceUpdates {
    *   Will be called after the upsert operation is complete.
    */
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void;
+
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String,
+    callback: () => void,
+  ): void;
 }

--- a/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
@@ -41,6 +41,16 @@ export interface LDDataSourceUpdates {
    */
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void;
 
+  /**
+   * @param basis If true, completely overwrites the current contents of the data store
+   * with the provided data.  If false, upserts the items in the provided data.  Upserts
+   * are made only if provided items have newer versions than existing items.
+   * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
+   * the value is an object that maps keys to entities. The actual type of this parameter is
+   * `interfaces.FullDataSet<VersionedData>`.
+   * @param selector TODO
+   * @param callback Will be called after the changes are applied.
+   */
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
@@ -137,6 +137,13 @@ export interface LDFeatureStore {
    */
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void;
 
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String | undefined,
+    callback: () => void,
+  ): void;
+
   /**
    * Tests whether the store is initialized.
    *

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
@@ -137,6 +137,16 @@ export interface LDFeatureStore {
    */
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void;
 
+  /**
+   * @param basis If true, completely overwrites the current contents of the data store
+   * with the provided data.  If false, upserts the items in the provided data.  Upserts
+   * are made only if provided items have newer versions than existing items.
+   * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
+   * the value is an object that maps keys to entities. The actual type of this parameter is
+   * `interfaces.FullDataSet<VersionedData>`.
+   * @param selector TODO
+   * @param callback Will be called after the changes are applied.
+   */
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
@@ -138,13 +138,16 @@ export interface LDFeatureStore {
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void;
 
   /**
+   * Applies the provided data onto the existing data, replacing all data or upserting depending
+   * on the basis parameter.
+   *
    * @param basis If true, completely overwrites the current contents of the data store
    * with the provided data.  If false, upserts the items in the provided data.  Upserts
    * are made only if provided items have newer versions than existing items.
    * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
    * the value is an object that maps keys to entities. The actual type of this parameter is
    * `interfaces.FullDataSet<VersionedData>`.
-   * @param selector TODO
+   * @param selector opaque string that uniquely identifies the state that contains the changes
    * @param callback Will be called after the changes are applied.
    */
   applyChanges(

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -59,6 +59,8 @@ const validations: Record<string, TypeValidator> = {
   hooks: TypeValidators.createTypeArray('Hook[]', {}),
 };
 
+
+
 /**
  * @internal
  */

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -59,8 +59,6 @@ const validations: Record<string, TypeValidator> = {
   hooks: TypeValidators.createTypeArray('Hook[]', {}),
 };
 
-
-
 /**
  * @internal
  */

--- a/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
+++ b/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
@@ -12,22 +12,6 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
 
   private _initCalled = false;
 
-  private _addItem(kind: DataKind, key: string, item: LDFeatureStoreItem) {
-    let items = this._allData[kind.namespace];
-    if (!items) {
-      items = {};
-      this._allData[kind.namespace] = items;
-    }
-    if (Object.hasOwnProperty.call(items, key)) {
-      const old = items[key];
-      if (!old || old.version < item.version) {
-        items[key] = item;
-      }
-    } else {
-      items[key] = item;
-    }
-  }
-
   get(kind: DataKind, key: string, callback: (res: LDFeatureStoreItem | null) => void): void {
     const items = this._allData[kind.namespace];
     if (items) {
@@ -95,9 +79,20 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
     } else {
       Object.entries(data).forEach(([namespace, items]) => {
         Object.keys(items || {}).forEach((key) => {
+          let existingItems = this._allData[namespace];
+          if (!existingItems) {
+            existingItems = {};
+            this._allData[namespace] = existingItems;
+          }
           const item = items[key];
-          // TODO: optimize this section, perhaps get rid of _addItem
-          this._addItem({ namespace }, key, item);
+          if (Object.hasOwnProperty.call(existingItems, key)) {
+            const old = existingItems[key];
+            if (!old || old.version < item.version) {
+              existingItems[key] = item;
+            }
+          } else {
+            existingItems[key] = item;
+          }
         });
       });
     }

--- a/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
+++ b/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
@@ -93,6 +93,7 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
           const item = items[key];
           if (Object.hasOwnProperty.call(existingItems, key)) {
             const old = existingItems[key];
+            // TODO: SDK-1046 - Determine if version check should be removed
             if (!old || old.version < item.version) {
               existingItems[key] = item;
             }

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -258,7 +258,19 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
     _selector: String | undefined,
     _callback: () => void,
   ): void {
-    // TODO: implement
+    // TODO: SDK-1029 - Transactional persistent store - update this to not iterate over items and instead send data to underlying PersistentDataStore
+    // no need for queue at the moment as init and upsert handle that, but as part of SDK-1029, queue may be needed
+    if (_basis) {
+      this.init(_data, _callback);
+    } else {
+      Object.entries(_data).forEach(([namespace, items]) => {
+        Object.keys(items || {}).forEach((key) => {
+          const item = items[key];
+          this.upsert({ namespace }, { key, ...item }, () => {});
+        });
+      });
+      _callback();
+    }
   }
 
   close(): void {

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -252,6 +252,15 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
     this.upsert(kind, { key, version, deleted: true }, callback);
   }
 
+  applyChanges(
+    _basis: boolean,
+    _data: LDFeatureStoreDataStorage,
+    _selector: String | undefined,
+    _callback: () => void,
+  ): void {
+    // TODO: implement
+  }
+
   close(): void {
     this._itemCache?.close();
     this._allItemsCache?.close();

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
@@ -51,6 +51,15 @@ export default class DynamoDBFeatureStore implements LDFeatureStore {
     this._wrapper.upsert(kind, data, callback);
   }
 
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String | undefined,
+    callback: () => void,
+  ): void {
+    this._wrapper.applyChanges(basis, data, selector, callback);
+  }
+
   initialized(callback: (isInitialized: boolean) => void): void {
     this._wrapper.initialized(callback);
   }

--- a/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
@@ -51,6 +51,15 @@ export default class RedisFeatureStore implements LDFeatureStore {
     this._wrapper.upsert(kind, data, callback);
   }
 
+  applyChanges(
+    basis: boolean,
+    data: LDFeatureStoreDataStorage,
+    selector: String | undefined,
+    callback: () => void,
+  ): void {
+    this._wrapper.applyChanges(basis, data, selector, callback);
+  }
+
   initialized(callback: (isInitialized: boolean) => void): void {
     this._wrapper.initialized(callback);
   }


### PR DESCRIPTION
Splitting these changes up into multiple PRs to keep them manageable and because we can't merge directly to main as `applyChanges` is dependent on transaction support in the PersistentDataStore.

Existing tests are exercising applyChanges, but through init, upsert, and delete.  Plan to add applyChanges tests in ta/fdv2-temporary-holding after transaction support is added to PersistentDataStore in a subsequent PR as part of SDK-1029