### PR TITLE
chore: Remove redundant default handling

### DIFF
--- a/packages/sdk/akamai-edgekv/src/index.ts
+++ b/packages/sdk/akamai-edgekv/src/index.ts
@@ -34,13 +34,12 @@ export const init = ({
   sdkKey,
 }: AkamaiLDClientParams): LDClient => {
   const logger = options.logger ?? BasicLogger.get();
-  const cacheTtlMs = options.cacheTtlMs ?? 100;
 
   const edgekvProvider = new EdgeKVProvider({ namespace, group, logger });
 
   return initEdge({
     sdkKey,
-    options: { ...options, logger, cacheTtlMs },
+    options: { ...options, logger },
     featureStoreProvider: edgekvProvider,
     platformName: 'Akamai EdgeWorker',
     sdkName: '@launchdarkly/akamai-server-edgekv-sdk',


### PR DESCRIPTION
The pending v2.0.0 release of the Akamai common package handles this
fallback for us, rendering this check redundant.
