### PR TITLE
chore: Add browser-telemetry to release please.

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -21,6 +21,7 @@ on:
           - packages/telemetry/node-server-sdk-otel
           - packages/sdk/browser
           - packages/sdk/server-ai
+          - packages/telemetry/browser-telemetry
 name: Publish Documentation
 jobs:
   build-publish:

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -34,6 +34,7 @@ on:
           - packages/tooling/jest
           - packages/sdk/browser
           - packages/sdk/server-ai
+          - packages/telemetry/browser-telemetry
       prerelease:
         description: 'Is this a prerelease. If so, then the latest tag will not be updated in npm.'
         type: boolean

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
       package-react-universal-release: ${{ steps.release.outputs['packages/sdk/react-universal--release_created'] }}
       package-browser-released: ${{ steps.release.outputs['packages/sdk/browser--release_created'] }}
       package-server-ai-released: ${{ steps.release.outputs['packages/sdk/server-ai--release_created'] }}
+      package-browser-telemetry-released: ${{ steps.release.outputs['packages/telemetry/browser-telemetry--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -397,4 +398,24 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/sdk/server-ai
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-browser-telemetry:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-browser']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-browser-telemetry-released == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
+      - id: release-browser-telemetry
+        name: Full release of packages/telemetry/browser-telemetry
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/telemetry/browser-telemetry
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -14,5 +14,6 @@
   "packages/sdk/react-native": "10.9.4",
   "packages/telemetry/node-server-sdk-otel": "1.1.3",
   "packages/sdk/browser": "0.4.0",
-  "packages/sdk/server-ai": "0.7.1"
+  "packages/sdk/server-ai": "0.7.1",
+  "packages/telemetry/browser-telemetry": "0.0.9"
 }

--- a/packages/telemetry/browser-telemetry/src/api/Breadcrumb.ts
+++ b/packages/telemetry/browser-telemetry/src/api/Breadcrumb.ts
@@ -68,7 +68,7 @@ export interface Breadcrumb {
 /**
  * Utility type which allows for easy extension of base breadcrumb type.
  */
-type ImplementsCrumb<U extends Breadcrumb> = U;
+export type ImplementsCrumb<U extends Breadcrumb> = U;
 
 /**
  * Type for custom breadcrumbs.

--- a/packages/telemetry/browser-telemetry/src/api/Options.ts
+++ b/packages/telemetry/browser-telemetry/src/api/Options.ts
@@ -212,8 +212,10 @@ export interface Options {
    *
    * Can be used to redact or modify error data.
    *
-   * For filtering breadcrumbs or URLs in error data, see {@link breadcrumbs.filters} and
-   * {@link breadcrumbs.http.customUrlFilter}.
+   * If any filter throws an exception, then the error data will be discarded.
+   *
+   * For filtering breadcrumbs or URLs in error data, refer to the `breadcrumbs.filters` option in {@link breadcrumbs} and
+   * `breadcrumbs.http.customUrlFilter` - {@link HttpBreadcrumbOptions.customUrlFilter}.
    */
   errorFilters?: ErrorDataFilter[];
 }

--- a/packages/telemetry/browser-telemetry/src/api/client/index.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/index.ts
@@ -1,2 +1,3 @@
 export * from './LDClientTracking';
 export * from './LDClientLogging';
+export * from './BrowserTelemetryInspector';

--- a/packages/telemetry/browser-telemetry/src/api/index.ts
+++ b/packages/telemetry/browser-telemetry/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './Recorder';
 export * from './stack';
 export * from './client';
 export * from './MinLogger';
+export * from './BrowserTelemetry';

--- a/packages/telemetry/browser-telemetry/src/index.ts
+++ b/packages/telemetry/browser-telemetry/src/index.ts
@@ -11,7 +11,7 @@ export * from './singleton';
 /**
  * Initialize a new telemetry instance.
  *
- * This instance is not global. Generally developers should use {@link initializeTelemetry} instead.
+ * This instance is not global. Generally developers should use {@link initTelemetry} instead.
  *
  * If for some reason multiple telemetry instances are needed, this method can be used to create a new instance.
  * Instances are not aware of each other and may send duplicate data from automatically captured events.
@@ -19,7 +19,7 @@ export * from './singleton';
  * @param options The options to use for the telemetry instance.
  * @returns A telemetry instance.
  */
-export function initializeTelemetryInstance(options?: Options): BrowserTelemetry {
+export function initTelemetryInstance(options?: Options): BrowserTelemetry {
   const parsedOptions = parse(options || {}, safeMinLogger(options?.logger));
   return new BrowserTelemetryImpl(parsedOptions);
 }

--- a/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
+++ b/packages/telemetry/browser-telemetry/src/singleton/singletonMethods.ts
@@ -7,7 +7,7 @@ import { getTelemetryInstance } from './singletonInstance';
  * Returns an array of active SDK inspectors to use with SDK versions that do
  * not support hooks.
  *
- * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
+ * Telemetry must be initialized, using {@link initTelemetry} before calling this method.
  * If telemetry is not initialized, this method will return an empty array.
  *
  * @returns An array of {@link BrowserTelemetryInspector} objects.
@@ -23,7 +23,7 @@ export function inspectors(): BrowserTelemetryInspector[] {
  * Unhandled errors are automatically captured, but this method can be used
  * to capture errors which were handled, but are still useful for telemetry.
  *
- * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
+ * Telemetry must be initialized, using {@link initTelemetry} before calling this method.
  * If telemetry is not initialized, then the exception will be discarded.
  *
  * @param exception The Error object to capture
@@ -41,7 +41,7 @@ export function captureError(exception: Error): void {
  *
  * For most errors {@link captureError} should be used.
  *
- * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
+ * Telemetry must be initialized, using {@link initTelemetry} before calling this method.
  * If telemetry is not initialized, then the error event will be discarded.
  *
  * @param errorEvent The ErrorEvent to capture
@@ -57,7 +57,7 @@ export function captureErrorEvent(errorEvent: ErrorEvent): void {
  * used for capturing manual breadcrumbs. For application specific breadcrumbs
  * the {@link CustomBreadcrumb} type can be used.
  *
- * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
+ * Telemetry must be initialized, using {@link initTelemetry} before calling this method.
  * If telemetry is not initialized, then the breadcrumb will be discarded.
  *
  * @param breadcrumb The breadcrumb to add.
@@ -73,7 +73,7 @@ export function addBreadcrumb(breadcrumb: Breadcrumb): void {
  * client instance. The client instance will be used to report telemetry
  * to LaunchDarkly and also for collecting flag and context data.
  *
- * Telemetry must be initialized, using {@link initializeTelemetry} before calling this method.
+ * Telemetry must be initialized, using {@link initTelemetry} before calling this method.
  * If telemetry is not initialized, then the client will not be registered, and no events will be sent to LaunchDarkly.
  *
  * @param client The {@link LDClientTracking} instance to register for
@@ -90,7 +90,7 @@ export function register(client: LDClientTracking): void {
  * where collection needs to be stopped independent of application
  * lifecycle.
  *
- * If telemetry is not initialized, using {@link initializeTelemetry}, then this method will do nothing.
+ * If telemetry is not initialized, using {@link initTelemetry}, then this method will do nothing.
  */
 export function close(): void {
   getTelemetryInstance()?.close();

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -65,6 +65,9 @@
           "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai']"
         }
       ]
+    },
+    "packages/telemetry/browser-telemetry": {
+      "bump-minor-pre-major": true
     }
   },
   "plugins": [


### PR DESCRIPTION
Add release-please support for browser-telemetry and address a number of minor issues.

BEGIN_COMMIT_OVERRIDE
chore: Add browser-telemetry to release please.
fix: Export BrowserTelemetry, BrowserTelemetryInspector, and ImplementsCrumb.
chore: Update documentation comment links that were invalid.
feat: Rename initializeTelemetryInstance to initTelemetryInstance for consistency with initTelemetry. 
END_COMMIT_OVERRIDE