### PR TITLE
chore: Fix unit tests to work with node 22.

### DIFF
--- a/packages/shared/common/__tests__/logging/format.test.ts
+++ b/packages/shared/common/__tests__/logging/format.test.ts
@@ -32,7 +32,7 @@ describe.each([
   [
     '',
     [Symbol('foo'), circular, BigInt(7), { apple: 'pie' }, global, undefined, null],
-     /\[Circular\] 7n {"apple":"pie"} \[.*\] undefined null/,
+    /\[Circular\] 7n {"apple":"pie"} \[.*\] undefined null/,
   ],
 ])('given node style format strings', (formatStr, args, result) => {
   it('produces the expected string', () => {

--- a/packages/shared/common/__tests__/logging/format.test.ts
+++ b/packages/shared/common/__tests__/logging/format.test.ts
@@ -32,10 +32,10 @@ describe.each([
   [
     '',
     [Symbol('foo'), circular, BigInt(7), { apple: 'pie' }, global, undefined, null],
-    ' [Circular] 7n {"apple":"pie"} [object Object] undefined null',
+     /\[Circular\] 7n {"apple":"pie"} \[.*\] undefined null/,
   ],
 ])('given node style format strings', (formatStr, args, result) => {
   it('produces the expected string', () => {
-    expect(format(formatStr, ...args)).toEqual(result);
+    expect(format(formatStr, ...args)).toMatch(result);
   });
 });


### PR DESCRIPTION
There was a minor change to the logging output in node 22 for object string conversion. This makes a test more lenient to account for it.