### PR TITLE
feat: Add cacheTtlMs option

### DIFF
--- a/packages/sdk/akamai-edgekv/__tests__/index.test.ts
+++ b/packages/sdk/akamai-edgekv/__tests__/index.test.ts
@@ -19,7 +19,12 @@ describe('init', () => {
 
   describe('init with Edge KV', () => {
     beforeAll(async () => {
-      ldClient = initWithEdgeKV({ namespace: 'akamai-test', group: 'Akamai', sdkKey, options: { logger } });
+      ldClient = initWithEdgeKV({
+        namespace: 'akamai-test',
+        group: 'Akamai',
+        sdkKey,
+        options: { logger },
+      });
       await ldClient.waitForInitialization();
     });
 
@@ -41,9 +46,9 @@ describe('init', () => {
 
     it('should not log a warning about initialization', async () => {
       const spy = jest.spyOn(logger, 'warn');
-      const value = await ldClient.variation(flagKey1, context, false);
+      await ldClient.variation(flagKey1, context, false);
       expect(spy).not.toHaveBeenCalled();
-    })
+    });
 
     describe('flags', () => {
       it('variation default', async () => {

--- a/packages/sdk/akamai-edgekv/src/index.ts
+++ b/packages/sdk/akamai-edgekv/src/index.ts
@@ -8,22 +8,10 @@
  *
  * @packageDocumentation
  */
-import {
-  init as initEdge,
-  LDClient,
-  LDOptions as LDCommonAkamaiOptions,
-} from '@launchdarkly/akamai-edgeworker-sdk-common';
+import { init as initEdge, LDClient, LDOptions } from '@launchdarkly/akamai-edgeworker-sdk-common';
 import { BasicLogger } from '@launchdarkly/js-server-sdk-common';
 
 import EdgeKVProvider from './edgekv/edgeKVProvider';
-
-export type LDOptions = LDCommonAkamaiOptions & {
-  /**
-   * The time-to-live for the cache in milliseconds. The default is 100ms. A
-   * value of 0 will cache indefinitely.
-   */
-  cacheTtlMs?: number;
-};
 
 export * from '@launchdarkly/akamai-edgeworker-sdk-common';
 

--- a/packages/sdk/akamai-edgekv/src/index.ts
+++ b/packages/sdk/akamai-edgekv/src/index.ts
@@ -8,10 +8,22 @@
  *
  * @packageDocumentation
  */
-import { init as initEdge, LDClient, LDOptions } from '@launchdarkly/akamai-edgeworker-sdk-common';
+import {
+  init as initEdge,
+  LDClient,
+  LDOptions as LDCommonAkamaiOptions,
+} from '@launchdarkly/akamai-edgeworker-sdk-common';
 import { BasicLogger } from '@launchdarkly/js-server-sdk-common';
 
 import EdgeKVProvider from './edgekv/edgeKVProvider';
+
+export type LDOptions = LDCommonAkamaiOptions & {
+  /**
+   * The time-to-live for the cache in milliseconds. The default is 100ms. A
+   * value of 0 will cache indefinitely.
+   */
+  cacheTtlMs?: number;
+};
 
 export * from '@launchdarkly/akamai-edgeworker-sdk-common';
 
@@ -34,12 +46,13 @@ export const init = ({
   sdkKey,
 }: AkamaiLDClientParams): LDClient => {
   const logger = options.logger ?? BasicLogger.get();
+  const cacheTtlMs = options.cacheTtlMs ?? 100;
 
   const edgekvProvider = new EdgeKVProvider({ namespace, group, logger });
 
   return initEdge({
     sdkKey,
-    options: { ...options, logger },
+    options: { ...options, logger, cacheTtlMs },
     featureStoreProvider: edgekvProvider,
     platformName: 'Akamai EdgeWorker',
     sdkName: '@launchdarkly/akamai-server-edgekv-sdk',

--- a/packages/sdk/svelte/svelte.config.js
+++ b/packages/sdk/svelte/svelte.config.js
@@ -11,8 +11,8 @@ const config = {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
-    adapter: adapter()
-  }
+    adapter: adapter(),
+  },
 };
 
 export default config;

--- a/packages/sdk/svelte/svelte.config.js
+++ b/packages/sdk/svelte/svelte.config.js
@@ -11,8 +11,8 @@ const config = {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
-    adapter: adapter(),
-  },
+    adapter: adapter()
+  }
 };
 
 export default config;

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
@@ -66,21 +66,23 @@ describe('given a mock edge provider with test data', () => {
     });
 
     it('caches expires after duration', async () => {
+      jest.spyOn(Date, 'now').mockImplementation(() => 0);
       const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 50);
       await cacheProvider.get('rootKey');
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(1);
 
-      await jest.advanceTimersByTimeAsync(20);
+      jest.spyOn(Date, 'now').mockImplementation(() => 20);
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(1);
 
-      await jest.advanceTimersByTimeAsync(30);
+      jest.spyOn(Date, 'now').mockImplementation(() => 50);
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(2);
     });
 
     it('prefetch respects cache TTL', async () => {
+      jest.spyOn(Date, 'now').mockImplementation(() => 0);
       const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 50);
       await cacheProvider.get('rootKey');
       await cacheProvider.get('rootKey');
@@ -90,7 +92,7 @@ describe('given a mock edge provider with test data', () => {
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(1);
 
-      await jest.advanceTimersByTimeAsync(50);
+      jest.spyOn(Date, 'now').mockImplementation(() => 50);
       await cacheProvider.prefetchPayloadFromOriginStore();
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(2);

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
@@ -2,7 +2,7 @@ import { EdgeProvider } from '../../src/featureStore';
 import CacheableStoreProvider from '../../src/featureStore/cacheableStoreProvider';
 import * as testData from '../testData.json';
 
-describe('CacheableStoreProvider', () => {
+describe('given a mock edge provider with test data', () => {
   const mockEdgeProvider: EdgeProvider = {
     get: jest.fn(),
   };
@@ -44,7 +44,7 @@ describe('CacheableStoreProvider', () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
 
-    it('prefetch does not reset', async () => {
+    it('does not reset on prefetch', async () => {
       const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 0);
       await cacheProvider.get('rootKey');
       await cacheProvider.get('rootKey');

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
@@ -9,7 +9,7 @@ describe('given a mock edge provider with test data', () => {
   const mockGet = mockEdgeProvider.get as jest.Mock;
 
   beforeEach(() => {
-    jest.useFakeTimers()
+    jest.useFakeTimers();
     mockGet.mockImplementation(() => Promise.resolve(JSON.stringify(testData)));
   });
 

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
@@ -9,6 +9,7 @@ describe('given a mock edge provider with test data', () => {
   const mockGet = mockEdgeProvider.get as jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers()
     mockGet.mockImplementation(() => Promise.resolve(JSON.stringify(testData)));
   });
 
@@ -70,8 +71,11 @@ describe('given a mock edge provider with test data', () => {
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(1);
 
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await jest.advanceTimersByTimeAsync(20);
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(30);
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(2);
     });
@@ -86,8 +90,7 @@ describe('given a mock edge provider with test data', () => {
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(1);
 
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await jest.advanceTimersByTimeAsync(50);
       await cacheProvider.prefetchPayloadFromOriginStore();
       await cacheProvider.get('rootKey');
       expect(mockGet).toHaveBeenCalledTimes(2);

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cacheableStore.test.ts
@@ -1,0 +1,96 @@
+import { EdgeProvider } from '../../src/featureStore';
+import CacheableStoreProvider from '../../src/featureStore/cacheableStoreProvider';
+import * as testData from '../testData.json';
+
+describe('CacheableStoreProvider', () => {
+  const mockEdgeProvider: EdgeProvider = {
+    get: jest.fn(),
+  };
+  const mockGet = mockEdgeProvider.get as jest.Mock;
+
+  beforeEach(() => {
+    mockGet.mockImplementation(() => Promise.resolve(JSON.stringify(testData)));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('without cache TTL', () => {
+    it('caches initial request', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey');
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('can force a refresh', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey');
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await cacheProvider.prefetchPayloadFromOriginStore();
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('with infinite cache ttl', () => {
+    it('caches initial request', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 0);
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('prefetch does not reset', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 0);
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await cacheProvider.prefetchPayloadFromOriginStore();
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with finite cache ttl', () => {
+    it('caches initial request', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 50);
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches expires after duration', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 50);
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      // eslint-disable-next-line no-promise-executor-return
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('prefetch respects cache TTL', async () => {
+      const cacheProvider = new CacheableStoreProvider(mockEdgeProvider, 'rootKey', 50);
+      await cacheProvider.get('rootKey');
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      await cacheProvider.prefetchPayloadFromOriginStore();
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+
+      // eslint-disable-next-line no-promise-executor-return
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      await cacheProvider.prefetchPayloadFromOriginStore();
+      await cacheProvider.get('rootKey');
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
@@ -34,6 +34,10 @@ class LDClient extends LDClientImpl {
     this._cacheableStoreProvider = storeProvider;
   }
 
+  override initialized(): boolean {
+    return true;
+  }
+
   override waitForInitialization(): Promise<LDClientType> {
     // we need to resolve the promise immediately because Akamai's runtime doesnt
     // have a setimeout so everything executes synchronously.

--- a/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
@@ -46,6 +46,7 @@ class LDClient extends LDClientImpl {
     defaultValue: LDFlagValue,
     callback?: (err: any, res: LDFlagValue) => void,
   ): Promise<LDFlagValue> {
+    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.variation(key, context, defaultValue, callback);
   }
 
@@ -55,6 +56,7 @@ class LDClient extends LDClientImpl {
     defaultValue: LDFlagValue,
     callback?: (err: any, res: LDEvaluationDetail) => void,
   ): Promise<LDEvaluationDetail> {
+    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.variationDetail(key, context, defaultValue, callback);
   }
 
@@ -63,6 +65,7 @@ class LDClient extends LDClientImpl {
     options?: LDFlagsStateOptions,
     callback?: (err: Error | null, res: LDFlagsState) => void,
   ): Promise<LDFlagsState> {
+    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.allFlagsState(context, options, callback);
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/api/LDClient.ts
@@ -46,7 +46,6 @@ class LDClient extends LDClientImpl {
     defaultValue: LDFlagValue,
     callback?: (err: any, res: LDFlagValue) => void,
   ): Promise<LDFlagValue> {
-    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.variation(key, context, defaultValue, callback);
   }
 
@@ -56,7 +55,6 @@ class LDClient extends LDClientImpl {
     defaultValue: LDFlagValue,
     callback?: (err: any, res: LDEvaluationDetail) => void,
   ): Promise<LDEvaluationDetail> {
-    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.variationDetail(key, context, defaultValue, callback);
   }
 
@@ -65,7 +63,6 @@ class LDClient extends LDClientImpl {
     options?: LDFlagsStateOptions,
     callback?: (err: Error | null, res: LDFlagsState) => void,
   ): Promise<LDFlagsState> {
-    await this._cacheableStoreProvider.prefetchPayloadFromOriginStore();
     return super.allFlagsState(context, options, callback);
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -2,14 +2,13 @@ import { EdgeProvider } from '.';
 
 /**
  * Wraps around an edge provider to cache a copy of the sdk payload locally an explicit request is made to refetch data from the origin.
- * The wrapper is neccessary to ensure that we dont make redundant sub-requests from Akamai to fetch an entire environment payload.
+ * The wrapper is necessary to ensure that we don't make redundant sub-requests from Akamai to fetch an entire environment payload.
  */
 export default class CacheableStoreProvider implements EdgeProvider {
   cache: string | null | undefined;
 
   constructor(
     private readonly _edgeProvider: EdgeProvider,
-    private readonly _rootKey: string,
   ) {}
 
   /**
@@ -23,17 +22,5 @@ export default class CacheableStoreProvider implements EdgeProvider {
     }
 
     return this.cache;
-  }
-
-  /**
-   * Invalidates cache and fetch environment payload data from origin. The result of this data is cached in memory.
-   * You should only call this function within a feature store to pre-fetch and cache payload data in environments
-   * where its expensive to make multiple outbound requests to the origin
-   * @param rootKey
-   * @returns
-   */
-  async prefetchPayloadFromOriginStore(rootKey?: string): Promise<string | null | undefined> {
-    this.cache = undefined; // clear the cache so that new data can be fetched from the origin
-    return this.get(rootKey || this._rootKey);
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -1,13 +1,29 @@
 import { EdgeProvider } from '.';
 
 /**
- * Wraps around an edge provider to cache a copy of the sdk payload locally an explicit request is made to refetch data from the origin.
- * The wrapper is necessary to ensure that we don't make redundant sub-requests from Akamai to fetch an entire environment payload.
+ * Wraps around an edge provider to cache a copy of the SDK payload locally.
+ *
+ * If a cacheTtlMs is specified, then the cacheable store provider will cache
+ * results for that specified duration. If the data lookup fails after that
+ * interval, previously stored values will be retained. The lookup will be
+ * retried again after the TTL.
+ *
+ * If no cacheTtlMs is specified, the cache will be stored for the lifetime of
+ * the object. The cache can be manually refreshed by calling
+ * `prefetchPayloadFromOriginStore`.
+ *
+ * The wrapper is necessary to ensure that we don't make redundant sub-requests
+ * from Akamai to fetch an entire environment payload.
  */
 export default class CacheableStoreProvider implements EdgeProvider {
   cache: string | null | undefined;
+  cachedAt: number | undefined;
 
-  constructor(private readonly _edgeProvider: EdgeProvider) {}
+  constructor(
+    private readonly _edgeProvider: EdgeProvider,
+    private readonly _rootKey: string,
+    private readonly _cacheTtlMs: number | undefined = undefined,
+  ) {}
 
   /**
    * Get data from the edge provider feature store.
@@ -15,10 +31,50 @@ export default class CacheableStoreProvider implements EdgeProvider {
    * @returns
    */
   async get(rootKey: string): Promise<string | null | undefined> {
-    if (!this.cache) {
-      this.cache = await this._edgeProvider.get(rootKey);
+    if (!this._isCacheValid()) {
+      const updatedResults = await this._edgeProvider.get(rootKey);
+      if (updatedResults !== undefined) {
+        this.cache = updatedResults;
+      }
+      this.cachedAt = Date.now();
     }
 
     return this.cache;
+  }
+
+  /**
+   * Fetches environment payload data from the origin in according with the caching configuration.
+   *
+   * You should only call this function within a feature store to pre-fetch and cache payload data in environments
+   * where its expensive to make multiple outbound requests to the origin
+   * @param rootKey
+   * @returns
+   */
+  async prefetchPayloadFromOriginStore(rootKey?: string): Promise<string | null | undefined> {
+    if (this._cacheTtlMs === undefined) {
+      this.cache = undefined; // clear the cache so that new data can be fetched from the origin
+    }
+
+    return this.get(rootKey || this._rootKey);
+  }
+
+  /**
+   * Internal helper to determine if the cached values are still considered valid.
+   */
+  private _isCacheValid(): boolean {
+    // If we don't have a cache, or we don't know how old the cache is, we have
+    // to consider it is invalid.
+    if (!this.cache || !this.cachedAt) {
+      return false;
+    }
+
+    // If the cache provider was configured without a TTL, then the cache is
+    // always considered valid.
+    if (!this._cacheTtlMs) {
+      return true;
+    }
+
+    // Otherwise, it all depends on the time.
+    return Date.now() - this.cachedAt < this._cacheTtlMs;
   }
 }

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -7,9 +7,7 @@ import { EdgeProvider } from '.';
 export default class CacheableStoreProvider implements EdgeProvider {
   cache: string | null | undefined;
 
-  constructor(
-    private readonly _edgeProvider: EdgeProvider,
-  ) {}
+  constructor(private readonly _edgeProvider: EdgeProvider) {}
 
   /**
    * Get data from the edge provider feature store.

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -13,7 +13,13 @@ import { EdgeProvider } from '.';
  * `prefetchPayloadFromOriginStore`.
  *
  * The wrapper is necessary to ensure that we don't make redundant sub-requests
- * from Akamai to fetch an entire environment payload.
+ * from Akamai to fetch an entire environment payload. At the time of this writing,
+ * the Akamai documentation (https://techdocs.akamai.com/edgeworkers/docs/resource-tier-limitations)
+ * limits the number of sub-requests to:
+ *
+ * - 2 for basic compute
+ * - 4 for dynamic compute
+ * - 10 for enterprise
  */
 export default class CacheableStoreProvider implements EdgeProvider {
   cache: string | null | undefined;

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -28,7 +28,7 @@ export default class CacheableStoreProvider implements EdgeProvider {
   constructor(
     private readonly _edgeProvider: EdgeProvider,
     private readonly _rootKey: string,
-    private readonly _cacheTtlMs: number | undefined = undefined,
+    private readonly _cacheTtlMs?: number,
   ) {}
 
   /**
@@ -49,7 +49,7 @@ export default class CacheableStoreProvider implements EdgeProvider {
   }
 
   /**
-   * Fetches environment payload data from the origin in according with the caching configuration.
+   * Fetches environment payload data from the origin in accordance with the caching configuration.
    *
    * You should only call this function within a feature store to pre-fetch and cache payload data in environments
    * where its expensive to make multiple outbound requests to the origin

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -22,7 +22,7 @@ import { EdgeProvider } from '.';
  * - 10 for enterprise
  */
 export default class CacheableStoreProvider implements EdgeProvider {
-  cache: string | null | undefined;
+  cache: Promise<string | null | undefined> | null | undefined;
   cachedAt: number | undefined;
 
   constructor(
@@ -38,10 +38,7 @@ export default class CacheableStoreProvider implements EdgeProvider {
    */
   async get(rootKey: string): Promise<string | null | undefined> {
     if (!this._isCacheValid()) {
-      const updatedResults = await this._edgeProvider.get(rootKey);
-      if (updatedResults !== undefined) {
-        this.cache = updatedResults;
-      }
+      this.cache = this._edgeProvider.get(rootKey);
       this.cachedAt = Date.now();
     }
 

--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/cacheableStoreProvider.ts
@@ -70,7 +70,7 @@ export default class CacheableStoreProvider implements EdgeProvider {
   private _isCacheValid(): boolean {
     // If we don't have a cache, or we don't know how old the cache is, we have
     // to consider it is invalid.
-    if (!this.cache || !this.cachedAt) {
+    if (!this.cache || this.cachedAt === undefined) {
       return false;
     }
 

--- a/packages/shared/akamai-edgeworker-sdk/src/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/index.ts
@@ -1,7 +1,7 @@
 import { BasicLogger, LDOptions as LDOptionsCommon } from '@launchdarkly/js-server-sdk-common';
 
 import LDClient from './api/LDClient';
-import { buildRootKey, EdgeFeatureStore, EdgeProvider } from './featureStore';
+import { EdgeFeatureStore, EdgeProvider } from './featureStore';
 import CacheableStoreProvider from './featureStore/cacheableStoreProvider';
 import EdgePlatform from './platform';
 import createPlatformInfo from './platform/info';

--- a/packages/shared/akamai-edgeworker-sdk/src/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/index.ts
@@ -37,10 +37,7 @@ export const init = (params: BaseSDKParams): LDClient => {
 
   const logger = options.logger ?? BasicLogger.get();
 
-  const cachableStoreProvider = new CacheableStoreProvider(
-    featureStoreProvider,
-    buildRootKey(sdkKey),
-  );
+  const cachableStoreProvider = new CacheableStoreProvider(featureStoreProvider);
   const featureStore = new EdgeFeatureStore(cachableStoreProvider, sdkKey, 'Akamai', logger);
 
   const ldOptions: LDOptionsCommon = {

--- a/packages/shared/akamai-edgeworker-sdk/src/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/index.ts
@@ -12,7 +12,13 @@ import { validateOptions } from './utils';
  * supported. sendEvents is unsupported and is only included as a beta
  * preview.
  */
-type LDOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents'>;
+type LDOptions = {
+  /**
+   * The time-to-live for the cache in milliseconds. The default is 100ms. A
+   * value of 0 will cache indefinitely.
+   */
+  cacheTtlMs?: number;
+} & Pick<LDOptionsCommon, 'logger' | 'sendEvents'>;
 
 /**
  * The internal options include featureStore because that's how the LDClient


### PR DESCRIPTION
When the SDK retrieves data from the EdgeKV, it does so using a single
sub-request per call to `variation`, `variationDetail`, or
`allFlagsState`. The problem is that Akamai imposes a limit of 4
sub-requests per handler event.

If a customer evaluates more than 4 distinct flags during the handling
of a single event, subsequent flag lookups would fail. To combat this,
we now cache the flag values for a specified amount of time.
