### PR TITLE
feat: Environment ID support for hooks

### DIFF
--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@launchdarkly/js-server-sdk-common": "2.14.0",
     "https-proxy-agent": "^5.0.1",
-    "launchdarkly-eventsource": "2.0.3"
+    "launchdarkly-eventsource": "2.1.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/shared/common/__tests__/internal/metadata/InitMetadata.test.ts
+++ b/packages/shared/common/__tests__/internal/metadata/InitMetadata.test.ts
@@ -1,0 +1,17 @@
+import { initMetadataFromHeaders } from '../../../src/internal/metadata';
+
+it('handles passing undefined headers', () => {
+  expect(initMetadataFromHeaders()).toBeUndefined();
+});
+
+it('handles missing x-ld-envid header', () => {
+  expect(initMetadataFromHeaders({})).toBeUndefined();
+});
+
+it('retrieves environmentId from headers', () => {
+  expect(initMetadataFromHeaders({ 'x-ld-envid': '12345' })).toEqual({ environmentId: '12345' });
+});
+
+it('retrieves environmentId from mixed case header', () => {
+  expect(initMetadataFromHeaders({ 'X-LD-EnvId': '12345' })).toEqual({ environmentId: '12345' });
+});

--- a/packages/shared/common/src/api/platform/EventSource.ts
+++ b/packages/shared/common/src/api/platform/EventSource.ts
@@ -4,13 +4,13 @@ export type EventName = string;
 export type EventListener = (event?: { data?: any }) => void;
 export type ProcessStreamResponse = {
   deserializeData: (data: string) => any;
-  processJson: (json: any) => void;
+  processJson: (json: any, initHeaders?: { [key: string]: string }) => void;
 };
 
 export interface EventSource {
   onclose: (() => void) | undefined;
   onerror: ((err?: HttpErrorResponse) => void) | undefined;
-  onopen: (() => void) | undefined;
+  onopen: ((e: { headers?: { [key: string]: string } }) => void) | undefined;
   onretrying: ((e: { delayMillis: number }) => void) | undefined;
 
   addEventListener(type: EventName, listener: EventListener): void;

--- a/packages/shared/common/src/internal/index.ts
+++ b/packages/shared/common/src/internal/index.ts
@@ -3,3 +3,4 @@ export * from './diagnostics';
 export * from './evaluation';
 export * from './events';
 export * from './fdv2';
+export * from './metadata';

--- a/packages/shared/common/src/internal/metadata/InitMetadata.ts
+++ b/packages/shared/common/src/internal/metadata/InitMetadata.ts
@@ -1,7 +1,5 @@
 /**
  * Metadata used to initialize an LDFeatureStore.
- *
- * @internal
  */
 export interface InitMetadata {
   environmentId: string;
@@ -14,8 +12,6 @@ export interface InitMetadata {
  * a streaming or polling connection to LD.
  * @returns InitMetadata object, or undefined if initHeaders is undefined
  * or missing the required header values.
- *
- * @internal
  */
 export function initMetadataFromHeaders(initHeaders?: {
   [key: string]: string;

--- a/packages/shared/common/src/internal/metadata/InitMetadata.ts
+++ b/packages/shared/common/src/internal/metadata/InitMetadata.ts
@@ -1,0 +1,30 @@
+/**
+ * Metadata used to initialize an LDFeatureStore.
+ *
+ * @internal
+ */
+export interface InitMetadata {
+  environmentId: string;
+}
+
+/**
+ * Creates an InitMetadata object from initialization headers.
+ *
+ * @param initHeaders Initialization headers received when establishing
+ * a streaming or polling connection to LD.
+ * @returns InitMetadata object, or undefined if initHeaders is undefined
+ * or missing the required header values.
+ *
+ * @internal
+ */
+export function initMetadataFromHeaders(initHeaders?: {
+  [key: string]: string;
+}): InitMetadata | undefined {
+  if (initHeaders) {
+    const envIdKey = Object.keys(initHeaders).find((key) => key.toLowerCase() === 'x-ld-envid');
+    if (envIdKey) {
+      return { environmentId: initHeaders[envIdKey] };
+    }
+  }
+  return undefined;
+}

--- a/packages/shared/common/src/internal/metadata/index.ts
+++ b/packages/shared/common/src/internal/metadata/index.ts
@@ -1,1 +1,3 @@
-export { InitMetadata, initMetadataFromHeaders } from './InitMetadata';
+import { InitMetadata, initMetadataFromHeaders } from './InitMetadata';
+
+export { InitMetadata, initMetadataFromHeaders };

--- a/packages/shared/common/src/internal/metadata/index.ts
+++ b/packages/shared/common/src/internal/metadata/index.ts
@@ -1,0 +1,1 @@
+export { InitMetadata, initMetadataFromHeaders } from './InitMetadata';

--- a/packages/shared/sdk-server/__tests__/data_sources/DataSourceUpdates.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/DataSourceUpdates.test.ts
@@ -1,10 +1,28 @@
 import { AsyncQueue } from 'launchdarkly-js-test-helpers';
 
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { LDFeatureStore } from '../../src/api/subsystems';
 import promisify from '../../src/async/promisify';
 import DataSourceUpdates from '../../src/data_sources/DataSourceUpdates';
 import InMemoryFeatureStore from '../../src/store/InMemoryFeatureStore';
 import VersionedDataKinds from '../../src/store/VersionedDataKinds';
+
+type InitMetadata = internal.InitMetadata;
+
+it('passes initialization metadata to underlying feature store', () => {
+  const metadata: InitMetadata = { environmentId: '12345' };
+  const store = new InMemoryFeatureStore();
+  store.init = jest.fn();
+  const updates = new DataSourceUpdates(
+    store,
+    () => false,
+    () => {},
+  );
+  updates.init({}, () => {}, metadata);
+  expect(store.init).toHaveBeenCalledTimes(1);
+  expect(store.init).toHaveBeenNthCalledWith(1, expect.any(Object), expect.any(Function), metadata);
+});
 
 describe.each([true, false])(
   'given a DataSourceUpdates with in memory store and change listeners: %s',

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessor.test.ts
@@ -76,6 +76,18 @@ describe('given an event processor', () => {
     expect(flags).toEqual(allData.flags);
     expect(segments).toEqual(allData.segments);
   });
+
+  it('initializes the feature store with metadata', () => {
+    const initHeaders = {
+      'x-ld-envid': '12345',
+    };
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, jsonData, initHeaders));
+
+    processor.start();
+    const metadata = storeFacade.getInitMetadata?.();
+
+    expect(metadata).toEqual({ environmentId: '12345' });
+  });
 });
 
 describe('given a polling processor with a short poll duration', () => {

--- a/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
@@ -49,7 +49,7 @@ describe('given a requestor', () => {
               throw new Error('Function not implemented.');
             },
             entries(): Iterable<[string, string]> {
-              throw new Error('Function not implemented.');
+              return testHeaders ? Object.entries(testHeaders) : [];
             },
             has(_name: string): boolean {
               throw new Error('Function not implemented.');
@@ -115,7 +115,9 @@ describe('given a requestor', () => {
   });
 
   it('stores and sends etags', async () => {
-    testHeaders.etag = 'abc123';
+    testHeaders = {
+      etag: 'abc123',
+    };
     testResponse = 'a response';
     const res1 = await promisify<{ err: any; body: any }>((cb) => {
       requestor.requestAllData((err, body) => cb({ err, body }));
@@ -133,5 +135,18 @@ describe('given a requestor', () => {
     const req2 = requestsMade[1];
     expect(req1.options.headers?.['if-none-match']).toBe(undefined);
     expect(req2.options.headers?.['if-none-match']).toBe((testHeaders.etag = 'abc123'));
+  });
+
+  it('passes response headers to callback', async () => {
+    testHeaders = {
+      header1: 'value1',
+      header2: 'value2',
+      header3: 'value3',
+    };
+    const res = await promisify<{ err: any; body: any; headers: any }>((cb) => {
+      requestor.requestAllData((err, body, headers) => cb({ err, body, headers }));
+    });
+
+    expect(res.headers).toEqual(testHeaders);
   });
 });

--- a/packages/shared/sdk-server/__tests__/data_sources/createStreamListeners.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/createStreamListeners.test.ts
@@ -94,13 +94,36 @@ describe('createStreamListeners', () => {
 
       processJson(allData);
 
-      expect(logger.debug).toBeCalledWith(expect.stringMatching(/initializing/i));
-      expect(dataSourceUpdates.init).toBeCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringMatching(/initializing/i));
+      expect(dataSourceUpdates.init).toHaveBeenCalledWith(
         {
           features: flags,
           segments,
         },
         onPutCompleteHandler,
+        undefined,
+      );
+    });
+
+    test('data source init is called with initialization metadata', async () => {
+      const listeners = createStreamListeners(dataSourceUpdates, logger, onCompleteHandlers);
+      const { processJson } = listeners.get('put')!;
+      const {
+        data: { flags, segments },
+      } = allData;
+      const initHeaders = {
+        'x-ld-envid': '12345',
+      };
+      processJson(allData, initHeaders);
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringMatching(/initializing/i));
+      expect(dataSourceUpdates.init).toHaveBeenCalledWith(
+        {
+          features: flags,
+          segments,
+        },
+        onPutCompleteHandler,
+        { environmentId: '12345' },
       );
     });
   });
@@ -121,8 +144,8 @@ describe('createStreamListeners', () => {
 
       processJson(patchData);
 
-      expect(logger.debug).toBeCalledWith(expect.stringMatching(/updating/i));
-      expect(dataSourceUpdates.upsert).toBeCalledWith(kind, data, onPatchCompleteHandler);
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringMatching(/updating/i));
+      expect(dataSourceUpdates.upsert).toHaveBeenCalledWith(kind, data, onPatchCompleteHandler);
     });
 
     test('data source upsert not called missing kind', async () => {
@@ -132,7 +155,7 @@ describe('createStreamListeners', () => {
 
       processJson(missingKind);
 
-      expect(dataSourceUpdates.upsert).not.toBeCalled();
+      expect(dataSourceUpdates.upsert).not.toHaveBeenCalled();
     });
 
     test('data source upsert not called wrong namespace path', async () => {
@@ -142,7 +165,7 @@ describe('createStreamListeners', () => {
 
       processJson(wrongKey);
 
-      expect(dataSourceUpdates.upsert).not.toBeCalled();
+      expect(dataSourceUpdates.upsert).not.toHaveBeenCalled();
     });
   });
 
@@ -162,8 +185,8 @@ describe('createStreamListeners', () => {
 
       processJson(deleteData);
 
-      expect(logger.debug).toBeCalledWith(expect.stringMatching(/deleting/i));
-      expect(dataSourceUpdates.upsert).toBeCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringMatching(/deleting/i));
+      expect(dataSourceUpdates.upsert).toHaveBeenCalledWith(
         kind,
         { key: 'flagkey', version, deleted: true },
         onDeleteCompleteHandler,
@@ -177,7 +200,7 @@ describe('createStreamListeners', () => {
 
       processJson(missingKind);
 
-      expect(dataSourceUpdates.upsert).not.toBeCalled();
+      expect(dataSourceUpdates.upsert).not.toHaveBeenCalled();
     });
 
     test('data source upsert not called wrong namespace path', async () => {
@@ -187,7 +210,7 @@ describe('createStreamListeners', () => {
 
       processJson(wrongKey);
 
-      expect(dataSourceUpdates.upsert).not.toBeCalled();
+      expect(dataSourceUpdates.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/shared/sdk-server/__tests__/hooks/HookRunner.test.ts
+++ b/packages/shared/sdk-server/__tests__/hooks/HookRunner.test.ts
@@ -36,6 +36,7 @@ describe('given a HookRunner', () => {
         reason: { kind: 'ERROR', errorKind: 'FLAG_NOT_FOUND' },
         variationIndex: null,
       }),
+      '12345',
     );
 
     testHook.verifyAfter(
@@ -44,6 +45,7 @@ describe('given a HookRunner', () => {
         context: { ...defaultUser },
         defaultValue: false,
         method: 'LDClient.variation',
+        environmentId: '12345',
       },
       { added: 'added data' },
       {
@@ -187,6 +189,7 @@ it('can add a hook after initialization', async () => {
       reason: { kind: 'FALLTHROUGH' },
       variationIndex: 0,
     }),
+    '12345',
   );
   testHook.verifyBefore(
     {
@@ -194,6 +197,7 @@ it('can add a hook after initialization', async () => {
       context: { ...defaultUser },
       defaultValue: false,
       method: 'LDClient.variation',
+      environmentId: '12345',
     },
     {},
   );
@@ -203,6 +207,7 @@ it('can add a hook after initialization', async () => {
       context: { ...defaultUser },
       defaultValue: false,
       method: 'LDClient.variation',
+      environmentId: '12345',
     },
     {},
     {

--- a/packages/shared/sdk-server/__tests__/store/InMemoryFeatureStore.test.ts
+++ b/packages/shared/sdk-server/__tests__/store/InMemoryFeatureStore.test.ts
@@ -147,4 +147,21 @@ describe('given an initialized feature store', () => {
     const feature = await featureStore.get({ namespace: 'potato' }, newPotato.key);
     expect(feature).toEqual(newPotato);
   });
+
+  it('returns undefined initMetadata', () => {
+    expect(featureStore.getInitMetadata?.()).toBeUndefined();
+  });
+});
+
+describe('given an initialized feature store with metadata', () => {
+  let featureStore: AsyncStoreFacade;
+
+  beforeEach(async () => {
+    featureStore = new AsyncStoreFacade(new InMemoryFeatureStore());
+    await featureStore.init({}, { environmentId: '12345' });
+  });
+
+  it('returns correct metadata', () => {
+    expect(featureStore.getInitMetadata?.()).toEqual({ environmentId: '12345' });
+  });
 });

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -344,6 +344,7 @@ export default class LDClientImpl implements LDClient {
               },
             );
           }),
+        this._featureStore.getInitMetaData?.()?.environmentId,
       )
       .then((detail) => {
         callback?.(null, detail.value);
@@ -375,6 +376,7 @@ export default class LDClientImpl implements LDClient {
             },
           );
         }),
+      this._featureStore.getInitMetaData?.()?.environmentId,
     );
   }
 
@@ -409,6 +411,7 @@ export default class LDClientImpl implements LDClient {
             typeChecker,
           );
         }),
+      this._featureStore.getInitMetaData?.()?.environmentId,
     );
   }
 
@@ -470,6 +473,7 @@ export default class LDClientImpl implements LDClient {
               },
             );
           }),
+        this._featureStore.getInitMetaData?.()?.environmentId,
       )
       .then((detail) => detail.value);
   }
