### PR TITLE
feat: Add the ability to filter errors.

### DIFF
--- a/packages/telemetry/browser-telemetry/src/api/Options.ts
+++ b/packages/telemetry/browser-telemetry/src/api/Options.ts
@@ -1,5 +1,6 @@
 import { Breadcrumb } from './Breadcrumb';
 import { Collector } from './Collector';
+import { ErrorData } from './ErrorData';
 import { MinLogger } from './MinLogger';
 
 /**
@@ -27,11 +28,19 @@ export interface UrlFilter {
 /**
  * Interface for breadcrumb filters.
  *
- * Given a breadcrumb the filter may return a modified breadcrumb or undefined to
- * exclude the breadcrumb.
+ * Given a breadcrumb the filter may return a modified breadcrumb or undefined to exclude the breadcrumb.
  */
 export interface BreadcrumbFilter {
   (breadcrumb: Breadcrumb): Breadcrumb | undefined;
+}
+
+/**
+ * Interface for filtering error data before it is sent to LaunchDarkly.
+ *
+ * Given {@link ErrorData} the filter may return modified data or undefined to exclude the breadcrumb.
+ */
+export interface ErrorDataFilter {
+  (event: ErrorData): ErrorData | undefined;
 }
 
 export interface HttpBreadcrumbOptions {
@@ -197,4 +206,14 @@ export interface Options {
    * logger. The 3.x SDKs do not expose their logger.
    */
   logger?: MinLogger;
+
+  /**
+   * Custom error data filters.
+   *
+   * Can be used to redact or modify error data.
+   *
+   * For filtering breadcrumbs or URLs in error data, see {@link breadcrumbs.filters} and
+   * {@link breadcrumbs.http.customUrlFilter}.
+   */
+  errorFilters?: ErrorDataFilter[];
 }

--- a/packages/telemetry/browser-telemetry/src/options.ts
+++ b/packages/telemetry/browser-telemetry/src/options.ts
@@ -2,6 +2,7 @@ import { Collector } from './api/Collector';
 import { MinLogger } from './api/MinLogger';
 import {
   BreadcrumbFilter,
+  ErrorDataFilter,
   HttpBreadcrumbOptions,
   Options,
   StackOptions,
@@ -32,6 +33,7 @@ export function defaultOptions(): ParsedOptions {
     },
     maxPendingEvents: 100,
     collectors: [],
+    errorFilters: [],
   };
 }
 
@@ -211,6 +213,13 @@ export default function parse(options: Options, logger?: MinLogger): ParsedOptio
       }),
     ],
     logger: parseLogger(options),
+    errorFilters: itemOrDefault(options.errorFilters, defaults.errorFilters, (item) => {
+      if (Array.isArray(item)) {
+        return true;
+      }
+      logger?.warn(wrongOptionType('errorFilters', 'ErrorDataFilter[]', typeof item));
+      return false;
+    }),
   };
 }
 
@@ -324,4 +333,9 @@ export interface ParsedOptions {
    * Logger to use for warnings.
    */
   logger?: MinLogger;
+
+  /**
+   * Custom error data filters.
+   */
+  errorFilters: ErrorDataFilter[];
 }


### PR DESCRIPTION
This PR adds support for error level filtering. This is the highest level filter type capable of filtering on any data.

Other filters are provided to simplify the implementation of filtering across all error types. Breadcrumb filters could be implemented in terms of an error filter, but they would have higher complexity and different performance characteristics. For example with a breadcrumb filter we filter that breadcrumb regardless of how many events it may appear in, versus having to filter that same breadcrumb each time an event is captures.

Custom url filters operate at the HTTP capture level similarly reducing the frequency of redaction.