### PR TITLE
chore: Add hook support in browser contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "packageManager": "yarn@3.4.1",
   "//": "Pin jsonc-parser because v3.3.0 breaks rollup-plugin-esbuild",
   "resolutions": {
-    "jsonc-parser": "3.2.0"
+    "jsonc-parser": "3.2.0",
+    "parse5": "7.2.1"
   }
 }

--- a/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
@@ -3,6 +3,7 @@ import { initialize, LDClient, LDLogger, LDOptions } from '@launchdarkly/js-clie
 import { CommandParams, CommandType, ValueType } from './CommandParams';
 import { CreateInstanceParams, SDKConfigParams } from './ConfigParams';
 import { makeLogger } from './makeLogger';
+import TestHook from './TestHook';
 
 export const badCommandError = new Error('unsupported command');
 export const malformedCommand = new Error('command was malformed');
@@ -62,6 +63,12 @@ function makeSdkConfig(options: SDKConfigParams, tag: string) {
       id: options.tags.applicationId,
       version: options.tags.applicationVersion,
     };
+  }
+
+  if (options.hooks) {
+    cf.hooks = options.hooks.hooks.map(
+      (hook) => new TestHook(hook.name, hook.callbackUri, hook.data, hook.errors),
+    );
   }
 
   cf.fetchGoals = false;

--- a/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -42,6 +42,7 @@ export default class TestHarnessWebSocket {
             'anonymous-redaction',
             'strongly-typed',
             'client-prereq-events',
+            'track-hooks',
           ];
 
           break;

--- a/packages/sdk/browser/contract-tests/entity/src/TestHook.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHook.ts
@@ -1,0 +1,94 @@
+import {
+  EvaluationSeriesContext,
+  EvaluationSeriesData,
+  Hook,
+  HookMetadata,
+  LDEvaluationDetail,
+  TrackSeriesContext,
+} from '@launchdarkly/js-client-sdk';
+
+export interface HookData {
+  beforeEvaluation?: Record<string, unknown>;
+  afterEvaluation?: Record<string, unknown>;
+}
+
+export interface HookErrors {
+  beforeEvaluation?: string;
+  afterEvaluation?: string;
+  afterTrack?: string;
+}
+
+export default class TestHook implements Hook {
+  private _name: string;
+  private _endpoint: string;
+  private _data?: HookData;
+  private _errors?: HookErrors;
+
+  constructor(name: string, endpoint: string, data?: HookData, errors?: HookErrors) {
+    this._name = name;
+    this._endpoint = endpoint;
+    this._data = data;
+    this._errors = errors;
+  }
+
+  private async _safePost(body: unknown): Promise<void> {
+    try {
+      await fetch(this._endpoint, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // The test could move on before the post, so we are ignoring
+      // failed posts.
+    }
+  }
+
+  getMetadata(): HookMetadata {
+    return {
+      name: this._name,
+    };
+  }
+
+  beforeEvaluation(
+    hookContext: EvaluationSeriesContext,
+    data: EvaluationSeriesData,
+  ): EvaluationSeriesData {
+    if (this._errors?.beforeEvaluation) {
+      throw new Error(this._errors.beforeEvaluation);
+    }
+    this._safePost({
+      evaluationSeriesContext: hookContext,
+      evaluationSeriesData: data,
+      stage: 'beforeEvaluation',
+    });
+    return { ...data, ...(this._data?.beforeEvaluation || {}) };
+  }
+
+  afterEvaluation(
+    hookContext: EvaluationSeriesContext,
+    data: EvaluationSeriesData,
+    detail: LDEvaluationDetail,
+  ): EvaluationSeriesData {
+    if (this._errors?.afterEvaluation) {
+      throw new Error(this._errors.afterEvaluation);
+    }
+    this._safePost({
+      evaluationSeriesContext: hookContext,
+      evaluationSeriesData: data,
+      stage: 'afterEvaluation',
+      evaluationDetail: detail,
+    });
+
+    return { ...data, ...(this._data?.afterEvaluation || {}) };
+  }
+
+  afterTrack(hookContext: TrackSeriesContext): void {
+    if (this._errors?.afterTrack) {
+      throw new Error(this._errors.afterTrack);
+    }
+    this._safePost({
+      trackSeriesContext: hookContext,
+      stage: 'afterTrack',
+    });
+  }
+}

--- a/packages/sdk/browser/src/common.ts
+++ b/packages/sdk/browser/src/common.ts
@@ -32,6 +32,7 @@ export type {
   LDLogLevel,
   LDMultiKindContext,
   LDSingleKindContext,
+  TrackSeriesContext,
 } from '@launchdarkly/js-client-sdk-common';
 
 /**

--- a/packages/shared/sdk-client/src/index.ts
+++ b/packages/shared/sdk-client/src/index.ts
@@ -28,6 +28,7 @@ export type {
   IdentifySeriesData,
   IdentifySeriesResult,
   IdentifySeriesStatus,
+  TrackSeriesContext,
   LDInspection,
 } from './api';
 


### PR DESCRIPTION
Adds hook support in browser contract tests as well as adding the `track-hooks` capability.