@@ -541,6 +545,7 @@ export default class LDClientImpl implements LDClient {
             },
           );
         }),
+      this._featureStore.getInitMetaData?.()?.environmentId,
     );
   }
 
@@ -615,6 +620,7 @@ export default class LDClientImpl implements LDClient {
       defaultValue,
       MIGRATION_VARIATION_METHOD_NAME,
       () => this._migrationVariationInternal(key, context, defaultValue),
+      this._featureStore.getInitMetaData?.()?.environmentId,
     );
 
     return res.migration;

--- a/packages/shared/sdk-server/src/api/integrations/Hook.ts
+++ b/packages/shared/sdk-server/src/api/integrations/Hook.ts
@@ -8,6 +8,7 @@ export interface EvaluationSeriesContext {
   readonly context: LDContext;
   readonly defaultValue: unknown;
   readonly method: string;
+  readonly environmentId?: string;
 }
 
 /**

--- a/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
@@ -1,5 +1,9 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { DataKind } from '../interfaces';
 import { LDFeatureStoreDataStorage, LDKeyedFeatureStoreItem } from './LDFeatureStore';
+
+type InitMetadata = internal.InitMetadata;
 
 /**
  * Interface that a data source implementation will use to push data into the SDK.
@@ -19,8 +23,11 @@ export interface LDDataSourceUpdates {
    *
    * @param callback
    *   Will be called when the store has been initialized.
+   *
+   * @param initMetadata
+   *   Optional metadata to initialize the data source with.
    */
