### PR TITLE
fix(react-native): check for nullability in SettingsManager?.settings

### DIFF
--- a/packages/sdk/react-native/src/platform/locale.ts
+++ b/packages/sdk/react-native/src/platform/locale.ts
@@ -6,7 +6,7 @@ import { NativeModules, Platform } from 'react-native';
  */
 const locale =
   Platform.OS === 'ios'
-    ? NativeModules.SettingsManager?.settings.AppleLocale // iOS
+    ? NativeModules.SettingsManager?.settings?.AppleLocale // iOS
     : NativeModules.I18nManager?.localeIdentifier;
 
 export default locale;


### PR DESCRIPTION
This check seems necessary for the new architecture (on React Native 0.77) to prevent an immediate crash.

Closes https://github.com/launchdarkly/js-core/issues/757
