### PR TITLE
feat: Support inline context for custom and migration events

### DIFF
--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -34,7 +34,7 @@ app.get('/', (req, res) => {
       'event-sampling',
       'strongly-typed',
       'polling-gzip',
-      'inline-context',
+      'inline-context-all',
       'anonymous-redaction',
       'evaluation-hooks',
       'wrapper',

--- a/packages/sdk/browser/__tests__/BrowserClient.test.ts
+++ b/packages/sdk/browser/__tests__/BrowserClient.test.ts
@@ -145,8 +145,9 @@ describe('given a mock platform for a BrowserClient', () => {
       kind: 'custom',
       creationDate: 1726704000000,
       key: 'user-key',
-      contextKeys: {
-        user: 'user-key',
+      context: {
+        key: 'user-key',
+        kind: 'user',
       },
       metricValue: 1,
       url: 'http://browserclientintegration.com',
@@ -178,8 +179,9 @@ describe('given a mock platform for a BrowserClient', () => {
       kind: 'custom',
       creationDate: 1726704000000,
       key: 'user-key',
-      contextKeys: {
-        user: 'user-key',
+      context: {
+        key: 'user-key',
+        kind: 'user',
       },
       metricValue: 1,
       url: 'http://filtered.org',

--- a/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -38,7 +38,7 @@ export default class TestHarnessWebSocket {
             'service-endpoints',
             'tags',
             'user-type',
-            'inline-context',
+            'inline-context-all',
             'anonymous-redaction',
             'strongly-typed',
             'client-prereq-events',

--- a/packages/sdk/browser/contract-tests/suppressions.txt
+++ b/packages/sdk/browser/contract-tests/suppressions.txt
@@ -4,3 +4,15 @@ streaming/requests/URL path is computed correctly/no environment filter/base URI
 streaming/requests/context properties/single kind minimal/REPORT
 streaming/requests/context properties/single kind with all attributes/REPORT
 streaming/requests/context properties/multi-kind/REPORT
+tags/stream requests/{"applicationId":null,"applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
+tags/stream requests/{"applicationId":null,"applicationVersion":"________________________________________________________________"}
+tags/stream requests/{"applicationId":"","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
+tags/stream requests/{"applicationId":"","applicationVersion":"________________________________________________________________"}
+tags/stream requests/{"applicationId":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678","applicationVersion":null}
+tags/stream requests/{"applicationId":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678","applicationVersion":""}
+tags/stream requests/{"applicationId":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
+tags/stream requests/{"applicationId":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678","applicationVersion":"________________________________________________________________"}
+tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":null}
+tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":""}
+tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
+tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}

--- a/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
+++ b/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
@@ -671,9 +671,7 @@ describe('given an event processor', () => {
         key: 'eventkey',
         data: { thing: 'stuff' },
         creationDate: 1000,
-        contextKeys: {
-          user: 'userKey',
-        },
+        context: { ...user, kind: 'user' },
       },
     ]);
   });
@@ -701,9 +699,7 @@ describe('given an event processor', () => {
         key: 'eventkey',
         data: { thing: 'stuff' },
         creationDate: 1000,
-        contextKeys: {
-          user: 'anon-user',
-        },
+        context: { ...anonUser, kind: 'user' },
       },
     ]);
   });
@@ -733,9 +729,7 @@ describe('given an event processor', () => {
         key: 'eventkey',
         data: { thing: 'stuff' },
         creationDate: 1000,
-        contextKeys: {
-          user: 'userKey',
-        },
+        context: { ...user, kind: 'user' },
         metricValue: 1.5,
       },
     ]);

--- a/packages/shared/common/src/internal/events/EventProcessor.ts
+++ b/packages/shared/common/src/internal/events/EventProcessor.ts
@@ -86,6 +86,7 @@ type DiagnosticEvent = any;
 interface MigrationOutputEvent extends Omit<InputMigrationEvent, 'samplingRatio' | 'context'> {
   // Make the sampling ratio optional so we can omit it when it is one.
   samplingRatio?: number;
+  // Context is optional because contextKeys is supported for backwards compatbility and may be provided instead of context.
   context?: FilteredContext;
 }
 

--- a/packages/shared/common/src/internal/events/InputMigrationEvent.ts
+++ b/packages/shared/common/src/internal/events/InputMigrationEvent.ts
@@ -2,12 +2,17 @@
 // shared implementation contains minimal typing. If/When migration events are
 // to be supported by client-side SDKs the appropriate types would be moved
 // to the common implementation.
+import Context from '../../Context';
 
 export default interface InputMigrationEvent {
   kind: 'migration_op';
   operation: string;
   creationDate: number;
-  contextKeys: Record<string, string>;
+  /**
+   * @deprecated Use 'context' instead.
+   */
+  contextKeys?: Record<string, string>;
+  context?: Context;
   evaluation: any;
   measurements: any[];
   samplingRatio: number;

--- a/packages/shared/sdk-server/__tests__/MigrationOpEventConversion.test.ts
+++ b/packages/shared/sdk-server/__tests__/MigrationOpEventConversion.test.ts
@@ -1,0 +1,86 @@
+import { LDContext, LDMigrationOpEvent, LDMigrationStage } from '../src';
+import migrationOpEventToInputEvent from '../src/MigrationOpEventConversion';
+
+const baseEvent: LDMigrationOpEvent = {
+  kind: 'migration_op',
+  operation: 'read',
+  creationDate: new Date().getTime(),
+  evaluation: {
+    default: LDMigrationStage.Off,
+    key: 'flag',
+    reason: { kind: 'FALLTHROUGH' },
+    value: LDMigrationStage.Off,
+  },
+  measurements: [],
+  samplingRatio: 1,
+};
+
+it('handles event without either context or contextKeys', () => {
+  expect(migrationOpEventToInputEvent(baseEvent)).toBeUndefined();
+});
+
+it('handles event with only context', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    context: { key: 'user-key' },
+  });
+  expect(outEvent).toBeDefined();
+  expect(outEvent?.context?.key()).toEqual('user-key');
+  expect(outEvent?.context?.kind).toEqual('user');
+  expect(outEvent?.contextKeys).toBeUndefined();
+});
+
+it('handles event with only contextKeys', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    contextKeys: { user: 'bob' },
+  });
+  expect(outEvent).toBeDefined();
+  expect(outEvent?.context).toBeUndefined();
+  expect(outEvent?.contextKeys).toEqual({ user: 'bob' });
+});
+
+it('handles invalid context', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    context: {} as LDContext,
+  });
+  expect(outEvent).toBeUndefined();
+});
+
+it('handles invalid context even if contextKeys is provided', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    context: {} as LDContext,
+    contextKeys: { user: 'bob' },
+  });
+  expect(outEvent).toBeUndefined();
+});
+
+it('handles invalid key in contextKeys', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    contextKeys: { kind: 'user' },
+  });
+  expect(outEvent).toBeUndefined();
+});
+
+it('handles invalid value in contextKeys', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    contextKeys: { user: '' },
+  });
+  expect(outEvent).toBeUndefined();
+});
+
+it('uses context if both context and contextKeys are provided', () => {
+  const outEvent = migrationOpEventToInputEvent({
+    ...baseEvent,
+    context: { key: 'user-key' },
+    contextKeys: { user: 'bob' },
+  });
+  expect(outEvent).toBeDefined();
+  expect(outEvent?.context?.key()).toEqual('user-key');
+  expect(outEvent?.context?.kind).toEqual('user');
+  expect(outEvent?.contextKeys).toBeUndefined();
+});

