### PR TITLE
chore(fastly): update type documentation

### DIFF
--- a/packages/sdk/fastly/src/index.ts
+++ b/packages/sdk/fastly/src/index.ts
@@ -1,13 +1,53 @@
+/**
+ * This is the API reference for the Fastly LaunchDarkly SDK.
+ *
+ * In typical usage, you will call {@link init} once per request to obtain an instance of
+ * {@link LDClient}, which provides access to all of the SDK's functionality.
+ *
+ * For more information, see the SDK reference guide.
+ *
+ * @packageDocumentation
+ */
 /// <reference types="@fastly/js-compute" />
 import { KVStore } from 'fastly:kv-store';
 
-import { BasicLogger } from '@launchdarkly/js-server-sdk-common';
+import { BasicLogger, LDEvaluationReason } from '@launchdarkly/js-server-sdk-common';
 
 import { EdgeFeatureStore, EdgeProvider, LDClient } from './api';
 import { DEFAULT_EVENTS_BACKEND_NAME } from './api/LDClient';
 import createPlatformInfo from './createPlatformInfo';
-import validateOptions, { FastlySDKOptions } from './utils/validateOptions';
+import validateOptions, { FastlySDKOptions, LDOptionsCommon } from './utils/validateOptions';
 
+export type {
+  BasicLogger,
+  FastlySDKOptions,
+  KVStore,
+  LDClient,
+  LDEvaluationReason,
+  LDOptionsCommon,
+};
+
+/**
+ * Creates an instance of the Fastly LaunchDarkly client.
+ *
+ * Applications should instantiate a single instance for the lifetime of a request.
+ * The client will begin attempting to connect to the configured Fastly KV as
+ * soon as it is created. To determine when it is ready to use, call {@link LDClient.waitForInitialization}.
+ *
+ * **Important:** Do **not** try to instantiate `LDClient` with its constructor
+ * (`new LDClient()/new LDClientImpl()/new LDClient()`); the SDK does not currently support
+ * this.
+ *
+ * @param clientSideId
+ *  The client side ID. This is only used to query the kvStore above,
+ *  not to connect with LaunchDarkly servers.
+ * @param kvStore
+ *  The Fastly KV store configured for LaunchDarkly.
+ * @param options
+ *  Optional {@link FastlySDKOptions | configuration settings}.
+ * @return
+ *  The new {@link LDClient} instance.
+ */
 export const init = (
   clientSideId: string,
   kvStore: KVStore,

--- a/packages/sdk/fastly/src/utils/validateOptions.ts
+++ b/packages/sdk/fastly/src/utils/validateOptions.ts
@@ -1,7 +1,8 @@
 import { LDOptions as LDOptionsCommon, TypeValidators } from '@launchdarkly/js-server-sdk-common';
 
+export type { LDOptionsCommon };
 /**
- * The Launchdarkly Fastly Compute SDK configuration options.
+ * The Launchdarkly Fastly Compute SDK configuration options. See {@link LDOptionsCommon} for more information on the 'logger', 'sendEvents', and 'eventsUri' options.
  */
 export type FastlySDKOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents' | 'eventsUri'> & {
   /**


### PR DESCRIPTION
This PR updates the documentation comments for our Fastly SDK. 

I was able to test it locally using `yarn run build:doc -- packages/sdk/fastly && npx serve packages/sdk/fastly/docs`