### PR TITLE
fix: Handle default flush interval for browser SDK.

### DIFF
--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -21,7 +21,7 @@ import { BrowserIdentifyOptions as LDIdentifyOptions } from './BrowserIdentifyOp
 import { registerStateDetection } from './BrowserStateDetector';
 import GoalManager from './goals/GoalManager';
 import { Goal, isClick } from './goals/Goals';
-import validateOptions, { BrowserOptions, filterToBaseOptions } from './options';
+import validateBrowserOptions, { BrowserOptions, filterToBaseOptionsWithDefaults } from './options';
 import BrowserPlatform from './platform/BrowserPlatform';
 
 /**
@@ -116,13 +116,16 @@ export class BrowserClient extends LDClientImpl implements LDClient {
     const baseUrl = options.baseUri ?? 'https://clientsdk.launchdarkly.com';
 
     const platform = overridePlatform ?? new BrowserPlatform(logger);
-    const validatedBrowserOptions = validateOptions(options, logger);
+    // Only the browser-specific options are in validatedBrowserOptions.
+    const validatedBrowserOptions = validateBrowserOptions(options, logger);
+    // The base options are in baseOptionsWithDefaults.
+    const baseOptionsWithDefaults = filterToBaseOptionsWithDefaults({ ...options, logger });
     const { eventUrlTransformer } = validatedBrowserOptions;
     super(
       clientSideId,
       autoEnvAttributes,
       platform,
-      filterToBaseOptions({ ...options, logger }),
+      baseOptionsWithDefaults,
       (
         flagManager: FlagManager,
         configuration: Configuration,

--- a/packages/sdk/browser/src/options.ts
+++ b/packages/sdk/browser/src/options.ts
@@ -73,8 +73,14 @@ const validators: { [Property in keyof BrowserOptions]: TypeValidator | undefine
   streaming: TypeValidators.Boolean,
 };
 
-export function filterToBaseOptions(opts: BrowserOptions): LDOptionsBase {
-  const baseOptions: LDOptionsBase = { ...opts };
+function withBrowserDefaults(opts: BrowserOptions): BrowserOptions {
+  const output = { ...opts };
+  output.flushInterval ??= DEFAULT_FLUSH_INTERVAL_SECONDS;
+  return output;
+}
+
+export function filterToBaseOptionsWithDefaults(opts: BrowserOptions): LDOptionsBase {
+  const baseOptions: LDOptionsBase = withBrowserDefaults(opts);
 
   // Remove any browser specific configuration keys so we don't get warnings from
   // the base implementation for unknown configuration.
@@ -84,14 +90,11 @@ export function filterToBaseOptions(opts: BrowserOptions): LDOptionsBase {
   return baseOptions;
 }
 
-function applyBrowserDefaults(opts: BrowserOptions) {
-  // eslint-disable-next-line no-param-reassign
-  opts.flushInterval ??= DEFAULT_FLUSH_INTERVAL_SECONDS;
-}
-
-export default function validateOptions(opts: BrowserOptions, logger: LDLogger): ValidatedOptions {
+export default function validateBrowserOptions(
+  opts: BrowserOptions,
+  logger: LDLogger,
+): ValidatedOptions {
   const output: ValidatedOptions = { ...optDefaults };
-  applyBrowserDefaults(output);
 
   Object.entries(validators).forEach((entry) => {
     const [key, validator] = entry as [keyof BrowserOptions, TypeValidator];


### PR DESCRIPTION
The browser SDK was incorrectly handling its default flush interval configuration.

There are two layers to defaults for the browser SDK. The first is defaults which differ from the base configuration defaults, second is defaults for browser specific configuration.

The base defaults were being applied to the browser specific configuration, which meant those changes were being lost and instead the base default was being used instead.

Fixes: SDK-1199