--- a/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
+++ b/packages/shared/sdk-server/__tests__/MigrationOpTracker.test.ts
@@ -1,4 +1,4 @@
-import { LDMigrationStage } from '../src';
+import { LDContext, LDMigrationStage } from '../src';
 import { LDMigrationOrigin } from '../src/api/LDMigration';
 import MigrationOpTracker from '../src/MigrationOpTracker';
 import TestLogger, { LogLevel } from './Logger';
@@ -6,7 +6,7 @@ import TestLogger, { LogLevel } from './Logger';
 it('does not generate an event if an op is not set', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -20,9 +20,15 @@ it('does not generate an event if an op is not set', () => {
 });
 
 it('does not generate an event with missing context keys', () => {
-  const tracker = new MigrationOpTracker('flag', {}, LDMigrationStage.Off, LDMigrationStage.Off, {
-    kind: 'FALLTHROUGH',
-  });
+  const tracker = new MigrationOpTracker(
+    'flag',
+    {} as LDContext,
+    LDMigrationStage.Off,
+    LDMigrationStage.Off,
+    {
+      kind: 'FALLTHROUGH',
+    },
+  );
 
   // Set the op otherwise/invoked that would prevent an event as well.
   tracker.op('write');
@@ -52,7 +58,7 @@ it('does not generate an event with empty flag key', () => {
 it('generates an event if the minimal requirements are met.', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -64,7 +70,7 @@ it('generates an event if the minimal requirements are met.', () => {
   tracker.invoked('old');
 
   expect(tracker.createEvent()).toMatchObject({
-    contextKeys: { user: 'bob' },
+    context: { key: 'user-key' },
     evaluation: { default: 'off', key: 'flag', reason: { kind: 'FALLTHROUGH' }, value: 'off' },
     kind: 'migration_op',
     measurements: [
@@ -82,7 +88,7 @@ it('generates an event if the minimal requirements are met.', () => {
 it('can include the variation in the event', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -96,7 +102,7 @@ it('can include the variation in the event', () => {
   tracker.invoked('old');
 
   expect(tracker.createEvent()).toMatchObject({
-    contextKeys: { user: 'bob' },
+    context: { key: 'user-key' },
     evaluation: {
       default: 'off',
       key: 'flag',
@@ -120,7 +126,7 @@ it('can include the variation in the event', () => {
 it('can include the version in the event', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -135,7 +141,7 @@ it('can include the version in the event', () => {
   tracker.invoked('old');
 
   expect(tracker.createEvent()).toMatchObject({
-    contextKeys: { user: 'bob' },
+    context: { key: 'user-key' },
     evaluation: {
       default: 'off',
       key: 'flag',
@@ -159,7 +165,7 @@ it('can include the version in the event', () => {
 it('includes errors if at least one is set', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -181,7 +187,7 @@ it('includes errors if at least one is set', () => {
 
   const trackerB = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -205,7 +211,7 @@ it('includes errors if at least one is set', () => {
 it('includes latency if at least one measurement exists', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -227,7 +233,7 @@ it('includes latency if at least one measurement exists', () => {
 
   const trackerB = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -251,7 +257,7 @@ it('includes latency if at least one measurement exists', () => {
 it('includes if the result was consistent', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -274,7 +280,7 @@ it('includes if the result was consistent', () => {
 it('includes if the result was inconsistent', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -297,7 +303,7 @@ it('includes if the result was inconsistent', () => {
 it.each(['old', 'new'])('includes which single origins were invoked', (origin) => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -317,7 +323,7 @@ it.each(['old', 'new'])('includes which single origins were invoked', (origin) =
 it('includes when both origins were invoked', () => {
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -339,7 +345,7 @@ it('can handle exceptions thrown in the consistency check method', () => {
   const logger = new TestLogger();
   const tracker = new MigrationOpTracker(
     'flag',
-    { user: 'bob' },
+    { key: 'user-key' },
     LDMigrationStage.Off,
     LDMigrationStage.Off,
     {
@@ -376,7 +382,7 @@ it.each([
   (invoke_old, invoke_new, measure_old, measure_new) => {
     const tracker = new MigrationOpTracker(
       'flag',
-      { user: 'bob' },
+      { key: 'user-key' },
       LDMigrationStage.Off,
       LDMigrationStage.Off,
       {
@@ -413,7 +419,7 @@ it.each([
   (invoke_old, invoke_new, measure_old, measure_new) => {
     const tracker = new MigrationOpTracker(
       'flag',
-      { user: 'bob' },
+      { key: 'user-key' },
       LDMigrationStage.Off,
       LDMigrationStage.Off,
       {
@@ -450,7 +456,7 @@ it.each([
   (invoke_old, invoke_new, consistent) => {
     const tracker = new MigrationOpTracker(
       'flag',
-      { user: 'bob' },
+      { key: 'user-key' },
       LDMigrationStage.Off,
       LDMigrationStage.Off,
       {

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -549,7 +549,6 @@ export default class LDClientImpl implements LDClient {
     context: LDContext,
     defaultValue: LDMigrationStage,
   ): Promise<{ detail: LDEvaluationDetail; migration: LDMigrationVariation }> {
-    const convertedContext = Context.fromLDContext(context);
     const res = await new Promise<{ detail: LDEvaluationDetail; flag?: Flag }>((resolve) => {
       this._evaluateIfPossible(
         key,
@@ -581,7 +580,6 @@ export default class LDClientImpl implements LDClient {
     });
 
     const { detail, flag } = res;
-    const contextKeys = convertedContext.valid ? convertedContext.kindsAndKeys : {};
     const checkRatio = flag?.migration?.checkRatio;
     const samplingRatio = flag?.samplingRatio;
 
@@ -591,7 +589,7 @@ export default class LDClientImpl implements LDClient {
         value: detail.value as LDMigrationStage,
         tracker: new MigrationOpTracker(
           key,
-          contextKeys,
+          context,
           defaultValue,
           detail.value,
           detail.reason,

--- a/packages/shared/sdk-server/src/MigrationOpTracker.ts
+++ b/packages/shared/sdk-server/src/MigrationOpTracker.ts
@@ -1,5 +1,7 @@
 import {
+  Context,
   internal,
+  LDContext,
   LDEvaluationReason,
   LDLogger,
   TypeValidators,
@@ -42,7 +44,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
 
   constructor(
     private readonly _flagKey: string,
-    private readonly _contextKeys: Record<string, string>,
+    private readonly _context: LDContext,
     private readonly _defaultStage: LDMigrationStage,
     private readonly _stage: LDMigrationStage,
     private readonly _reason: LDEvaluationReason,
@@ -97,7 +99,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
       return undefined;
     }
 
-    if (Object.keys(this._contextKeys).length === 0) {
+    if (!Context.fromLDContext(this._context).valid) {
       this._logger?.error(
         'The migration was not done against a valid context and cannot generate an event.',
       );
@@ -127,7 +129,7 @@ export default class MigrationOpTracker implements LDMigrationTracker {
       kind: 'migration_op',
       operation: this._operation,
       creationDate: Date.now(),
-      contextKeys: this._contextKeys,
+      context: this._context,
       evaluation: {
         key: this._flagKey,
         value: this._stage,

--- a/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
+++ b/packages/shared/sdk-server/src/api/data/LDMigrationOpEvent.ts
@@ -1,4 +1,4 @@
-import { LDEvaluationReason } from '@launchdarkly/js-sdk-common';
+import { LDContext, LDEvaluationReason } from '@launchdarkly/js-sdk-common';
 
 import { LDMigrationStage } from './LDMigrationStage';
 
@@ -66,7 +66,11 @@ export interface LDMigrationOpEvent {
   kind: 'migration_op';
   operation: LDMigrationOp;
   creationDate: number;
-  contextKeys: Record<string, string>;
+  /**
+   * @deprecated Use 'context' instead.
+   */
+  contextKeys?: Record<string, string>;
+  context?: LDContext;
   evaluation: LDMigrationEvaluation;
   measurements: LDMigrationMeasurement[];
   samplingRatio: number;


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

- Support inlining context for custom events.  The logic for this needs to happen in EventProcessor which is shared between server and client sdks in js-core.  It has been verified with product analytics that this is ok for the client sdks.
- Support inlining context for migration events.  This causes a change in the public interface for `LDClient.trackMigration` where the `LDMigrationOpEvent` parameter has been modified.  `contextKeys` has been made optional and deprecated in favor of `context` and all internal uses of `LDMigrationOpEvent` have been changed to use `context`.

BEGIN_COMMIT_OVERRIDE
feat: Support inline context for custom and migration events
fix: Deprecate LDMigrationOpEvent.contextKeys in favor of LDMigrationOpEvent.context
END_COMMIT_OVERRIDE