### PR TITLE
fix: Clear pending events buffer when registered.

### DIFF
--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -130,6 +130,7 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
     this._pendingEvents.forEach((event) => {
       this._client?.track(event.type, event.data);
     });
+    this._pendingEvents = [];
   }
 
   inspectors(): LDInspection[] {


### PR DESCRIPTION
After the client is registered there isn't any further use for the pending events.