### PR TITLE
fix: Fix race condition with client registration.

### DIFF
--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -34,6 +34,10 @@ const GENERIC_EXCEPTION = 'generic';
 const NULL_EXCEPTION_MESSAGE = 'exception was null or undefined';
 const MISSING_MESSAGE = 'exception had no message';
 
+// Timeout for client initialization. The telemetry SDK doesn't require that the client be initialized, but it does
+// require that the context processing that happens during initialization complete. This is some subset of the total
+// initialization time, but we don't care if initialization actually completes within the, just that the context
+// is available for event sending.
 const INITIALIZATION_TIMEOUT = 5;
 
 /**

--- a/packages/telemetry/browser-telemetry/src/api/client/LDClientInitialization.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/LDClientInitialization.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal client interface which allows waiting for initialization.
+ */
+export interface LDClientInitialization {
+  waitForInitialization(timeout?: number): Promise<void>;
+}

--- a/packages/telemetry/browser-telemetry/src/api/client/index.ts
+++ b/packages/telemetry/browser-telemetry/src/api/client/index.ts
@@ -1,3 +1,4 @@
 export * from './LDClientTracking';
 export * from './LDClientLogging';
 export * from './BrowserTelemetryInspector';
+export * from './LDClientInitialization';


### PR DESCRIPTION
During initialization the js-client-sdk does some context processing. This is an async operation which will add keys to anonymous contexts. Being as this doesn't happen synchronously within the initialization call there is a possibility that you register the telemetry SDK before that initialization is complete.

This PR updates the registration to attempt to wait for initialization. This is a larger window than we need to wait, but ensures that process will be complete. 