-  init(allData: LDFeatureStoreDataStorage, callback: () => void): void;
+  init(allData: LDFeatureStoreDataStorage, callback: () => void, initMetadata?: InitMetadata): void;
 
   /**
    * Updates or inserts an item in the specified collection. For updates, the object will only be

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
@@ -6,5 +6,5 @@
  * @ignore
  */
 export interface LDFeatureRequestor {
-  requestAllData: (cb: (err: any, body: any) => void) => void;
+  requestAllData: (cb: (err: any, body: any, headers: any) => void) => void;
 }

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
@@ -1,4 +1,8 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { DataKind } from '../interfaces';
+
+type InitMetadata = internal.InitMetadata;
 
 /**
  * Represents an item which can be stored in the feature store.
@@ -92,8 +96,11 @@ export interface LDFeatureStore {
    *
    * @param callback
    *   Will be called when the store has been initialized.
+   *
+   * @param initMetadata
+   *   Optional metadata to initialize the feature store with.
    */
-  init(allData: LDFeatureStoreDataStorage, callback: () => void): void;
+  init(allData: LDFeatureStoreDataStorage, callback: () => void, initMetadata?: InitMetadata): void;
 
   /**
    * Delete an entity from the store.
@@ -158,4 +165,9 @@ export interface LDFeatureStore {
    * Get a description of the store.
    */
   getDescription?(): string;
