### PR TITLE
chore: Add react-universal to release-please config.

### DIFF
--- a/packages/sdk/react-universal/package.json
+++ b/packages/sdk/react-universal/package.json
@@ -67,9 +67,9 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@launchdarkly/js-client-sdk-common": "^1.1.4",
-    "@launchdarkly/node-server-sdk": "^9.4.6",
-    "launchdarkly-js-client-sdk": "^3.4.0"
+    "@launchdarkly/js-client-sdk": "0.3.3",
+    "@launchdarkly/js-client-sdk-common": "1.12.1",
+    "@launchdarkly/node-server-sdk": "9.7.2"
   },
   "peerDependencies": {
     "react": "*"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,6 +51,9 @@
     "packages/sdk/browser": {
       "bump-minor-pre-major": true
     },
+    "packages/sdk/react-universal": {
+      "bump-minor-pre-major": true
+    },
     "packages/sdk/server-ai": {
       "bump-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
G'day sdk team, thank you for your continuing hard work to maintain the sdks. I recognize your efforts and appreciate you.

We are building a demo [sandbox](https://docs.google.com/document/d/1fBlcukglrD_im_7c83JPhrH0RW_jwWP8wHZKc7oZ_CQ/edit?tab=t.0) for customers to preview launchdarkly. tldr part of the work is to create data for this sandbox, including flag evals and coderefs. To generate these, we built a nextjs sample [app](https://github.com/launchdarkly-labs/sandbox-sample-app). We really wanted to use the react-universal sdk, but alas it was not even alpha-available. I remember it was waiting for the modern js sdk to be published, and now the time is (kinda) here.

So the ask is to have both the browser sdk (in alpha) and also the react-universal sdk in alpha so we can use them.

Thank you for considering and reviewing this pr.