### PR TITLE
fix: Client SDKs should use wrapper information.

### DIFF
--- a/packages/sdk/browser/__tests__/BrowserDataManager.test.ts
+++ b/packages/sdk/browser/__tests__/BrowserDataManager.test.ts
@@ -102,7 +102,7 @@ describe('given a BrowserDataManager with mocked dependencies', () => {
         createHash: () => new MockHasher(),
         randomUUID: () => '123',
       },
-      info: new BrowserInfo(),
+      info: new BrowserInfo({}),
       requests: {
         createEventSource: jest.fn((streamUri: string = '', options: any = {}) => ({
           streamUri,

--- a/packages/sdk/browser/__tests__/platform/BrowserInfo.test.ts
+++ b/packages/sdk/browser/__tests__/platform/BrowserInfo.test.ts
@@ -1,0 +1,51 @@
+import BrowserInfo from '../../src/platform/BrowserInfo';
+
+it('returns correct platform data', () => {
+  const browserInfo = new BrowserInfo({});
+  expect(browserInfo.platformData()).toEqual({
+    name: 'JS',
+  });
+});
+
+it('returns correct SDK data without wrapper info', () => {
+  const browserInfo = new BrowserInfo({});
+  expect(browserInfo.sdkData()).toEqual({
+    name: '@launchdarkly/js-client-sdk',
+    version: '0.0.0',
+    userAgentBase: 'JSClient',
+  });
+});
+
+it('returns correct SDK data with wrapper name', () => {
+  const browserInfo = new BrowserInfo({ wrapperName: 'test-wrapper' });
+  expect(browserInfo.sdkData()).toEqual({
+    name: '@launchdarkly/js-client-sdk',
+    version: '0.0.0',
+    userAgentBase: 'JSClient',
+    wrapperName: 'test-wrapper',
+  });
+});
+
+it('returns correct SDK data with wrapper version', () => {
+  const browserInfo = new BrowserInfo({ wrapperVersion: '1.0.0' });
+  expect(browserInfo.sdkData()).toEqual({
+    name: '@launchdarkly/js-client-sdk',
+    version: '0.0.0',
+    userAgentBase: 'JSClient',
+    wrapperVersion: '1.0.0',
+  });
+});
+
+it('returns correct SDK data with both wrapper name and version', () => {
+  const browserInfo = new BrowserInfo({
+    wrapperName: 'test-wrapper',
+    wrapperVersion: '1.0.0',
+  });
+  expect(browserInfo.sdkData()).toEqual({
+    name: '@launchdarkly/js-client-sdk',
+    version: '0.0.0',
+    userAgentBase: 'JSClient',
+    wrapperName: 'test-wrapper',
+    wrapperVersion: '1.0.0',
+  });
+});

--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -115,7 +115,7 @@ export class BrowserClient extends LDClientImpl implements LDClient {
     // TODO: Use the already-configured baseUri from the SDK config. SDK-560
     const baseUrl = options.baseUri ?? 'https://clientsdk.launchdarkly.com';
 
-    const platform = overridePlatform ?? new BrowserPlatform(logger);
+    const platform = overridePlatform ?? new BrowserPlatform(logger, options);
     // Only the browser-specific options are in validatedBrowserOptions.
     const validatedBrowserOptions = validateBrowserOptions(options, logger);
     // The base options are in baseOptionsWithDefaults.

--- a/packages/sdk/browser/src/platform/BrowserInfo.ts
+++ b/packages/sdk/browser/src/platform/BrowserInfo.ts
@@ -1,16 +1,29 @@
 import { Info, PlatformData, SdkData } from '@launchdarkly/js-client-sdk-common';
 
 export default class BrowserInfo implements Info {
+  constructor(private readonly _config: { wrapperName?: string; wrapperVersion?: string }) {}
+
   platformData(): PlatformData {
     return {
       name: 'JS', // Name maintained from previous 3.x implementation.
     };
   }
+
   sdkData(): SdkData {
-    return {
+    const data: SdkData = {
       name: '@launchdarkly/js-client-sdk',
       version: '0.0.0', // x-release-please-version
       userAgentBase: 'JSClient',
     };
+
+    if (this._config.wrapperName) {
+      data.wrapperName = this._config.wrapperName;
+    }
+
+    if (this._config.wrapperVersion) {
+      data.wrapperVersion = this._config.wrapperVersion;
+    }
+
+    return data;
   }
 }

--- a/packages/sdk/browser/src/platform/BrowserPlatform.ts
+++ b/packages/sdk/browser/src/platform/BrowserPlatform.ts
@@ -8,6 +8,7 @@ import {
   Storage,
 } from '@launchdarkly/js-client-sdk-common';
 
+import { BrowserOptions } from '../options';
 import BrowserCrypto from './BrowserCrypto';
 import BrowserEncoding from './BrowserEncoding';
 import BrowserInfo from './BrowserInfo';
@@ -16,15 +17,16 @@ import LocalStorage, { isLocalStorageSupported } from './LocalStorage';
 
 export default class BrowserPlatform implements Platform {
   encoding: Encoding = new BrowserEncoding();
-  info: Info = new BrowserInfo();
+  info: Info;
   // fileSystem?: Filesystem;
   crypto: Crypto = new BrowserCrypto();
   requests: Requests = new BrowserRequests();
   storage?: Storage;
 
-  constructor(logger: LDLogger) {
+  constructor(logger: LDLogger, options: BrowserOptions) {
     if (isLocalStorageSupported()) {
       this.storage = new LocalStorage(logger);
     }
+    this.info = new BrowserInfo(options);
   }
 }

--- a/packages/sdk/react-native/__tests__/MobileDataManager.test.ts
+++ b/packages/sdk/react-native/__tests__/MobileDataManager.test.ts
@@ -91,7 +91,7 @@ describe('given a MobileDataManager with mocked dependencies', () => {
     const mockedFetch = mockFetch('{"flagA": true}', 200);
     platform = {
       crypto: new PlatformCrypto(),
-      info: new PlatformInfo(config.logger),
+      info: new PlatformInfo(config.logger, {}),
       requests: {
         createEventSource: jest.fn((streamUri: string = '', options: any = {}) => ({
           streamUri,

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -62,7 +62,7 @@ export default class ReactNativeLDClient extends LDClientImpl {
     };
 
     const validatedRnOptions = validateOptions(options, logger);
-    const platform = createPlatform(logger, validatedRnOptions.storage);
+    const platform = createPlatform(logger, options, validatedRnOptions.storage);
 
     super(
       sdkKey,

--- a/packages/sdk/react-native/src/platform/PlatformInfo.ts
+++ b/packages/sdk/react-native/src/platform/PlatformInfo.ts
@@ -4,7 +4,10 @@ import { name, version } from '../../package.json';
 import { ldApplication, ldDevice } from './autoEnv';
 
 export default class PlatformInfo implements Info {
-  constructor(private readonly _logger: LDLogger) {}
+  constructor(
+    private readonly _logger: LDLogger,
+    private readonly _config: { wrapperName?: string; wrapperVersion?: string },
+  ) {}
 
   platformData(): PlatformData {
     const data = {
@@ -18,11 +21,19 @@ export default class PlatformInfo implements Info {
   }
 
   sdkData(): SdkData {
-    const data = {
+    const data: SdkData = {
       name,
       version,
       userAgentBase: 'ReactNativeClient',
     };
+
+    if (this._config?.wrapperName) {
+      data.wrapperName = this._config.wrapperName;
+    }
+
+    if (this._config?.wrapperVersion) {
+      data.wrapperVersion = this._config.wrapperVersion;
+    }
 
     this._logger.debug(`sdkData: ${JSON.stringify(data, null, 2)}`);
     return data;

--- a/packages/sdk/react-native/src/platform/index.ts
+++ b/packages/sdk/react-native/src/platform/index.ts
@@ -1,14 +1,15 @@
 import { LDLogger, Platform, Storage } from '@launchdarkly/js-client-sdk-common';
 
+import RNOptions from '../RNOptions';
 import PlatformCrypto from './crypto';
 import PlatformEncoding from './PlatformEncoding';
 import PlatformInfo from './PlatformInfo';
 import PlatformRequests from './PlatformRequests';
 import PlatformStorage from './PlatformStorage';
 
-const createPlatform = (logger: LDLogger, storage?: Storage): Platform => ({
+const createPlatform = (logger: LDLogger, options: RNOptions, storage?: Storage): Platform => ({
   crypto: new PlatformCrypto(),
-  info: new PlatformInfo(logger),
+  info: new PlatformInfo(logger, options),
   requests: new PlatformRequests(logger),
   encoding: new PlatformEncoding(),
   storage: storage ?? new PlatformStorage(logger),


### PR DESCRIPTION
Wrappers are accessed through the platform, but react-native and the browser implementation were not propagating these to the platform.

The first implementation was the node platform, which handled this correctly. The Cloudlare and RN platform didn't, and then the RN platform was used as reference for implementing the browser platform.

So, this also affects edge and a similar update should be considered for those SDKs.
