### PR TITLE
feat: Make browser-telemetry specific inspector type.

### DIFF
--- a/packages/telemetry/browser-telemetry/__tests__/singleton/singletonMethods.test.ts
+++ b/packages/telemetry/browser-telemetry/__tests__/singleton/singletonMethods.test.ts
@@ -1,5 +1,3 @@
-import { LDInspection } from '@launchdarkly/js-client-sdk';
-
 import { Breadcrumb, LDClientTracking } from '../../src/api';
 import { BrowserTelemetry } from '../../src/api/BrowserTelemetry';
 import { getTelemetryInstance } from '../../src/singleton/singletonInstance';
@@ -11,6 +9,7 @@ import {
   inspectors,
   register,
 } from '../../src/singleton/singletonMethods';
+import { BrowserTelemetryInspector } from '../../src/api/client/BrowserTelemetryInspector';
 
 jest.mock('../../src/singleton/singletonInstance');
 
@@ -36,8 +35,8 @@ it('returns empty array when telemetry is not initialized for inspectors', () =>
 });
 
 it('returns inspectors when telemetry is initialized', () => {
-  const mockInspectors: LDInspection[] = [
-    { name: 'test-inspector', type: 'flag-used', method: () => {} },
+  const mockInspectors: BrowserTelemetryInspector[] = [
+    { name: 'test-inspector', type: 'flag-used', synchronous: true, method: () => {} },
   ];
   mockGetTelemetryInstance.mockReturnValue(mockTelemetry);
   mockTelemetry.inspectors.mockReturnValue(mockInspectors);

--- a/packages/telemetry/browser-telemetry/__tests__/singleton/singletonMethods.test.ts
+++ b/packages/telemetry/browser-telemetry/__tests__/singleton/singletonMethods.test.ts
@@ -1,5 +1,6 @@
 import { Breadcrumb, LDClientTracking } from '../../src/api';
 import { BrowserTelemetry } from '../../src/api/BrowserTelemetry';
+import { BrowserTelemetryInspector } from '../../src/api/client/BrowserTelemetryInspector';
 import { getTelemetryInstance } from '../../src/singleton/singletonInstance';
 import {
   addBreadcrumb,
@@ -9,7 +10,6 @@ import {
   inspectors,
   register,
 } from '../../src/singleton/singletonMethods';
-import { BrowserTelemetryInspector } from '../../src/api/client/BrowserTelemetryInspector';
 
 jest.mock('../../src/singleton/singletonInstance');
 

--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -3,7 +3,7 @@
  * This is only a type dependency and these types should be compatible between
  * SDKs.
  */
-import type { LDContext, LDEvaluationDetail, LDInspection } from '@launchdarkly/js-client-sdk';
+import type { LDContext, LDEvaluationDetail } from '@launchdarkly/js-client-sdk';
 
 import { BreadcrumbFilter, LDClientLogging, LDClientTracking, MinLogger } from './api';
 import { Breadcrumb, FeatureManagementBreadcrumb } from './api/Breadcrumb';
@@ -18,6 +18,7 @@ import FetchCollector from './collectors/http/fetch';
 import XhrCollector from './collectors/http/xhr';
 import defaultUrlFilter from './filters/defaultUrlFilter';
 import makeInspectors from './inspectors';
+import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector';
 import { fallbackLogger, prefixLog } from './logging';
 import { ParsedOptions, ParsedStackOptions } from './options';
 import randomUuidV4 from './randomUuidV4';
@@ -94,7 +95,7 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
 
   private _breadcrumbs: Breadcrumb[] = [];
 
-  private _inspectorInstances: LDInspection[] = [];
+  private _inspectorInstances: BrowserTelemetryInspector[] = [];
   private _collectors: Collector[] = [];
   private _sessionId: string = randomUuidV4();
 
@@ -149,7 +150,7 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
     );
 
     const impl = this;
-    const inspectors: LDInspection[] = [];
+    const inspectors: BrowserTelemetryInspector[] = [];
     makeInspectors(_options, inspectors, impl);
     this._inspectorInstances.push(...inspectors);
 
@@ -184,7 +185,7 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
     }
   }
 
-  inspectors(): LDInspection[] {
+  inspectors(): BrowserTelemetryInspector[] {
     return this._inspectorInstances;
   }
 

--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -8,6 +8,7 @@ import type { LDContext, LDEvaluationDetail } from '@launchdarkly/js-client-sdk'
 import { BreadcrumbFilter, LDClientLogging, LDClientTracking, MinLogger } from './api';
 import { Breadcrumb, FeatureManagementBreadcrumb } from './api/Breadcrumb';
 import { BrowserTelemetry } from './api/BrowserTelemetry';
+import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector';
 import { Collector } from './api/Collector';
 import { ErrorData } from './api/ErrorData';
 import { EventData } from './api/EventData';
@@ -18,7 +19,6 @@ import FetchCollector from './collectors/http/fetch';
 import XhrCollector from './collectors/http/xhr';
 import defaultUrlFilter from './filters/defaultUrlFilter';
 import makeInspectors from './inspectors';
-import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector';
 import { fallbackLogger, prefixLog } from './logging';
 import { ParsedOptions, ParsedStackOptions } from './options';
 import randomUuidV4 from './randomUuidV4';

--- a/packages/telemetry/browser-telemetry/src/api/BrowserTelemetry.ts
+++ b/packages/telemetry/browser-telemetry/src/api/BrowserTelemetry.ts
@@ -1,8 +1,6 @@
-import type { LDInspection } from '@launchdarkly/js-client-sdk';
-
 import { Breadcrumb } from './Breadcrumb';
-import { LDClientTracking } from './client/LDClientTracking';
 import { BrowserTelemetryInspector } from './client/BrowserTelemetryInspector';
+import { LDClientTracking } from './client/LDClientTracking';
 
 /**
  * Interface for browser-based telemetry collection in LaunchDarkly SDKs.
@@ -16,7 +14,7 @@ export interface BrowserTelemetry {
    * Returns an array of active SDK inspectors to use with SDK versions that do
    * not support hooks.
    *
-   * @returns An array of {@link LDInspection} objects.
+   * @returns An array of {@link BrowserTelemetryInspector} objects.
    */
   inspectors(): BrowserTelemetryInspector[];
 

--- a/packages/telemetry/browser-telemetry/src/api/BrowserTelemetry.ts
+++ b/packages/telemetry/browser-telemetry/src/api/BrowserTelemetry.ts
@@ -2,6 +2,7 @@ import type { LDInspection } from '@launchdarkly/js-client-sdk';
 
 import { Breadcrumb } from './Breadcrumb';
 import { LDClientTracking } from './client/LDClientTracking';
+import { BrowserTelemetryInspector } from './client/BrowserTelemetryInspector';
 
 /**
  * Interface for browser-based telemetry collection in LaunchDarkly SDKs.
@@ -17,7 +18,7 @@ export interface BrowserTelemetry {
    *
    * @returns An array of {@link LDInspection} objects.
    */
-  inspectors(): LDInspection[];
+  inspectors(): BrowserTelemetryInspector[];
 
   /**
    * Captures an Error object for telemetry purposes.

--- a/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
@@ -1,0 +1,7 @@
+
+export interface BrowserTelemetryInspector {
+  type: 'flag-used' | 'flag-detail-changed';
+  name: string;
+  synchronous: boolean;
+  method: (...args: any[]) => void;
+}

--- a/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
@@ -2,8 +2,8 @@
  * A less constrained version of the LDInspection interface in order to allow for greater compatibility between
  * SDK versions.
  *
- * This interface is not intended for use by the application developer and is instead intended as a compatibility bridge
- *  to support multiple SDK versions.
+ * This interface is not intended for use by application developers and is instead intended as a compatibility bridge
+ * to support multiple SDK versions.
  */
 export interface BrowserTelemetryInspector {
   /**

--- a/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/BrowserTelemetryInspector.ts
@@ -1,7 +1,29 @@
-
+/**
+ * A less constrained version of the LDInspection interface in order to allow for greater compatibility between
+ * SDK versions.
+ *
+ * This interface is not intended for use by the application developer and is instead intended as a compatibility bridge
+ *  to support multiple SDK versions.
+ */
 export interface BrowserTelemetryInspector {
+  /**
+   * The telemetry package only requires flag-detail-changed inspectors and flag-used inspectors.
+   */
   type: 'flag-used' | 'flag-detail-changed';
+
+  /**
+   * The name of the inspector, used for debugging purposes.
+   */
   name: string;
+  /**
+   * Whether the inspector is synchronous.
+   */
   synchronous: boolean;
+  /**
+   * The method to call when the inspector is triggered.
+   *
+   * The typing here is intentionally loose to allow for greater compatibility between SDK versions.
+   * This function should ONLY be called by an SDK instance and not by an application developer.
+   */
   method: (...args: any[]) => void;
 }

--- a/packages/telemetry/browser-telemetry/src/inspectors.ts
+++ b/packages/telemetry/browser-telemetry/src/inspectors.ts
@@ -1,7 +1,8 @@
-import type { LDContext, LDEvaluationDetail, LDInspection } from '@launchdarkly/js-client-sdk';
+import type { LDContext, LDEvaluationDetail } from '@launchdarkly/js-client-sdk';
 
 import BrowserTelemetryImpl from './BrowserTelemetryImpl.js';
 import { ParsedOptions } from './options.js';
+import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector.js';
 
 /**
  * Create inspectors to register with an LDClient instance.
@@ -12,7 +13,7 @@ import { ParsedOptions } from './options.js';
  */
 export default function makeInspectors(
   options: ParsedOptions,
-  inspectors: LDInspection[],
+  inspectors: BrowserTelemetryInspector[],
   telemetry: BrowserTelemetryImpl,
 ) {
   if (options.breadcrumbs.evaluations) {

--- a/packages/telemetry/browser-telemetry/src/inspectors.ts
+++ b/packages/telemetry/browser-telemetry/src/inspectors.ts
@@ -1,8 +1,8 @@
 import type { LDContext, LDEvaluationDetail } from '@launchdarkly/js-client-sdk';
 
+import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector.js';
 import BrowserTelemetryImpl from './BrowserTelemetryImpl.js';
 import { ParsedOptions } from './options.js';
-import { BrowserTelemetryInspector } from './api/client/BrowserTelemetryInspector.js';
 
 /**
  * Create inspectors to register with an LDClient instance.

--- a/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
+++ b/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
@@ -1,9 +1,7 @@
-import type { LDInspection } from '@launchdarkly/js-client-sdk';
-
 import { LDClientTracking } from '../api';
 import { Breadcrumb } from '../api/Breadcrumb';
-import { getTelemetryInstance } from './singletonInstance';
 import { BrowserTelemetryInspector } from '../api/client/BrowserTelemetryInspector';
+import { getTelemetryInstance } from './singletonInstance';
 
 /**
  * Returns an array of active SDK inspectors to use with SDK versions that do
@@ -12,7 +10,7 @@ import { BrowserTelemetryInspector } from '../api/client/BrowserTelemetryInspect
  * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
  * If telemetry is not initialized, this method will return an empty array.
  *
- * @returns An array of {@link LDInspection} objects.
+ * @returns An array of {@link BrowserTelemetryInspector} objects.
  */
 export function inspectors(): BrowserTelemetryInspector[] {
   return getTelemetryInstance()?.inspectors() || [];

--- a/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
+++ b/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
@@ -3,6 +3,7 @@ import type { LDInspection } from '@launchdarkly/js-client-sdk';
 import { LDClientTracking } from '../api';
 import { Breadcrumb } from '../api/Breadcrumb';
 import { getTelemetryInstance } from './singletonInstance';
+import { BrowserTelemetryInspector } from '../api/client/BrowserTelemetryInspector';
 
 /**
  * Returns an array of active SDK inspectors to use with SDK versions that do
@@ -13,7 +14,7 @@ import { getTelemetryInstance } from './singletonInstance';
  *
  * @returns An array of {@link LDInspection} objects.
  */
-export function inspectors(): LDInspection[] {
+export function inspectors(): BrowserTelemetryInspector[] {
   return getTelemetryInstance()?.inspectors() || [];
 }
 


### PR DESCRIPTION
This is a compatibility improvement PR intended to make the telemetry package less dependent on a specific SDK package.

The inspector interface between 3.x and 4.x has some minor differences and this provides a more broad interface that is compatible with both.