### PR TITLE
fix: Fix cancelling timeout when waitForInitialization throws an exception

### DIFF
--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -940,14 +940,16 @@ export default class LDClientImpl implements LDClient {
     if (timeout) {
       const cancelableTimeout = cancelableTimedPromise(timeout, 'waitForInitialization');
       return Promise.race([
-        basePromise.then(() => cancelableTimeout.cancel()).then(() => this),
+        basePromise.then(() => this),
         cancelableTimeout.promise.then(() => this),
-      ]).catch((reason) => {
-        if (reason instanceof LDTimeoutError) {
-          logger?.error(reason.message);
-        }
-        throw reason;
-      });
+      ])
+        .catch((reason) => {
+          if (reason instanceof LDTimeoutError) {
+            logger?.error(reason.message);
+          }
+          throw reason;
+        })
+        .finally(() => cancelableTimeout.cancel());
     }
     return basePromise;
   }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.atlassian.net/browse/SDK-1132

**Describe the solution you've provided**

Previously the timeout was cancelled in a `then()` and would be skipped if the base promise threw an exception.  The cancelation was moved to `finally()` where it will always be called regardless of an exception.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A