+
+  /**
+   * Get the initialization metadata of the store.
+   */
+  getInitMetaData?(): InitMetadata | undefined;
 }

--- a/packages/shared/sdk-server/src/data_sources/DataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/data_sources/DataSourceUpdates.ts
@@ -1,3 +1,5 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { DataKind } from '../api/interfaces';
 import {
   LDDataSourceUpdates,
@@ -12,6 +14,8 @@ import { Prerequisite } from '../evaluation/data/Prerequisite';
 import VersionedDataKinds from '../store/VersionedDataKinds';
 import DependencyTracker from './DependencyTracker';
 import NamespacedDataSet from './NamespacedDataSet';
+
+type InitMetadata = internal.InitMetadata;
 
 /**
  * This type allows computing the clause dependencies of either a flag or a segment.
@@ -66,46 +70,54 @@ export default class DataSourceUpdates implements LDDataSourceUpdates {
     private readonly _onChange: (key: string) => void,
   ) {}
 
-  init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
+  init(
+    allData: LDFeatureStoreDataStorage,
+    callback: () => void,
+    initMetadata?: InitMetadata,
+  ): void {
     const checkForChanges = this._hasEventListeners();
     const doInit = (oldData?: LDFeatureStoreDataStorage) => {
-      this._featureStore.init(allData, () => {
-        // Defer change events so they execute after the callback.
-        Promise.resolve().then(() => {
-          this._dependencyTracker.reset();
+      this._featureStore.init(
+        allData,
+        () => {
+          // Defer change events so they execute after the callback.
+          Promise.resolve().then(() => {
+            this._dependencyTracker.reset();
 
-          Object.entries(allData).forEach(([namespace, items]) => {
-            Object.keys(items || {}).forEach((key) => {
-              const item = items[key];
-              this._dependencyTracker.updateDependenciesFrom(
-                namespace,
-                key,
-                computeDependencies(namespace, item),
-              );
-            });
-          });
-
-          if (checkForChanges) {
-            const updatedItems = new NamespacedDataSet<boolean>();
-            Object.keys(allData).forEach((namespace) => {
-              const oldDataForKind = oldData?.[namespace] || {};
-              const newDataForKind = allData[namespace];
-              const mergedData = { ...oldDataForKind, ...newDataForKind };
-              Object.keys(mergedData).forEach((key) => {
-                this.addIfModified(
+            Object.entries(allData).forEach(([namespace, items]) => {
+              Object.keys(items || {}).forEach((key) => {
+                const item = items[key];
+                this._dependencyTracker.updateDependenciesFrom(
                   namespace,
                   key,
-                  oldDataForKind && oldDataForKind[key],
-                  newDataForKind && newDataForKind[key],
-                  updatedItems,
+                  computeDependencies(namespace, item),
                 );
               });
             });
-            this.sendChangeEvents(updatedItems);
-          }
-        });
-        callback?.();
-      });
+
+            if (checkForChanges) {
+              const updatedItems = new NamespacedDataSet<boolean>();
+              Object.keys(allData).forEach((namespace) => {
+                const oldDataForKind = oldData?.[namespace] || {};
+                const newDataForKind = allData[namespace];
+                const mergedData = { ...oldDataForKind, ...newDataForKind };
+                Object.keys(mergedData).forEach((key) => {
+                  this.addIfModified(
+                    namespace,
+                    key,
+                    oldDataForKind && oldDataForKind[key],
+                    newDataForKind && newDataForKind[key],
+                    updatedItems,
+                  );
+                });
+              });
+              this.sendChangeEvents(updatedItems);
+            }
+          });
+          callback?.();
+        },
+        initMetadata,
+      );
     };
 
     if (checkForChanges) {

--- a/packages/shared/sdk-server/src/data_sources/PollingProcessor.ts
+++ b/packages/shared/sdk-server/src/data_sources/PollingProcessor.ts
@@ -1,6 +1,7 @@
 import {
   DataSourceErrorKind,
   httpErrorMessage,
+  internal,
   isHttpRecoverable,
   LDLogger,
   LDPollingError,
@@ -15,6 +16,8 @@ import VersionedDataKinds from '../store/VersionedDataKinds';
 import Requestor from './Requestor';
 
 export type PollingErrorHandler = (err: LDPollingError) => void;
+
+const { initMetadataFromHeaders } = internal;
 
 /**
  * @internal
@@ -57,7 +60,7 @@ export default class PollingProcessor implements subsystem.LDStreamProcessor {
 
     const startTime = Date.now();
     this._logger?.debug('Polling LaunchDarkly for feature flag updates');
-    this._requestor.requestAllData((err, body) => {
+    this._requestor.requestAllData((err, body, headers) => {
       const elapsed = Date.now() - startTime;
       const sleepFor = Math.max(this._pollInterval * 1000 - elapsed, 0);
 
@@ -86,13 +89,17 @@ export default class PollingProcessor implements subsystem.LDStreamProcessor {
             [VersionedDataKinds.Features.namespace]: parsed.flags,
             [VersionedDataKinds.Segments.namespace]: parsed.segments,
           };
-          this._featureStore.init(initData, () => {
-            this._initSuccessHandler();
-            // Triggering the next poll after the init has completed.
-            this._timeoutHandle = setTimeout(() => {
-              this._poll();
-            }, sleepFor);
-          });
+          this._featureStore.init(
+            initData,
+            () => {
+              this._initSuccessHandler();
+              // Triggering the next poll after the init has completed.
+              this._timeoutHandle = setTimeout(() => {
+                this._poll();
+              }, sleepFor);
+            },
+            initMetadataFromHeaders(headers),
+          );
           // The poll will be triggered by  the feature store initialization
           // completing.
           return;

--- a/packages/shared/sdk-server/src/data_sources/Requestor.ts
+++ b/packages/shared/sdk-server/src/data_sources/Requestor.ts
@@ -70,7 +70,7 @@ export default class Requestor implements LDFeatureRequestor {
     return { res, body };
   }
 
-  async requestAllData(cb: (err: any, body: any) => void) {
+  async requestAllData(cb: (err: any, body: any, headers: any) => void) {
     const options: Options = {
       method: 'GET',
       headers: this._headers,
@@ -83,11 +83,15 @@ export default class Requestor implements LDFeatureRequestor {
           `Unexpected status code: ${res.status}`,
           res.status,
         );
-        return cb(err, undefined);
+        return cb(err, undefined, undefined);
       }
-      return cb(undefined, res.status === 304 ? null : body);
+      return cb(
+        undefined,
+        res.status === 304 ? null : body,
+        Object.fromEntries(res.headers.entries()),
+      );
     } catch (err) {
-      return cb(err, undefined);
+      return cb(err, undefined, undefined);
     }
   }
 }

--- a/packages/shared/sdk-server/src/data_sources/StreamingProcessor.ts
+++ b/packages/shared/sdk-server/src/data_sources/StreamingProcessor.ts
@@ -38,6 +38,7 @@ export default class StreamingProcessor implements subsystem.LDStreamProcessor {
   private _eventSource?: EventSource;
   private _requests: Requests;
   private _connectionAttemptStartTime?: number;
+  private _initHeaders?: { [key: string]: string };
 
   constructor(
     clientContext: ClientContext,
@@ -125,7 +126,8 @@ export default class StreamingProcessor implements subsystem.LDStreamProcessor {
       // The work is done by `errorFilter`.
     };
 
-    eventSource.onopen = () => {
+    eventSource.onopen = (e) => {
+      this._initHeaders = e.headers;
       this._logger?.info('Opened LaunchDarkly stream connection');
     };
 
@@ -146,7 +148,7 @@ export default class StreamingProcessor implements subsystem.LDStreamProcessor {
             reportJsonError(eventName, data, this._logger, this._errorHandler);
             return;
           }
-          processJson(dataJson);
+          processJson(dataJson, this._initHeaders);
         } else {
           this._errorHandler?.(
             new LDStreamingError(

--- a/packages/shared/sdk-server/src/data_sources/createStreamListeners.ts
+++ b/packages/shared/sdk-server/src/data_sources/createStreamListeners.ts
@@ -1,5 +1,6 @@
 import {
   EventName,
+  internal,
   LDLogger,
   ProcessStreamResponse,
   VoidFunction,
@@ -16,20 +17,24 @@ import {
 } from '../store/serialization';
 import VersionedDataKinds from '../store/VersionedDataKinds';
 
+const { initMetadataFromHeaders } = internal;
+
 export const createPutListener = (
   dataSourceUpdates: LDDataSourceUpdates,
   logger?: LDLogger,
   onPutCompleteHandler: VoidFunction = () => {},
 ) => ({
   deserializeData: deserializeAll,
-  processJson: async ({ data: { flags, segments } }: AllData) => {
+  processJson: async (
+    { data: { flags, segments } }: AllData,
+    initHeaders?: { [key: string]: string },
+  ) => {
     const initData = {
       [VersionedDataKinds.Features.namespace]: flags,
       [VersionedDataKinds.Segments.namespace]: segments,
     };
-
     logger?.debug('Initializing all data');
-    dataSourceUpdates.init(initData, onPutCompleteHandler);
+    dataSourceUpdates.init(initData, onPutCompleteHandler, initMetadataFromHeaders(initHeaders));
   },
 });
 

--- a/packages/shared/sdk-server/src/hooks/HookRunner.ts
+++ b/packages/shared/sdk-server/src/hooks/HookRunner.ts
@@ -22,6 +22,7 @@ export default class HookRunner {
     defaultValue: unknown,
     methodName: string,
     method: () => Promise<LDEvaluationDetail>,
+    environmentId?: string,
   ): Promise<LDEvaluationDetail> {
     // This early return is here to avoid the extra async/await associated with
     // using withHooksDataWithDetail.
@@ -38,6 +39,7 @@ export default class HookRunner {
         const detail = await method();
         return { detail };
       },
+      environmentId,
     ).then(({ detail }) => detail);
   }
 
@@ -51,12 +53,13 @@ export default class HookRunner {
     defaultValue: unknown,
     methodName: string,
     method: () => Promise<{ detail: LDEvaluationDetail; [index: string]: any }>,
+    environmentId?: string,
   ): Promise<{ detail: LDEvaluationDetail; [index: string]: any }> {
     if (this._hooks.length === 0) {
       return method();
     }
     const { hooks, hookContext }: { hooks: Hook[]; hookContext: EvaluationSeriesContext } =
-      this._prepareHooks(key, context, defaultValue, methodName);
+      this._prepareHooks(key, context, defaultValue, methodName, environmentId);
     const hookData = this._executeBeforeEvaluation(hooks, hookContext);
     const result = await method();
     this._executeAfterEvaluation(hooks, hookContext, hookData, result.detail);
@@ -124,6 +127,7 @@ export default class HookRunner {
     context: LDContext,
     defaultValue: unknown,
     methodName: string,
+    environmentId?: string,
   ): {
     hooks: Hook[];
     hookContext: EvaluationSeriesContext;
@@ -137,6 +141,7 @@ export default class HookRunner {
       context,
       defaultValue,
       method: methodName,
+      environmentId,
     };
     return { hooks, hookContext };
   }

--- a/packages/shared/sdk-server/src/store/AsyncStoreFacade.ts
+++ b/packages/shared/sdk-server/src/store/AsyncStoreFacade.ts
@@ -1,3 +1,5 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { DataKind } from '../api/interfaces';
 import {
   LDFeatureStore,
@@ -7,6 +9,8 @@ import {
   LDKeyedFeatureStoreItem,
 } from '../api/subsystems';
 import promisify from '../async/promisify';
+
+type InitMetadata = internal.InitMetadata;
 
 /**
  * Provides an async interface to a feature store.
@@ -33,9 +37,9 @@ export default class AsyncStoreFacade {
     });
   }
 
-  async init(allData: LDFeatureStoreDataStorage): Promise<void> {
+  async init(allData: LDFeatureStoreDataStorage, initMetadata?: InitMetadata): Promise<void> {
     return promisify((cb) => {
-      this._store.init(allData, cb);
+      this._store.init(allData, cb, initMetadata);
     });
   }
 
@@ -59,5 +63,9 @@ export default class AsyncStoreFacade {
 
   close(): void {
     this._store.close();
+  }
+
+  getInitMetadata?(): InitMetadata | undefined {
+    return this._store.getInitMetaData?.();
   }
 }

--- a/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
+++ b/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
@@ -1,3 +1,5 @@
+import { internal } from '@launchdarkly/js-sdk-common';
+
 import { DataKind } from '../api/interfaces';
 import {
   LDFeatureStore,
@@ -7,10 +9,14 @@ import {
   LDKeyedFeatureStoreItem,
 } from '../api/subsystems';
 
+type InitMetadata = internal.InitMetadata;
+
 export default class InMemoryFeatureStore implements LDFeatureStore {
   private _allData: LDFeatureStoreDataStorage = {};
 
   private _initCalled = false;
+
+  private _initMetadata?: InitMetadata;
 
   private _addItem(kind: DataKind, key: string, item: LDFeatureStoreItem) {
     let items = this._allData[kind.namespace];
@@ -52,9 +58,14 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
     callback?.(result);
   }
 
-  init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
+  init(
+    allData: LDFeatureStoreDataStorage,
+    callback: () => void,
+    initMetadata?: InitMetadata,
+  ): void {
     this._initCalled = true;
     this._allData = allData as LDFeatureStoreDataStorage;
+    this._initMetadata = initMetadata;
     callback?.();
   }
 
@@ -80,5 +91,9 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
 
   getDescription(): string {
     return 'memory';
+  }
+
+  getInitMetaData(): InitMetadata | undefined {
+    return this._initMetadata;
   }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

If present, `environmentId` is now passed to the HookRunner in the evaluation series.

For streaming connections:
- Response headers are now attached to the `open` event (https://github.com/launchdarkly/js-eventsource/pull/33)
- `StreamingProcessor` passes these headers to the stream listeners via `processJson`.  The listener for the PUT event extracts the `environmentId` from the headers and passes this as initialization metadata to the underlying feature store.

For polling connections:
- `PollingProcessor` retrieves  the response headers via the underlying `Requestor` and extracts the `environmentId` from the headers and passes this as initialization metadata to the underlying feature store.

LDClient will then call `getInitMetaData()` on the underlying feature store (if the feature store supports it) when executing a hook and pass `environmentId` in the execution series data.

Currently only `InMemoryFeatureStore` has been modified to support initialization metadata.  This functionality can be added to other feature stores by modifying `init()` to accept the optional `initMetadata` parameter and implementing the optional `getInitMetadata()` method.





