### PR TITLE
feat: Option to use gzip to compress event

### DIFF
--- a/contract-tests/index.js
+++ b/contract-tests/index.js
@@ -39,6 +39,8 @@ app.get('/', (req, res) => {
       'evaluation-hooks',
       'wrapper',
       'client-prereq-events',
+      'event-gzip',
+      'optional-event-gzip',
     ],
   });
 });

--- a/contract-tests/sdkClientEntity.js
+++ b/contract-tests/sdkClientEntity.js
@@ -45,6 +45,7 @@ export function makeSdkConfig(options, tag) {
     cf.diagnosticOptOut = !options.events.enableDiagnostics;
     cf.flushInterval = maybeTime(options.events.flushIntervalMs);
     cf.privateAttributes = options.events.globalPrivateAttributes;
+    cf.enableEventCompression = options.events.enableGzip;
   }
   if (options.tags) {
     cf.application = {

--- a/packages/sdk/server-node/src/platform/NodePlatform.ts
+++ b/packages/sdk/server-node/src/platform/NodePlatform.ts
@@ -16,6 +16,11 @@ export default class NodePlatform implements platform.Platform {
 
   constructor(options: LDOptions) {
     this.info = new NodeInfo(options);
-    this.requests = new NodeRequests(options.tlsParams, options.proxyOptions, options.logger);
+    this.requests = new NodeRequests(
+      options.tlsParams,
+      options.proxyOptions,
+      options.logger,
+      options.enableEventCompression,
+    );
   }
 }

--- a/packages/sdk/server-node/src/platform/NodeRequests.ts
+++ b/packages/sdk/server-node/src/platform/NodeRequests.ts
@@ -105,7 +105,7 @@ export default class NodeRequests implements platform.Requests {
 
   private _hasProxyAuth: boolean = false;
 
-  private _enableEventCompression: boolean = false;
+  private _enableBodyCompression: boolean = false;
 
   constructor(
     tlsOptions?: LDTLSOptions,
@@ -116,7 +116,7 @@ export default class NodeRequests implements platform.Requests {
     this._agent = createAgent(tlsOptions, proxyOptions, logger);
     this._hasProxy = !!proxyOptions;
     this._hasProxyAuth = !!proxyOptions?.auth;
-    this._enableEventCompression = !!enableEventCompression;
+    this._enableBodyCompression = !!enableEventCompression;
   }
 
   async fetch(url: string, options: platform.Options = {}): Promise<platform.Response> {
@@ -135,7 +135,7 @@ export default class NodeRequests implements platform.Requests {
     // enableEventCompression config setting is true and the compressBodyIfPossible
     // option is true.
     else if (
-      this._enableEventCompression &&
+      this._enableBodyCompression &&
       !!options.compressBodyIfPossible &&
       options.method?.toLowerCase() === 'post' &&
       options.body

--- a/packages/shared/common/__tests__/internal/events/EventSender.test.ts
+++ b/packages/shared/common/__tests__/internal/events/EventSender.test.ts
@@ -133,6 +133,7 @@ describe('given an event sender', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(`${basicConfig.serviceEndpoints.events}/bulk`, {
       body: JSON.stringify(testEventData1),
+      compressBodyIfPossible: true,
       headers: analyticsHeaders(uuid),
       method: 'POST',
       keepalive: true,
@@ -150,6 +151,7 @@ describe('given an event sender', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch).toHaveBeenNthCalledWith(1, `${basicConfig.serviceEndpoints.events}/bulk`, {
       body: JSON.stringify(testEventData1),
+      compressBodyIfPossible: true,
       headers: analyticsHeaders(uuid),
       method: 'POST',
       keepalive: true,
@@ -159,6 +161,7 @@ describe('given an event sender', () => {
       `${basicConfig.serviceEndpoints.events}/diagnostic`,
       {
         body: JSON.stringify(testEventData2),
+        compressBodyIfPossible: true,
         headers: diagnosticHeaders,
         method: 'POST',
         keepalive: true,

--- a/packages/shared/common/src/api/platform/Requests.ts
+++ b/packages/shared/common/src/api/platform/Requests.ts
@@ -75,6 +75,11 @@ export interface Options {
   headers?: Record<string, string>;
   method?: string;
   body?: string;
+  /**
+   * Gzip compress the post body only if the underlying SDK framework supports it
+   * and the config option enableEventCompression is set to true.
+   */
+  compressBodyIfPossible?: boolean;
   timeout?: number;
   /**
    * For use in browser environments. Platform support will be best effort for this field.

--- a/packages/shared/common/src/internal/events/EventSender.ts
+++ b/packages/shared/common/src/internal/events/EventSender.ts
@@ -64,6 +64,7 @@ export default class EventSender implements LDEventSender {
       const { status, headers: resHeaders } = await this._requests.fetch(uri, {
         headers,
         body: JSON.stringify(events),
+        compressBodyIfPossible: true,
         method: 'POST',
         // When sending events from browser environments the request should be completed even
         // if the user is navigating away from the page.

--- a/packages/shared/sdk-server/src/api/options/LDOptions.ts
+++ b/packages/shared/sdk-server/src/api/options/LDOptions.ts
@@ -304,4 +304,14 @@ export interface LDOptions {
    * ```
    */
   hooks?: Hook[];
+
+  /**
+   * Set to true to opt in to compressing event payloads if the SDK supports it, since the
+   * compression library may not be supported in the underlying SDK framework.  If the compression
+   * library is not supported then event payloads will not be compressed even if this option
+   * is enabled.
+   *
+   * Defaults to false.
+   */
+  enableEventCompression?: boolean;
 }

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -57,6 +57,7 @@ const validations: Record<string, TypeValidator> = {
   application: TypeValidators.Object,
   payloadFilterKey: TypeValidators.stringMatchingRegex(/^[a-zA-Z0-9](\w|\.|-)*$/),
   hooks: TypeValidators.createTypeArray('Hook[]', {}),
+  enableEventCompression: TypeValidators.Boolean,
 };
 
 /**
@@ -82,6 +83,7 @@ export const defaultValues: ValidatedOptions = {
   diagnosticOptOut: false,
   diagnosticRecordingInterval: 900,
   featureStore: () => new InMemoryFeatureStore(),
+  enableEventCompression: false,
 };
 
 function validateTypesAndNames(options: LDOptions): {
@@ -215,6 +217,8 @@ export default class Configuration {
 
   public readonly hooks?: Hook[];
 
+  public readonly enableEventCompression: boolean;
+
   constructor(options: LDOptions = {}, internalOptions: internal.LDInternalOptions = {}) {
     // The default will handle undefined, but not null.
     // Because we can be called from JS we need to be extra defensive.
@@ -283,5 +287,6 @@ export default class Configuration {
     }
 
     this.hooks = validatedOptions.hooks;
+    this.enableEventCompression = validatedOptions.enableEventCompression;
   }
 }

--- a/packages/shared/sdk-server/src/options/ValidatedOptions.ts
+++ b/packages/shared/sdk-server/src/options/ValidatedOptions.ts
@@ -41,4 +41,5 @@ export interface ValidatedOptions {
   [index: string]: any;
   bigSegments?: LDBigSegmentsOptions;
   hooks?: Hook[];
+  enableEventCompression: boolean;
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

LDConfig option `enableEventCompression` was added for js-server-sdk-common and NodeRequests was modified to support gzip compression of POST bodies if this option is enabled.