### PR TITLE
feat: falls back to FDv1 polling if flag delivery sends fallback header

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "packageManager": "yarn@3.4.1",
   "//": "Pin jsonc-parser because v3.3.0 breaks rollup-plugin-esbuild",
   "resolutions": {
-    "jsonc-parser": "3.2.0"
+    "jsonc-parser": "3.2.0",
+    "parse5": "7.2.1"
   }
 }

--- a/packages/sdk/server-node/__tests__/LDClientNode.proxy.test.ts
+++ b/packages/sdk/server-node/__tests__/LDClientNode.proxy.test.ts
@@ -38,7 +38,7 @@ describe('When using a proxy', () => {
   it('can use proxy in polling mode', async () => {
     const proxy = await TestHttpServer.startProxy();
     const server = await TestHttpServer.start();
-    server.forMethodAndPath('get', '/sdk/latest-all', TestHttpHandlers.respondJson(allData));
+    server.forMethodAndPath('get', '/sdk/poll', TestHttpHandlers.respondJson(allData));
 
     const client = new LDClientNode(sdkKey, {
       baseUri: server.url,
@@ -67,7 +67,7 @@ describe('When using a proxy', () => {
     const server = await TestHttpServer.start();
     const events = new AsyncQueue<SSEItem>();
     events.add({ type: 'put', data: JSON.stringify({ data: allData }) });
-    server.forMethodAndPath('get', '/all', TestHttpHandlers.sseStream(events));
+    server.forMethodAndPath('get', '/sdk/stream', TestHttpHandlers.sseStream(events));
 
     const client = new LDClientNode(sdkKey, {
       streamUri: server.url,
@@ -94,7 +94,7 @@ describe('When using a proxy', () => {
     const proxy = await TestHttpServer.startProxy();
     const pollingServer = await TestHttpServer.start();
     const eventsServer = await TestHttpServer.start();
-    pollingServer.forMethodAndPath('get', '/sdk/latest-all', TestHttpHandlers.respondJson(allData));
+    pollingServer.forMethodAndPath('get', '/sdk/poll', TestHttpHandlers.respondJson(allData));
     eventsServer.forMethodAndPath('post', '/diagnostic', TestHttpHandlers.respond(200));
 
     const client = new LDClientNode(sdkKey, {

--- a/packages/sdk/server-node/__tests__/LDClientNode.tls.test.ts
+++ b/packages/sdk/server-node/__tests__/LDClientNode.tls.test.ts
@@ -26,7 +26,7 @@ describe('When using a TLS connection', () => {
 
   it('can connect via HTTPS to a server with a self-signed certificate, if CA is specified', async () => {
     server = await TestHttpServer.startSecure();
-    server.forMethodAndPath('get', '/sdk/latest-all', TestHttpHandlers.respondJson({}));
+    server.forMethodAndPath('get', '/sdk/poll', TestHttpHandlers.respondJson({}));
 
     client = new LDClientNode('sdk-key', {
       baseUri: server.url,
@@ -41,7 +41,7 @@ describe('When using a TLS connection', () => {
 
   it('cannot connect via HTTPS to a server with a self-signed certificate, using default config', async () => {
     server = await TestHttpServer.startSecure();
-    server.forMethodAndPath('get', '/sdk/latest-all', TestHttpHandlers.respondJson({}));
+    server.forMethodAndPath('get', '/sdk/poll', TestHttpHandlers.respondJson({}));
 
     client = new LDClientNode('sdk-key', {
       baseUri: server.url,
@@ -64,7 +64,7 @@ describe('When using a TLS connection', () => {
     const events = new AsyncQueue<SSEItem>();
     events.add({ type: 'put', data: JSON.stringify(eventData) });
     server = await TestHttpServer.startSecure();
-    server.forMethodAndPath('get', '/stream/all', TestHttpHandlers.sseStream(events));
+    server.forMethodAndPath('get', '/stream/sdk/stream', TestHttpHandlers.sseStream(events));
 
     client = new LDClientNode('sdk-key', {
       baseUri: server.url,
@@ -83,7 +83,7 @@ describe('When using a TLS connection', () => {
   it('can use custom TLS options for posting events', async () => {
     server = await TestHttpServer.startSecure();
     server.forMethodAndPath('post', '/events/bulk', TestHttpHandlers.respond(200));
-    server.forMethodAndPath('get', '/sdk/latest-all', TestHttpHandlers.respondJson({}));
+    server.forMethodAndPath('get', '/sdk/poll', TestHttpHandlers.respondJson({}));
 
     client = new LDClientNode('sdk-key', {
       baseUri: server.url,
@@ -99,7 +99,7 @@ describe('When using a TLS connection', () => {
     await client.flush();
 
     const flagsRequest = await server.nextRequest();
-    expect(flagsRequest.path).toEqual('/sdk/latest-all');
+    expect(flagsRequest.path).toEqual('/sdk/poll');
 
     const eventsRequest = await server.nextRequest();
     expect(eventsRequest.path).toEqual('/events/bulk');

--- a/packages/sdk/server-node/package.json
+++ b/packages/sdk/server-node/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@launchdarkly/js-server-sdk-common": "2.10.0",
     "https-proxy-agent": "^5.0.1",
-    "launchdarkly-eventsource": "2.0.3"
+    "launchdarkly-eventsource": "2.2.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",

--- a/packages/shared/common/__tests__/internal/fdv2/PayloadStreamReader.test.ts
+++ b/packages/shared/common/__tests__/internal/fdv2/PayloadStreamReader.test.ts
@@ -2,7 +2,6 @@ import { EventListener, EventName, LDLogger } from '../../../src/api';
 import { Payload } from '../../../src/internal/fdv2/payloadProcessor';
 import { EventStream, PayloadStreamReader } from '../../../src/internal/fdv2/payloadStreamReader';
 
-
 class MockEventStream implements EventStream {
   private _listeners: Record<EventName, EventListener> = {};
 
@@ -26,7 +25,7 @@ it('it sets basis to true when intent code is xfer-full', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('payload-transferred', {
     data: '{"state": "mockState", "version": 1}',
@@ -48,7 +47,7 @@ it('it sets basis to false when intent code is xfer-changes', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-changes", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-changes", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('payload-transferred', {
     data: '{"state": "mockState", "version": 1}',
@@ -70,7 +69,7 @@ it('it sets basis to false and emits empty payload when intent code is none', ()
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "none", "id": "mockId", "target": 42}]}',
+    data: '{"payloads": [{"intentCode": "none", "id": "mockId", "target": 42}]}',
   });
   expect(receivedPayloads.length).toEqual(1);
   expect(receivedPayloads[0].id).toEqual('mockId');
@@ -89,7 +88,7 @@ it('it handles xfer-full then xfer-changes', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -131,7 +130,7 @@ it('it includes multiple types of updates in payload', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -172,7 +171,7 @@ it('it does not include messages thats are not between server-intent and payload
     data: '{"kind": "mockKind", "key": "flagShouldIgnore", "version": 123, "object": {"objectFieldShouldIgnore": "objectValueShouldIgnore"}}',
   });
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -238,7 +237,7 @@ it('logs prescribed message when error event is encountered', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -280,7 +279,7 @@ it('discards partially transferred data when an error is encountered', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -295,7 +294,7 @@ it('discards partially transferred data when an error is encountered', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId2"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId2"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagX", "version": 123, "object": {"objectFieldX": "objectValueX"}}',
@@ -339,7 +338,7 @@ it('silently ignores unrecognized kinds', () => {
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -369,7 +368,7 @@ it('ignores additional payloads beyond the first payload in the server-intent me
   });
 
   mockStream.simulateEvent('server-intent', {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"},{"code": "IShouldBeIgnored", "id": "IShouldBeIgnored"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"},{"intentCode": "IShouldBeIgnored", "id": "IShouldBeIgnored"}]}',
   });
   mockStream.simulateEvent('put-object', {
     data: '{"kind": "mockKind", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',

--- a/packages/shared/common/__tests__/options/ServiceEndpoints.test.ts
+++ b/packages/shared/common/__tests__/options/ServiceEndpoints.test.ts
@@ -49,14 +49,14 @@ it('applies payload filter to polling and streaming endpoints', () => {
     'filterKey',
   );
 
-  expect(getStreamingUri(endpoints, '/all', [])).toEqual(
-    'https://stream.launchdarkly.com/all?filter=filterKey',
+  expect(getStreamingUri(endpoints, '/sdk/stream', [])).toEqual(
+    'https://stream.launchdarkly.com/sdk/stream?filter=filterKey',
   );
-  expect(getPollingUri(endpoints, '/sdk/latest-all', [])).toEqual(
-    'https://sdk.launchdarkly.com/sdk/latest-all?filter=filterKey',
+  expect(getPollingUri(endpoints, '/sdk/poll', [])).toEqual(
+    'https://sdk.launchdarkly.com/sdk/poll?filter=filterKey',
   );
   expect(
-    getPollingUri(endpoints, '/sdk/latest-all', [{ key: 'withReasons', value: 'true' }]),
-  ).toEqual('https://sdk.launchdarkly.com/sdk/latest-all?withReasons=true&filter=filterKey');
+    getPollingUri(endpoints, '/sdk/poll', [{ key: 'withReasons', value: 'true' }]),
+  ).toEqual('https://sdk.launchdarkly.com/sdk/poll?withReasons=true&filter=filterKey');
   expect(getEventsUri(endpoints, '/bulk', [])).toEqual('https://events.launchdarkly.com/bulk');
 });

--- a/packages/shared/common/src/api/platform/EventSource.ts
+++ b/packages/shared/common/src/api/platform/EventSource.ts
@@ -10,7 +10,7 @@ export type ProcessStreamResponse = {
 export interface EventSource {
   onclose: (() => void) | undefined;
   onerror: ((err?: HttpErrorResponse) => void) | undefined;
-  onopen: (() => void) | undefined;
+  onopen: ((e: { headers?: { [key: string]: string } }) => void) | undefined;
   onretrying: ((e: { delayMillis: number }) => void) | undefined;
 
   addEventListener(type: EventName, listener: EventListener): void;

--- a/packages/shared/common/src/api/platform/Requests.ts
+++ b/packages/shared/common/src/api/platform/Requests.ts
@@ -129,4 +129,5 @@ export interface Requests {
 export interface HttpErrorResponse {
   message: string;
   status?: number;
+  headers?: Record<string, string>;
 }

--- a/packages/shared/common/src/datasource/errors.ts
+++ b/packages/shared/common/src/datasource/errors.ts
@@ -36,4 +36,21 @@ export class LDStreamingError extends Error {
   }
 }
 
+/**
+ * This is a short term error and will be removed once FDv2 adoption is sufficient.
+ */
+export class LDFlagDeliveryFallbackError extends Error {
+  public readonly kind: DataSourceErrorKind;
+  public readonly code?: number;
+  public readonly recoverable: boolean;
+
+  constructor(kind: DataSourceErrorKind, message: string, code?: number) {
+    super(message);
+    this.kind = kind;
+    this.code = code;
+    this.name = 'LDFlagDeliveryFallbackError';
+    this.recoverable = false;
+  }
+}
+
 export type StreamingErrorHandler = (err: LDStreamingError) => void;

--- a/packages/shared/common/src/datasource/index.ts
+++ b/packages/shared/common/src/datasource/index.ts
@@ -3,6 +3,7 @@ import { CompositeDataSource } from './CompositeDataSource';
 import { DataSourceErrorKind } from './DataSourceErrorKinds';
 import {
   LDFileDataSourceError,
+  LDFlagDeliveryFallbackError,
   LDPollingError,
   LDStreamingError,
   StreamingErrorHandler,
@@ -14,6 +15,7 @@ export {
   DefaultBackoff,
   DataSourceErrorKind,
   LDFileDataSourceError,
+  LDFlagDeliveryFallbackError,
   LDPollingError,
   LDStreamingError,
   StreamingErrorHandler,

--- a/packages/shared/common/src/index.ts
+++ b/packages/shared/common/src/index.ts
@@ -7,6 +7,7 @@ import {
   DataSourceErrorKind,
   DefaultBackoff,
   LDFileDataSourceError,
+  LDFlagDeliveryFallbackError,
   LDPollingError,
   LDStreamingError,
   StreamingErrorHandler,
@@ -33,4 +34,5 @@ export {
   LDStreamingError,
   StreamingErrorHandler,
   LDFileDataSourceError,
+  LDFlagDeliveryFallbackError,
 };

--- a/packages/shared/common/src/internal/fdv2/payloadProcessor.ts
+++ b/packages/shared/common/src/internal/fdv2/payloadProcessor.ts
@@ -137,7 +137,7 @@ export class PayloadProcessor {
     // at the time of writing this, it was agreed upon that SDKs could assume exactly 1 element in this list.  In the future, a negotiation of protocol version will be required to remove this assumption.
     const payload = data.payloads[0];
 
-    switch (payload?.code) {
+    switch (payload?.intentCode) {
       case 'xfer-full':
         this._tempBasis = true;
         break;
@@ -150,6 +150,7 @@ export class PayloadProcessor {
         break;
       default:
         // unrecognized intent code, return
+        this._logger?.warn(`Unable to process intent code '${payload?.intentCode}'.`);
         return;
     }
 

--- a/packages/shared/common/src/internal/fdv2/proto.ts
+++ b/packages/shared/common/src/internal/fdv2/proto.ts
@@ -12,7 +12,7 @@ export type IntentCode = 'xfer-full' | 'xfer-changes' | 'none';
 export interface PayloadIntent {
   id: string;
   target: number;
-  code: IntentCode;
+  intentCode: IntentCode;
   reason: string;
 }
 

--- a/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
@@ -1,8 +1,7 @@
-import { DataSourceErrorKind, LDPollingError, subsystem } from '../../src';
+import { subsystem } from '../../src';
 import OneShotInitializerFDv2 from '../../src/data_sources/OneShotInitializerFDv2';
-import PollingProcessorFDv2 from '../../src/data_sources/PollingProcessorFDv2';
 import Requestor from '../../src/data_sources/Requestor';
-import TestLogger, { LogLevel } from '../Logger';
+import TestLogger from '../Logger';
 
 describe('given a one shot initializer', () => {
   const requestor = {
@@ -12,7 +11,7 @@ describe('given a one shot initializer', () => {
     events: [
       {
         event: 'server-intent',
-        data: { payloads: [{ code: 'xfer-full', id: 'mockId' }] },
+        data: { payloads: [{ intentCode: 'xfer-full', id: 'mockId' }] },
       },
       {
         event: 'put-object',

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -12,7 +12,7 @@ describe('given an event processor', () => {
     events: [
       {
         event: 'server-intent',
-        data: { payloads: [{ code: 'xfer-full', id: 'mockId' }] },
+        data: { payloads: [{ intentCode: 'xfer-full', id: 'mockId' }] },
       },
       {
         event: 'put-object',

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -8,7 +8,7 @@ describe('given an event processor', () => {
     requestAllData: jest.fn(),
   };
   const longInterval = 100000;
-  const allEvents = {
+  const allFDv2Events = {
     events: [
       {
         event: 'server-intent',
@@ -29,7 +29,13 @@ describe('given an event processor', () => {
       },
     ],
   };
-  const jsonData = JSON.stringify(allEvents);
+  const fdv2JsonData = JSON.stringify(allFDv2Events);
+
+  const allFDv1Data = {
+    flags: { flagA: { version: 456 } },
+    segments: { segmentA: { version: 789 } },
+  };
+  const fdv1JsonData = JSON.stringify(allFDv1Data);
 
   let processor: PollingProcessorFDv2;
   const mockDataCallback = jest.fn();
@@ -60,7 +66,7 @@ describe('given an event processor', () => {
   });
 
   it('calls callback on success', async () => {
-    requestor.requestAllData = jest.fn((cb) => cb(undefined, jsonData));
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv2JsonData));
     let dataCallback;
     await new Promise<void>((resolve) => {
       dataCallback = jest.fn(() => {
@@ -85,7 +91,51 @@ describe('given an event processor', () => {
       version: 1,
     });
   });
+
+  it('can process FDv1 data when configured to do so', async () => {
+    processor = new PollingProcessorFDv2(
+      requestor as unknown as Requestor,
+      longInterval,
+      new TestLogger(),
+      true,
+    );
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv1JsonData));
+    let dataCallback;
+    await new Promise<void>((resolve) => {
+      dataCallback = jest.fn(() => {
+        resolve();
+      });
+
+      processor.start(dataCallback, mockStatusCallback);
+    });
+
+    expect(dataCallback).toHaveBeenNthCalledWith(1, true, {
+      basis: true,
+      id: `FDv1Fallback`,
+      state: `FDv1Fallback`,
+      updates: [
+        {
+          kind: `flag`,
+          key: `flagA`,
+          version: 456,
+          object: { version: 456 },
+        },
+        {
+          kind: `segment`,
+          key: `segmentA`,
+          version: 789,
+          object: { version: 789 },
+        },
+      ],
+      version: 1,
+    });
+  });
 });
+
+const allFDv1Data = {
+  flags: { flag: { version: 456 } },
+  segments: { segment: { version: 789 } },
+};
 
 describe('given a polling processor with a short poll duration', () => {
   const requestor = {

--- a/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
@@ -91,7 +91,7 @@ describe('given a requestor', () => {
       expect(body).toEqual(testResponse);
 
       expect(requestsMade.length).toBe(1);
-      expect(requestsMade[0].url).toBe('https://sdk.launchdarkly.com/sdk/latest-all');
+      expect(requestsMade[0].url).toBe('https://sdk.launchdarkly.com/sdk/poll');
       expect(requestsMade[0].options.headers?.authorization).toBe('sdkKey');
 
       done();

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessor.test.ts
@@ -116,7 +116,7 @@ describe('given a stream processor with mock event source', () => {
         basicConfiguration: getBasicConfiguration(logger),
         platform: basicPlatform,
       },
-      '/all',
+      '/sdk/stream',
       [],
       listeners,
       {
@@ -139,7 +139,7 @@ describe('given a stream processor with mock event source', () => {
 
   it('uses expected uri and eventSource init args', () => {
     expect(basicPlatform.requests.createEventSource).toBeCalledWith(
-      `${serviceEndpoints.streaming}/all`,
+      `${serviceEndpoints.streaming}/sdk/stream`,
       {
         errorFilter: expect.any(Function),
         headers: defaultHeaders(sdkKey, info, undefined),
@@ -156,7 +156,7 @@ describe('given a stream processor with mock event source', () => {
         basicConfiguration: getBasicConfiguration(logger),
         platform: basicPlatform,
       },
-      '/all',
+      '/sdk/stream',
       [],
       listeners,
       {
@@ -171,7 +171,7 @@ describe('given a stream processor with mock event source', () => {
     streamingProcessor.start();
 
     expect(basicPlatform.requests.createEventSource).toHaveBeenLastCalledWith(
-      `${serviceEndpoints.streaming}/all`,
+      `${serviceEndpoints.streaming}/sdk/stream`,
       {
         errorFilter: expect.any(Function),
         headers: defaultHeaders(sdkKey, info, undefined),

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
@@ -34,7 +34,7 @@ const dateNowString = '2023-08-10';
 const sdkKey = 'my-sdk-key';
 const events = {
   'server-intent': {
-    data: '{"payloads": [{"code": "xfer-full", "id": "mockId"}]}',
+    data: '{"payloads": [{"intentCode": "xfer-full", "id": "mockId"}]}',
   },
   'put-object': {
     data: '{"kind": "flag", "key": "flagA", "version": 123, "object": {"objectFieldA": "objectValueA"}}',
@@ -108,7 +108,7 @@ describe('given a stream processor with mock event source', () => {
         basicConfiguration: getBasicConfiguration(logger),
         platform: basicPlatform,
       },
-      '/all',
+      '/sdk/stream',
       [],
       {
         authorization: 'my-sdk-key',
@@ -132,7 +132,7 @@ describe('given a stream processor with mock event source', () => {
 
   it('uses expected uri and eventSource init args', () => {
     expect(basicPlatform.requests.createEventSource).toBeCalledWith(
-      `${serviceEndpoints.streaming}/all`,
+      `${serviceEndpoints.streaming}/sdk/stream`,
       {
         errorFilter: expect.any(Function),
         headers: defaultHeaders(sdkKey, info, undefined),
@@ -149,7 +149,7 @@ describe('given a stream processor with mock event source', () => {
         basicConfiguration: getBasicConfiguration(logger),
         platform: basicPlatform,
       },
-      '/all',
+      '/sdk/stream',
       [],
       {
         authorization: 'my-sdk-key',
@@ -162,7 +162,7 @@ describe('given a stream processor with mock event source', () => {
     streamingProcessor.start(jest.fn(), jest.fn());
 
     expect(basicPlatform.requests.createEventSource).toHaveBeenLastCalledWith(
-      `${serviceEndpoints.streaming}/all`,
+      `${serviceEndpoints.streaming}/sdk/stream`,
       {
         errorFilter: expect.any(Function),
         headers: defaultHeaders(sdkKey, info, undefined),

--- a/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
@@ -3,6 +3,7 @@ import {
   httpErrorMessage,
   internal,
   isHttpRecoverable,
+  LDFlagDeliveryFallbackError,
   LDLogger,
   LDPollingError,
   subsystem as subsystemCommon,
@@ -10,8 +11,9 @@ import {
 
 import { Flag } from '../evaluation/data/Flag';
 import { Segment } from '../evaluation/data/Segment';
-import { processFlag, processSegment } from '../store/serialization';
+import { FlagsAndSegments, processFlag, processSegment } from '../store/serialization';
 import Requestor from './Requestor';
+import { PayloadProcessor } from '@launchdarkly/js-sdk-common/dist/esm/internal';
 
 export type PollingErrorHandler = (err: LDPollingError) => void;
 
@@ -24,10 +26,18 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
 
   private _statusCallback?: (status: subsystemCommon.DataSourceState, err?: any) => void;
 
+  /**
+   * @param _requestor to fetch flags from cloud services
+   * @param _pollInterval in seconds controlling how frequently polling request is made
+   * @param _logger for logging
+   * @param _processResponseAsFDv1 defaults to false, but if set to true, this data source will process
+   * the response body as FDv1 and convert it into a FDv2 payload.
+   */
   constructor(
     private readonly _requestor: Requestor,
     private readonly _pollInterval: number = 30,
     private readonly _logger?: LDLogger,
+    private readonly _processResponseAsFDv1: boolean = false,
   ) {}
 
   private _poll(
@@ -47,6 +57,14 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
       this._logger?.debug('Elapsed: %d ms, sleeping for %d ms', elapsed, sleepFor);
       if (err) {
         const { status } = err;
+        // this is a short term error and will be removed once FDv2 adoption is sufficient.
+        if (err instanceof LDFlagDeliveryFallbackError) {
+          this._logger?.error(err.message);
+          statusCallback(subsystemCommon.DataSourceState.Closed, err);
+          // It is not recoverable, return and do not trigger another poll.
+          return;
+        }
+
         if (status && !isHttpRecoverable(status)) {
           const message = httpErrorMessage(err, 'polling request');
           this._logger?.error(message);
@@ -87,7 +105,6 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
       }
 
       try {
-        const parsed = JSON.parse(body) as internal.FDv2EventsCollection;
         const payloadProcessor = new internal.PayloadProcessor(
           {
             flag: (flag: Flag) => {
@@ -112,7 +129,15 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
           dataCallback(payload.basis, payload);
         });
 
-        payloadProcessor.processEvents(parsed.events);
+        if (!this._processResponseAsFDv1) {
+          // FDv2 case
+          const parsed = JSON.parse(body) as internal.FDv2EventsCollection;
+          payloadProcessor.processEvents(parsed.events);
+        } else {
+          // FDv1 case
+          const parsed = JSON.parse(body) as FlagsAndSegments;
+          this._processFDv1FlagsAndSegments(payloadProcessor, parsed);
+        }
 
         // TODO: SDK-855 implement blocking duplicate data source state events in DataAvailability API
         statusCallback(subsystemCommon.DataSourceState.Valid);
@@ -132,6 +157,62 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
         this._poll(dataCallback, statusCallback);
       }, sleepFor);
     });
+  }
+
+  // helper function to transform FDv1 response data into events the PayloadProcessor can parse
+  private _processFDv1FlagsAndSegments(payloadProcessor: PayloadProcessor, data: FlagsAndSegments) {
+    payloadProcessor.processEvents([
+      {
+        event: `server-intent`,
+        data: {
+          payloads: [
+            {
+              id: `FDv1Fallback`,
+              target: 0,
+              code: `xfer-full`,
+            },
+          ],
+        },
+      },
+    ]);
+
+    Object.values(data?.flags || []).forEach((flag) => {
+      payloadProcessor.processEvents([
+        {
+          event: `put-object`,
+          data: {
+            kind: 'flag',
+            key: flag.key,
+            version: flag.version,
+            object: flag,
+          },
+        },
+      ]);
+    });
+
+    Object.values(data?.segments || []).forEach((segment) => {
+      payloadProcessor.processEvents([
+        {
+          event: `put-object`,
+          data: {
+            kind: 'segment',
+            key: segment.key,
+            version: segment.version,
+            object: segment,
+          },
+        },
+      ]);
+    });
+
+    payloadProcessor.processEvents([
+      {
+        event: `payload-transferred`,
+        data: {
+          state: `FDv1Fallback`,
+          version: 0,
+        },
+      },
+    ]);
   }
 
   start(

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -71,7 +71,7 @@ const validations: Record<string, TypeValidator> = {
   type: TypeValidators.String,
 };
 
-const DEFAULT_POLL_INTERVAL = 30;
+export const DEFAULT_POLL_INTERVAL = 30;
 const DEFAULT_STREAM_RECONNECT_DELAY = 1;
 
 const defaultStandardDataSourceOptions: StandardDataSourceOptions = {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
Will validate on holding branch later.

**Related issues**

SDK-1179

**Describe the solution you've provided**

Adds FDv1 fallback error type.  FDv2 datasources now report that error type if they see the fallback header from the FDv2 endpoints.

Updates FDv2 polling datasource to support being constructed in a FDv1 to FDv2 conversion mode.  In that mode, the response from an FDv1 endpoint will be converted to an FDv2 payload and passed through the FDv2 payloadProcessor.

CompositeDataSource now supports an FDv1 fallback synchronizer list.  If any datasource reports the FDv1 fallback error, the CompositeDataSource switches to use the fallback synchronizer list.

This PR also contains tweaks to get the holding branch working with the latest contract tests that got some tweaks during recent integration testing.
