### PR TITLE
chore: Add implementation for async task queue.

### DIFF
--- a/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
+++ b/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
@@ -12,27 +12,30 @@ it.each([true, false])('executes the initial task it is given: shedable: %s', as
   expect(task).toHaveBeenCalled();
 });
 
-it.each([true, false])('executes the next task in the queue when the previous task completes: shedable: %s', async (shedable) => {
-  const queue = new AsyncTaskQueue<string>();
-  const task1 = jest.fn().mockResolvedValue('test1');
-  const task2 = jest.fn().mockResolvedValue('test2');
-  const promise1 = queue.execute(task1, shedable);
-  const promise2 = queue.execute(task2, shedable);
-  // We have not awaited, so there has not been an opportunity to execute any tasks.
-  expect(queue.pendingCount()).toBe(1);
+it.each([true, false])(
+  'executes the next task in the queue when the previous task completes: shedable: %s',
+  async (shedable) => {
+    const queue = new AsyncTaskQueue<string>();
+    const task1 = jest.fn().mockResolvedValue('test1');
+    const task2 = jest.fn().mockResolvedValue('test2');
+    const promise1 = queue.execute(task1, shedable);
+    const promise2 = queue.execute(task2, shedable);
+    // We have not awaited, so there has not been an opportunity to execute any tasks.
+    expect(queue.pendingCount()).toBe(1);
 
-  const [result1, result2] = await Promise.all([promise1, promise2]);
-  expect(result1).toEqual({
-    status: 'complete',
-    result: 'test1',
-  });
-  expect(result2).toEqual({
-    status: 'complete',
-    result: 'test2',
-  });
-  expect(task1).toHaveBeenCalled();
-  expect(task2).toHaveBeenCalled();
-});
+    const [result1, result2] = await Promise.all([promise1, promise2]);
+    expect(result1).toEqual({
+      status: 'complete',
+      result: 'test1',
+    });
+    expect(result2).toEqual({
+      status: 'complete',
+      result: 'test2',
+    });
+    expect(task1).toHaveBeenCalled();
+    expect(task2).toHaveBeenCalled();
+  },
+);
 
 it('can shed pending shedable tasks', async () => {
   const queue = new AsyncTaskQueue<string>();
@@ -112,38 +115,43 @@ it('handles mix of shedable and non-shedable tasks correctly', async () => {
   const task2 = jest.fn().mockResolvedValue('test2');
   const task3 = jest.fn().mockResolvedValue('test3');
   const task4 = jest.fn().mockResolvedValue('test4');
-  
+
   // Add tasks in order: shedable, non-shedable, shedable, non-shedable
   const promise1 = queue.execute(task1, true);
   const promise2 = queue.execute(task2, false);
   const promise3 = queue.execute(task3, true);
   const promise4 = queue.execute(task4, false);
-  
-  const [result1, result2, result3, result4] = await Promise.all([promise1, promise2, promise3, promise4]);
-  
+
+  const [result1, result2, result3, result4] = await Promise.all([
+    promise1,
+    promise2,
+    promise3,
+    promise4,
+  ]);
+
   // First task should complete
   expect(result1).toEqual({
     status: 'complete',
     result: 'test1',
   });
-  
+
   // Second task should complete (not shedable)
   expect(result2).toEqual({
     status: 'complete',
     result: 'test2',
   });
-  
+
   // Third task should be shed
   expect(result3).toEqual({
     status: 'shed',
   });
-  
+
   // Fourth task should complete
   expect(result4).toEqual({
     status: 'complete',
     result: 'test4',
   });
-  
+
   expect(task1).toHaveBeenCalled();
   expect(task2).toHaveBeenCalled();
   expect(task3).not.toHaveBeenCalled();

--- a/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
+++ b/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
@@ -1,9 +1,9 @@
 import { AsyncTaskQueue } from '../../src/async/AsyncTaskQueue';
 
-it.each([true, false])('executes the initial task it is given: shedable: %s', async (shedable) => {
+it.each([true, false])('executes the initial task it is given: sheddable: %s', async (sheddable) => {
   const queue = new AsyncTaskQueue<string>();
   const task = jest.fn().mockResolvedValue('test');
-  const result = await queue.execute(task, shedable);
+  const result = await queue.execute(task, sheddable);
   expect(queue.pendingCount()).toBe(0);
   expect(result).toEqual({
     status: 'complete',
@@ -13,13 +13,13 @@ it.each([true, false])('executes the initial task it is given: shedable: %s', as
 });
 
 it.each([true, false])(
-  'executes the next task in the queue when the previous task completes: shedable: %s',
-  async (shedable) => {
+  'executes the next task in the queue when the previous task completes: sheddable: %s',
+  async (sheddable) => {
     const queue = new AsyncTaskQueue<string>();
     const task1 = jest.fn().mockResolvedValue('test1');
     const task2 = jest.fn().mockResolvedValue('test2');
-    const promise1 = queue.execute(task1, shedable);
-    const promise2 = queue.execute(task2, shedable);
+    const promise1 = queue.execute(task1, sheddable);
+    const promise2 = queue.execute(task2, sheddable);
     // We have not awaited, so there has not been an opportunity to execute any tasks.
     expect(queue.pendingCount()).toBe(1);
 
@@ -37,7 +37,7 @@ it.each([true, false])(
   },
 );
 
-it('can shed pending shedable tasks', async () => {
+it('can shed pending sheddable tasks', async () => {
   const queue = new AsyncTaskQueue<string>();
   const task1 = jest.fn().mockResolvedValue('test1');
   const task2 = jest.fn().mockResolvedValue('test2');
@@ -63,7 +63,7 @@ it('can shed pending shedable tasks', async () => {
   expect(task3).toHaveBeenCalled();
 });
 
-it('does not shed pending non-shedable tasks', async () => {
+it('does not shed pending non-sheddable tasks', async () => {
   const queue = new AsyncTaskQueue<string>();
   const task1 = jest.fn().mockResolvedValue('test1');
   const task2 = jest.fn().mockResolvedValue('test2');
@@ -109,14 +109,14 @@ it('can handle errors from tasks', async () => {
   expect(task2).toHaveBeenCalled();
 });
 
-it('handles mix of shedable and non-shedable tasks correctly', async () => {
+it('handles mix of sheddable and non-sheddable tasks correctly', async () => {
   const queue = new AsyncTaskQueue<string>();
   const task1 = jest.fn().mockResolvedValue('test1');
   const task2 = jest.fn().mockResolvedValue('test2');
   const task3 = jest.fn().mockResolvedValue('test3');
   const task4 = jest.fn().mockResolvedValue('test4');
 
-  // Add tasks in order: shedable, non-shedable, shedable, non-shedable
+  // Add tasks in order: sheddable, non-sheddable, sheddable, non-sheddable
   const promise1 = queue.execute(task1, true);
   const promise2 = queue.execute(task2, false);
   const promise3 = queue.execute(task3, true);
@@ -135,7 +135,7 @@ it('handles mix of shedable and non-shedable tasks correctly', async () => {
     result: 'test1',
   });
 
-  // Second task should complete (not shedable)
+  // Second task should complete (not sheddable)
   expect(result2).toEqual({
     status: 'complete',
     result: 'test2',

--- a/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
+++ b/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
@@ -1,0 +1,151 @@
+import { AsyncTaskQueue } from '../../src/async/AsyncTaskQueue';
+
+it.each([true, false])('executes the initial task it is given: shedable: %s', async (shedable) => {
+  const queue = new AsyncTaskQueue<string>();
+  const task = jest.fn().mockResolvedValue('test');
+  const result = await queue.execute(task, shedable);
+  expect(queue.pendingCount()).toBe(0);
+  expect(result).toEqual({
+    status: 'complete',
+    result: 'test',
+  });
+  expect(task).toHaveBeenCalled();
+});
+
+it.each([true, false])('executes the next task in the queue when the previous task completes: shedable: %s', async (shedable) => {
+  const queue = new AsyncTaskQueue<string>();
+  const task1 = jest.fn().mockResolvedValue('test1');
+  const task2 = jest.fn().mockResolvedValue('test2');
+  const promise1 = queue.execute(task1, shedable);
+  const promise2 = queue.execute(task2, shedable);
+  // We have not awaited, so there has not been an opportunity to execute any tasks.
+  expect(queue.pendingCount()).toBe(1);
+
+  const [result1, result2] = await Promise.all([promise1, promise2]);
+  expect(result1).toEqual({
+    status: 'complete',
+    result: 'test1',
+  });
+  expect(result2).toEqual({
+    status: 'complete',
+    result: 'test2',
+  });
+  expect(task1).toHaveBeenCalled();
+  expect(task2).toHaveBeenCalled();
+});
+
+it('can shed pending shedable tasks', async () => {
+  const queue = new AsyncTaskQueue<string>();
+  const task1 = jest.fn().mockResolvedValue('test1');
+  const task2 = jest.fn().mockResolvedValue('test2');
+  const task3 = jest.fn().mockResolvedValue('test3');
+  const promise1 = queue.execute(task1, true);
+  const promise2 = queue.execute(task2, true);
+  const promise3 = queue.execute(task3, true);
+
+  const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3]);
+  expect(result1).toEqual({
+    status: 'complete',
+    result: 'test1',
+  });
+  expect(result2).toEqual({
+    status: 'shed',
+  });
+  expect(result3).toEqual({
+    status: 'complete',
+    result: 'test3',
+  });
+  expect(task1).toHaveBeenCalled();
+  expect(task2).not.toHaveBeenCalled();
+  expect(task3).toHaveBeenCalled();
+});
+
+it('does not shed pending non-shedable tasks', async () => {
+  const queue = new AsyncTaskQueue<string>();
+  const task1 = jest.fn().mockResolvedValue('test1');
+  const task2 = jest.fn().mockResolvedValue('test2');
+  const task3 = jest.fn().mockResolvedValue('test3');
+  const promise1 = queue.execute(task1, false);
+  const promise2 = queue.execute(task2, false);
+  const promise3 = queue.execute(task3, false);
+
+  const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3]);
+  expect(result1).toEqual({
+    status: 'complete',
+    result: 'test1',
+  });
+  expect(result2).toEqual({
+    status: 'complete',
+    result: 'test2',
+  });
+  expect(result3).toEqual({
+    status: 'complete',
+    result: 'test3',
+  });
+  expect(task1).toHaveBeenCalled();
+  expect(task2).toHaveBeenCalled();
+  expect(task3).toHaveBeenCalled();
+});
+
+it('can handle errors from tasks', async () => {
+  const queue = new AsyncTaskQueue<string>();
+  const task1 = jest.fn().mockRejectedValue(new Error('test'));
+  const task2 = jest.fn().mockResolvedValue('test2');
+  const promise1 = queue.execute(task1, true);
+  const promise2 = queue.execute(task2, true);
+  const [result1, result2] = await Promise.all([promise1, promise2]);
+  expect(result1).toEqual({
+    status: 'error',
+    error: new Error('test'),
+  });
+  expect(result2).toEqual({
+    status: 'complete',
+    result: 'test2',
+  });
+  expect(task1).toHaveBeenCalled();
+  expect(task2).toHaveBeenCalled();
+});
+
+it('handles mix of shedable and non-shedable tasks correctly', async () => {
+  const queue = new AsyncTaskQueue<string>();
+  const task1 = jest.fn().mockResolvedValue('test1');
+  const task2 = jest.fn().mockResolvedValue('test2');
+  const task3 = jest.fn().mockResolvedValue('test3');
+  const task4 = jest.fn().mockResolvedValue('test4');
+  
+  // Add tasks in order: shedable, non-shedable, shedable, non-shedable
+  const promise1 = queue.execute(task1, true);
+  const promise2 = queue.execute(task2, false);
+  const promise3 = queue.execute(task3, true);
+  const promise4 = queue.execute(task4, false);
+  
+  const [result1, result2, result3, result4] = await Promise.all([promise1, promise2, promise3, promise4]);
+  
+  // First task should complete
+  expect(result1).toEqual({
+    status: 'complete',
+    result: 'test1',
+  });
+  
+  // Second task should complete (not shedable)
+  expect(result2).toEqual({
+    status: 'complete',
+    result: 'test2',
+  });
+  
+  // Third task should be shed
+  expect(result3).toEqual({
+    status: 'shed',
+  });
+  
+  // Fourth task should complete
+  expect(result4).toEqual({
+    status: 'complete',
+    result: 'test4',
+  });
+  
+  expect(task1).toHaveBeenCalled();
+  expect(task2).toHaveBeenCalled();
+  expect(task3).not.toHaveBeenCalled();
+  expect(task4).toHaveBeenCalled();
+});

--- a/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
+++ b/packages/shared/sdk-client/__tests__/async/AsyncTaskQueue.test.ts
@@ -1,16 +1,19 @@
 import { AsyncTaskQueue } from '../../src/async/AsyncTaskQueue';
 
-it.each([true, false])('executes the initial task it is given: sheddable: %s', async (sheddable) => {
-  const queue = new AsyncTaskQueue<string>();
-  const task = jest.fn().mockResolvedValue('test');
-  const result = await queue.execute(task, sheddable);
-  expect(queue.pendingCount()).toBe(0);
-  expect(result).toEqual({
-    status: 'complete',
-    result: 'test',
-  });
-  expect(task).toHaveBeenCalled();
-});
+it.each([true, false])(
+  'executes the initial task it is given: sheddable: %s',
+  async (sheddable) => {
+    const queue = new AsyncTaskQueue<string>();
+    const task = jest.fn().mockResolvedValue('test');
+    const result = await queue.execute(task, sheddable);
+    expect(queue.pendingCount()).toBe(0);
+    expect(result).toEqual({
+      status: 'complete',
+      result: 'test',
+    });
+    expect(task).toHaveBeenCalled();
+  },
+);
 
 it.each([true, false])(
   'executes the next task in the queue when the previous task completes: sheddable: %s',

--- a/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
+++ b/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
@@ -1,4 +1,4 @@
-import { LDLogger } from "@launchdarkly/js-sdk-common";
+import { LDLogger } from '@launchdarkly/js-sdk-common';
 
 /**
  * Represents a task that has been shed from the queue.
@@ -13,7 +13,7 @@ export interface ShedTask {
  */
 export interface CompletedTask<TTaskResult> {
   status: 'complete';
-  result: TTaskResult
+  result: TTaskResult;
 }
 
 /**
@@ -21,7 +21,7 @@ export interface CompletedTask<TTaskResult> {
  */
 export interface ErroredTask {
   status: 'error';
-  error: Error
+  error: Error;
 }
 
 /**
@@ -30,9 +30,9 @@ export interface ErroredTask {
 export type TaskResult<TTaskResult> = CompletedTask<TTaskResult> | ErroredTask | ShedTask;
 
 /**
- *  Represents a pending task. This encapsulates the async function that needs to be executed as well as a promise that represents its state. 
+ *  Represents a pending task. This encapsulates the async function that needs to be executed as well as a promise that represents its state.
  *  The promise is not directly the promise associated with the async function, because we will not execute the async function until some point in the future, if at all.
- **/
+ * */
 interface PendingTask<TTaskResult> {
   shedable: boolean;
   execute: () => void;
@@ -40,7 +40,9 @@ interface PendingTask<TTaskResult> {
   promise: Promise<TaskResult<TTaskResult>>;
 }
 
-const error = new Error('Task has already been executed or shed. This is likely an implementation error. The task will not be executed again.');
+const duplicateExecutionError = new Error(
+  'Task has already been executed or shed. This is likely an implementation error. The task will not be executed again.',
+);
 
 /**
  * Creates a pending task.
@@ -48,10 +50,14 @@ const error = new Error('Task has already been executed or shed. This is likely 
  * @param shedable Whether the task can be shed from the queue.
  * @returns A pending task.
  */
-function makePending<TTaskResult>(task: () => Promise<TTaskResult>, _logger?: LDLogger, shedable: boolean = false): PendingTask<TTaskResult> {
+function makePending<TTaskResult>(
+  task: () => Promise<TTaskResult>,
+  _logger?: LDLogger,
+  shedable: boolean = false,
+): PendingTask<TTaskResult> {
   let res: (value: TaskResult<TTaskResult>) => void;
 
-  const promise = new Promise<TaskResult<TTaskResult>>((resolve, reject) => {
+  const promise = new Promise<TaskResult<TTaskResult>>((resolve) => {
     res = resolve;
   });
 
@@ -60,48 +66,48 @@ function makePending<TTaskResult>(task: () => Promise<TTaskResult>, _logger?: LD
     execute: () => {
       if (executedOrShed) {
         // This should never happen. If it does, then it represents an implementation error in the SDK.
-        _logger?.error(error);
+        _logger?.error(duplicateExecutionError);
       }
       executedOrShed = true;
       task()
-        .then(result => res({ status: 'complete', result }))
-        .catch(error => res({ status: 'error', error }));
+        .then((result) => res({ status: 'complete', result }))
+        .catch((error) => res({ status: 'error', error }));
     },
     shed: () => {
       if (executedOrShed) {
         // This should never happen. If it does, then it represents an implementation error in the SDK.
-        _logger?.error(error);
+        _logger?.error(duplicateExecutionError);
       }
       executedOrShed = true;
       res({ status: 'shed' });
     },
     promise,
     shedable,
-  }
+  };
 }
 
 /**
  * An asynchronous task queue with the ability to replace pending tasks.
- * 
+ *
  * This is useful when you have asynchronous operations which much execute in order, and for cases where intermediate
  * operations can be discarded.
- * 
+ *
  * For instance, the SDK can only have one active context at a time, if you request identification of many contexts,
- * then the ultimate state will be based on the last request. The intermediate identifies can be discarded. 
- * 
- * This class will always begin execution of the first item added to the queue, at that point the item itself is not 
+ * then the ultimate state will be based on the last request. The intermediate identifies can be discarded.
+ *
+ * This class will always begin execution of the first item added to the queue, at that point the item itself is not
  * queued, but active. If another request is made while that item is still active, then it is added to the queue.
  * A third request would then replace the second request if the second request had not yet become active, and it was
  * shedable.
- * 
+ *
  * Once a task is active the queue will complete it. It doesn't cancel tasks that it has started, but it can shed tasks
  * that have not started.
- * 
+ *
  * TTaskResult Is the return type of the task to be executed. Tasks accept no parameters. So if you need parameters
  * you should use a lambda to capture them.
- * 
+ *
  * Exceptions from tasks are always handled and the execute method will never reject a promise.
- * 
+ *
  * Queue management should be done synchronously. There should not be asynchronous operations between checking the queue
  * and acting on the results of said check.
  */
@@ -109,16 +115,19 @@ export class AsyncTaskQueue<TTaskResult> {
   private _activeTask?: Promise<TaskResult<TTaskResult>>;
   private _queue: PendingTask<TTaskResult>[] = [];
 
-  constructor(private readonly _logger?: LDLogger) { }
+  constructor(private readonly _logger?: LDLogger) {}
 
   /**
    * Execute a task using the queue.
-   * 
+   *
    * @param task The async function to execute.
    * @param shedable Whether the task can be shed from the queue.
    * @returns A promise that resolves to the result of the task.
    */
-  execute(task: () => Promise<TTaskResult>, shedable: boolean = false): Promise<TaskResult<TTaskResult>> {
+  execute(
+    task: () => Promise<TTaskResult>,
+    shedable: boolean = false,
+  ): Promise<TaskResult<TTaskResult>> {
     const pending = makePending(task, this._logger, shedable);
 
     if (!this._activeTask) {
@@ -146,7 +155,7 @@ export class AsyncTaskQueue<TTaskResult> {
 
     // There are pending tasks, so we need to execute the next one.
     if (this._queue.length > 0) {
-      let nextTask = this._queue.shift()!;
+      const nextTask = this._queue.shift()!;
 
       this._activeTask = nextTask.promise.finally(() => {
         this._activeTask = undefined;
@@ -160,7 +169,7 @@ export class AsyncTaskQueue<TTaskResult> {
   /**
    * Returns the number of pending tasks in the queue.
    * Intended for use for testing purposes only.
-   * 
+   *
    * @internal
    * @returns The number of pending tasks in the queue.
    */

--- a/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
+++ b/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
@@ -168,7 +168,7 @@ export class AsyncTaskQueue<TTaskResult> {
 
   /**
    * Returns the number of pending tasks in the queue.
-   * Intended for use for testing purposes only.
+   * Intended for testing purposes only.
    *
    * @internal
    * @returns The number of pending tasks in the queue.

--- a/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
+++ b/packages/shared/sdk-client/src/async/AsyncTaskQueue.ts
@@ -1,0 +1,170 @@
+import { LDLogger } from "@launchdarkly/js-sdk-common";
+
+/**
+ * Represents a task that has been shed from the queue.
+ * This task will never be executed.
+ */
+export interface ShedTask {
+  status: 'shed';
+}
+
+/**
+ * Represents a task that has been ran to completion.
+ */
+export interface CompletedTask<TTaskResult> {
+  status: 'complete';
+  result: TTaskResult
+}
+
+/**
+ * Represents a task that has errored.
+ */
+export interface ErroredTask {
+  status: 'error';
+  error: Error
+}
+
+/**
+ * Represents the result of a task.
+ */
+export type TaskResult<TTaskResult> = CompletedTask<TTaskResult> | ErroredTask | ShedTask;
+
+/**
+ *  Represents a pending task. This encapsulates the async function that needs to be executed as well as a promise that represents its state. 
+ *  The promise is not directly the promise associated with the async function, because we will not execute the async function until some point in the future, if at all.
+ **/
+interface PendingTask<TTaskResult> {
+  shedable: boolean;
+  execute: () => void;
+  shed: () => void;
+  promise: Promise<TaskResult<TTaskResult>>;
+}
+
+const error = new Error('Task has already been executed or shed. This is likely an implementation error. The task will not be executed again.');
+
+/**
+ * Creates a pending task.
+ * @param task The async function to execute.
+ * @param shedable Whether the task can be shed from the queue.
+ * @returns A pending task.
+ */
+function makePending<TTaskResult>(task: () => Promise<TTaskResult>, _logger?: LDLogger, shedable: boolean = false): PendingTask<TTaskResult> {
+  let res: (value: TaskResult<TTaskResult>) => void;
+
+  const promise = new Promise<TaskResult<TTaskResult>>((resolve, reject) => {
+    res = resolve;
+  });
+
+  let executedOrShed = false;
+  return {
+    execute: () => {
+      if (executedOrShed) {
+        // This should never happen. If it does, then it represents an implementation error in the SDK.
+        _logger?.error(error);
+      }
+      executedOrShed = true;
+      task()
+        .then(result => res({ status: 'complete', result }))
+        .catch(error => res({ status: 'error', error }));
+    },
+    shed: () => {
+      if (executedOrShed) {
+        // This should never happen. If it does, then it represents an implementation error in the SDK.
+        _logger?.error(error);
+      }
+      executedOrShed = true;
+      res({ status: 'shed' });
+    },
+    promise,
+    shedable,
+  }
+}
+
+/**
+ * An asynchronous task queue with the ability to replace pending tasks.
+ * 
+ * This is useful when you have asynchronous operations which much execute in order, and for cases where intermediate
+ * operations can be discarded.
+ * 
+ * For instance, the SDK can only have one active context at a time, if you request identification of many contexts,
+ * then the ultimate state will be based on the last request. The intermediate identifies can be discarded. 
+ * 
+ * This class will always begin execution of the first item added to the queue, at that point the item itself is not 
+ * queued, but active. If another request is made while that item is still active, then it is added to the queue.
+ * A third request would then replace the second request if the second request had not yet become active, and it was
+ * shedable.
+ * 
+ * Once a task is active the queue will complete it. It doesn't cancel tasks that it has started, but it can shed tasks
+ * that have not started.
+ * 
+ * TTaskResult Is the return type of the task to be executed. Tasks accept no parameters. So if you need parameters
+ * you should use a lambda to capture them.
+ * 
+ * Exceptions from tasks are always handled and the execute method will never reject a promise.
+ * 
+ * Queue management should be done synchronously. There should not be asynchronous operations between checking the queue
+ * and acting on the results of said check.
+ */
+export class AsyncTaskQueue<TTaskResult> {
+  private _activeTask?: Promise<TaskResult<TTaskResult>>;
+  private _queue: PendingTask<TTaskResult>[] = [];
+
+  constructor(private readonly _logger?: LDLogger) { }
+
+  /**
+   * Execute a task using the queue.
+   * 
+   * @param task The async function to execute.
+   * @param shedable Whether the task can be shed from the queue.
+   * @returns A promise that resolves to the result of the task.
+   */
+  execute(task: () => Promise<TTaskResult>, shedable: boolean = false): Promise<TaskResult<TTaskResult>> {
+    const pending = makePending(task, this._logger, shedable);
+
+    if (!this._activeTask) {
+      this._activeTask = pending.promise.finally(() => {
+        this._activeTask = undefined;
+        this._checkPending();
+      });
+      pending.execute();
+    } else {
+      // If the last pending task is shedable, we need to shed it before adding the new task.
+      if (this._queue[this._queue.length - 1]?.shedable) {
+        this._queue.pop()?.shed();
+      }
+      this._queue.push(pending);
+    }
+
+    return pending.promise;
+  }
+
+  private _checkPending() {
+    // There is an existing active task, so we don't need to do anything.
+    if (this._activeTask) {
+      return;
+    }
+
+    // There are pending tasks, so we need to execute the next one.
+    if (this._queue.length > 0) {
+      let nextTask = this._queue.shift()!;
+
+      this._activeTask = nextTask.promise.finally(() => {
+        this._activeTask = undefined;
+        this._checkPending();
+      });
+
+      nextTask.execute();
+    }
+  }
+
+  /**
+   * Returns the number of pending tasks in the queue.
+   * Intended for use for testing purposes only.
+   * 
+   * @internal
+   * @returns The number of pending tasks in the queue.
+   */
+  public pendingCount(): number {
+    return this._queue.length;
+  }
+}


### PR DESCRIPTION
This PR adds an async task queue. This queue is roughly based on the flutter implementation, but with support for non-shedable tasks like iOS.
https://github.com/launchdarkly/flutter-client-sdk/blob/01841d65d8eb9dbf7cdc1c29b76f2ac8a699fb05/packages/common/lib/src/async/async_single_queue.dart
https://github.com/launchdarkly/ios-client-sdk/blob/082430ff008d76d503327c52b27e3b2af99c3ef2/LaunchDarkly/LaunchDarkly/ServiceObjects/SheddingQueue.swift

This is a `chore`, because the type is unused and doesn't need a release. A subsequent PR will use it for functionality.

This queue is going to be used for an implementation of the client-side identify spec.
https://github.com/launchdarkly/sdk-specs/tree/main/specs/CSI-client-side-identify

(Spec is private.)

Available for review by anyone, I added Matthew for reference to the iOS SDK in case he was interested.