### PR TITLE
chore: Replace node 21 with 22 for server-node CI.

### DIFF
--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [18, 21]
+        version: [18, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The rennovate PR adjusts all the builds which just use node as a tool, but server-node is using a range of versions for validation. This updates the versions to be 18 and 22 instead of 18 and 21.