### PR TITLE
feat: now utilizes FDv2 basis param for more efficient polling

### DIFF
--- a/packages/shared/akamai-edgeworker-sdk/src/featureStore/index.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/featureStore/index.ts
@@ -107,14 +107,14 @@ export class EdgeFeatureStore implements LDFeatureStore {
   }
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
-    this.applyChanges(true, allData, undefined, callback);
+    this.applyChanges(true, allData, callback, undefined);
   }
 
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined,
     callback: () => void,
+    selector?: string,
   ): void {
     callback();
   }

--- a/packages/shared/common/src/api/subsystem/DataSystem/DataSource.ts
+++ b/packages/shared/common/src/api/subsystem/DataSystem/DataSource.ts
@@ -20,6 +20,7 @@ export interface DataSource {
   start(
     dataCallback: (basis: boolean, data: any) => void,
     statusCallback: (status: DataSourceState, err?: any) => void,
+    selectorGetter?: () => string | undefined,
   ): void;
 
   /**

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -85,6 +85,7 @@ export class CompositeDataSource implements DataSource {
   async start(
     dataCallback: (basis: boolean, data: any) => void,
     statusCallback: (status: DataSourceState, err?: any) => void,
+    selectorGetter?: () => string | undefined,
   ): Promise<void> {
     if (!this._stopped) {
       // don't allow multiple simultaneous runs
@@ -136,7 +137,7 @@ export class CompositeDataSource implements DataSource {
               // time in the future if this status remains for some duration (ex: Recover to primary synchronizer after the secondary
               // synchronizer has been Valid for some time).  These scheduled transitions are configurable in the constructor.
               this._logger?.debug(
-                `CompositeDataSource received state ${state} from underlying data source.`,
+                `CompositeDataSource received state ${state} from underlying data source.  Err is ${err}`,
               );
               if (err || state === DataSourceState.Closed) {
                 callbackHandler.disable();
@@ -182,6 +183,7 @@ export class CompositeDataSource implements DataSource {
           currentDS.start(
             (basis, data) => callbackHandler.dataHandler(basis, data),
             (status, err) => callbackHandler.statusHandler(status, err),
+            selectorGetter,
           );
         } else {
           // we don't have a data source to use!

--- a/packages/shared/common/src/options/ServiceEndpoints.ts
+++ b/packages/shared/common/src/options/ServiceEndpoints.ts
@@ -54,7 +54,7 @@ export default class ServiceEndpoints {
   }
 }
 
-function getWithParams(uri: string, parameters: { key: string; value: string }[]) {
+function getWithParams(uri: string, parameters: { key: string; value: string }[] = []) {
   if (parameters.length === 0) {
     return uri;
   }
@@ -95,7 +95,7 @@ export function getStreamingUri(
 export function getPollingUri(
   endpoints: ServiceEndpoints,
   path: string,
-  parameters: { key: string; value: string }[],
+  parameters: { key: string; value: string }[] = [],
 ): string {
   const canonicalizedPath = canonicalizePath(path);
 
@@ -117,7 +117,7 @@ export function getPollingUri(
 export function getEventsUri(
   endpoints: ServiceEndpoints,
   path: string,
-  parameters: { key: string; value: string }[],
+  parameters: { key: string; value: string }[] = [],
 ): string {
   const canonicalizedPath = canonicalizePath(path);
 

--- a/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
+++ b/packages/shared/sdk-server-edge/src/api/EdgeFeatureStore.ts
@@ -100,14 +100,14 @@ export class EdgeFeatureStore implements LDFeatureStore {
   }
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
-    this.applyChanges(true, allData, undefined, callback);
+    this.applyChanges(true, allData, callback, undefined);
   }
 
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined,
     callback: () => void,
+    selector?: string,
   ): void {
     callback();
   }

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -130,12 +130,29 @@ describe('given an event processor', () => {
       version: 1,
     });
   });
-});
 
-const allFDv1Data = {
-  flags: { flag: { version: 456 } },
-  segments: { segment: { version: 789 } },
-};
+  it('uses selectorGetter when provided', async () => {
+    processor = new PollingProcessorFDv2(
+      requestor as unknown as Requestor,
+      longInterval,
+      new TestLogger(),
+      true,
+    );
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv2JsonData));
+    let dataCallback;
+    await new Promise<void>((resolve) => {
+      dataCallback = jest.fn(() => {
+        resolve();
+      });
+
+      processor.start(dataCallback, mockStatusCallback, () => 'mockSelector');
+    });
+
+    expect(requestor.requestAllData).toHaveBeenNthCalledWith(1, expect.anything(), [
+      { key: 'basis', value: 'mockSelector' },
+    ]);
+  });
+});
 
 describe('given a polling processor with a short poll duration', () => {
   const requestor = {

--- a/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
@@ -98,6 +98,25 @@ describe('given a requestor', () => {
     });
   });
 
+  it('includes basis query param when provided', (done) => {
+    testResponse = 'a response';
+    requestor.requestAllData(
+      (err, body) => {
+        expect(err).toBeUndefined();
+        expect(body).toEqual(testResponse);
+
+        expect(requestsMade.length).toBe(1);
+        expect(requestsMade[0].url).toBe(
+          'https://sdk.launchdarkly.com/sdk/poll?basis=bogusSelector',
+        );
+        expect(requestsMade[0].options.headers?.authorization).toBe('sdkKey');
+
+        done();
+      },
+      [{ key: 'basis', value: 'bogusSelector' }],
+    );
+  });
+
   it('returns an error result for an http error', (done) => {
     testStatus = 401;
     requestor.requestAllData((err, _body) => {

--- a/packages/shared/sdk-server/__tests__/data_sources/createPayloadListenersFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/createPayloadListenersFDv2.test.ts
@@ -80,6 +80,13 @@ const changesTransferPayload = {
   ],
 };
 
+const changesTransferNone = {
+  id: 'payloadID',
+  version: 99,
+  basis: false,
+  updates: [],
+};
+
 describe('createPayloadListenerFDv2', () => {
   let dataSourceUpdates: LDDataSourceUpdates;
   let basisReceived: jest.Mock;
@@ -97,7 +104,7 @@ describe('createPayloadListenerFDv2', () => {
     jest.resetAllMocks();
   });
 
-  test('data source init is called', async () => {
+  test('data source updates called with basis true', async () => {
     const listener = createPayloadListener(dataSourceUpdates, logger, basisReceived);
     listener(fullTransferPayload);
 
@@ -117,7 +124,7 @@ describe('createPayloadListenerFDv2', () => {
     );
   });
 
-  test('data source upsert is called', async () => {
+  test('data source updates called with basis false', async () => {
     const listener = createPayloadListener(dataSourceUpdates, logger, basisReceived);
     listener(changesTransferPayload);
 
@@ -148,5 +155,13 @@ describe('createPayloadListenerFDv2', () => {
       basisReceived,
       'changes',
     );
+  });
+
+  test('data source updates not called when basis is false and changes are empty', async () => {
+    const listener = createPayloadListener(dataSourceUpdates, logger, basisReceived);
+    listener(changesTransferNone);
+
+    expect(logger.debug).toBeCalledWith(expect.stringMatching(/ignoring/i));
+    expect(dataSourceUpdates.applyChanges).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -279,7 +279,13 @@ export default class LDClientImpl implements LDClient {
           synchronizers.push(
             () =>
               new PollingProcessorFDv2(
-                new Requestor(config, this._platform.requests, baseHeaders),
+                new Requestor(
+                  config,
+                  this._platform.requests,
+                  baseHeaders,
+                  undefined,
+                  config.logger,
+                ),
                 pollingInterval,
                 config.logger,
               ),
@@ -290,7 +296,13 @@ export default class LDClientImpl implements LDClient {
         const fdv1FallbackSynchronizers = [
           () =>
             new PollingProcessorFDv2(
-              new Requestor(config, this._platform.requests, baseHeaders, "/sdk/latest-all"),
+              new Requestor(
+                config,
+                this._platform.requests,
+                baseHeaders,
+                '/sdk/latest-all',
+                this.logger,
+              ),
               pollingInterval,
               config.logger,
               true,
@@ -312,10 +324,11 @@ export default class LDClientImpl implements LDClient {
             payloadListener(payload);
           },
           (state, err) => {
-            if (state == subsystem.DataSourceState.Closed && err) {
+            if (state === subsystem.DataSourceState.Closed && err) {
               this._dataSourceErrorHandler(err);
             }
           },
+          () => featureStore.getSelector?.(),
         );
       }
     } else {

--- a/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDDataSourceUpdates.ts
@@ -48,13 +48,13 @@ export interface LDDataSourceUpdates {
    * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
    * the value is an object that maps keys to entities. The actual type of this parameter is
    * `interfaces.FullDataSet<VersionedData>`.
-   * @param selector opaque string that uniquely identifies the state that contains the changes
    * @param callback Will be called after the changes are applied.
+   * @param selector opaque string that uniquely identifies the state that contains the changes
    */
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String,
     callback: () => void,
+    selector?: string,
   ): void;
 }

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
@@ -3,8 +3,14 @@
  *
  * The client uses this internally to retrieve feature flags from LaunchDarkly.
  *
+ * @param cb The callback with error or information from the response if successful
+ * @param queryParams Additional query params that will be included with the request. Values passed into this
+ * function should already be encoded as this function will not perform encoding.
  * @ignore
  */
 export interface LDFeatureRequestor {
-  requestAllData: (cb: (err: any, body: any) => void) => void;
+  requestAllData: (
+    cb: (err: any, body: any) => void,
+    queryParams?: { key: string; value: string }[],
+  ) => void;
 }

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureStore.ts
@@ -148,14 +148,14 @@ export interface LDFeatureStore {
    * @param data An object in which each key is the "namespace" of a collection (e.g. `"features"`) and
    * the value is an object that maps keys to entities. The actual type of this parameter is
    * `interfaces.FullDataSet<VersionedData>`.
-   * @param selector opaque string that uniquely identifies the state that contains the changes
    * @param callback Will be called after the changes are applied.
+   * @param selector opaque string that uniquely identifies the state that contains the changes
    */
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined,
     callback: () => void,
+    selector?: string,
   ): void;
 
   /**
@@ -179,4 +179,9 @@ export interface LDFeatureStore {
    * Get a description of the store.
    */
   getDescription?(): string;
+
+  /**
+   * Gets the selector for the currently stored data.
+   */
+  getSelector?(): string | undefined;
 }

--- a/packages/shared/sdk-server/src/store/AsyncStoreFacade.ts
+++ b/packages/shared/sdk-server/src/store/AsyncStoreFacade.ts
@@ -60,10 +60,10 @@ export default class AsyncStoreFacade {
   async applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined,
+    selector?: string,
   ): Promise<void> {
     return promisify((cb) => {
-      this._store.applyChanges(basis, data, selector, cb);
+      this._store.applyChanges(basis, data, cb, selector);
     });
   }
 

--- a/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
+++ b/packages/shared/sdk-server/src/store/InMemoryFeatureStore.ts
@@ -10,6 +10,9 @@ import {
 export default class InMemoryFeatureStore implements LDFeatureStore {
   private _allData: LDFeatureStoreDataStorage = {};
 
+  // this tracks the last received selector, which may not be present
+  private _selector: string | undefined;
+
   private _initCalled = false;
 
   get(kind: DataKind, key: string, callback: (res: LDFeatureStoreItem | null) => void): void {
@@ -37,7 +40,7 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
   }
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
-    this.applyChanges(true, allData, undefined, callback);
+    this.applyChanges(true, allData, callback, undefined);
   }
 
   delete(kind: DataKind, key: string, version: number, callback: () => void): void {
@@ -49,8 +52,9 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
           [key]: item,
         },
       },
-      undefined,
       callback,
+      undefined,
+
     );
   }
 
@@ -62,16 +66,16 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
           [data.key]: data,
         },
       },
-      undefined,
       callback,
+      undefined,
     );
   }
 
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined, // TODO: SDK-1044 - Utilize selector
     callback: () => void,
+    selector?: string,
   ): void {
     if (basis) {
       this._initCalled = true;
@@ -106,6 +110,8 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
       this._allData = tempData;
     }
 
+    this._selector = selector;
+
     callback?.();
   }
 
@@ -120,5 +126,9 @@ export default class InMemoryFeatureStore implements LDFeatureStore {
 
   getDescription(): string {
     return 'memory';
+  }
+
+  getSelector(): string | undefined {
+    return this._selector;
   }
 }

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -266,8 +266,8 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined, // TODO: SDK-1044 - Utilize selector
     callback: () => void,
+    _selector?: string, // select is not persisted nor do we have intention to persist it at the time of writing
   ): void {
     if (basis) {
       this._queue.enqueue((cb) => {

--- a/packages/shared/sdk-server/src/store/TransactionalPersistentStore.ts
+++ b/packages/shared/sdk-server/src/store/TransactionalPersistentStore.ts
@@ -33,7 +33,7 @@ export default class TransactionalPersistentStore implements LDFeatureStore {
 
   init(allData: LDFeatureStoreDataStorage, callback: () => void): void {
     // adapt to applyChanges for common handling
-    this.applyChanges(true, allData, undefined, callback);
+    this.applyChanges(true, allData, callback, undefined);
   }
 
   delete(kind: DataKind, key: string, version: number, callback: () => void): void {
@@ -46,8 +46,8 @@ export default class TransactionalPersistentStore implements LDFeatureStore {
           [key]: item,
         },
       },
-      undefined,
       callback,
+      undefined,
     );
   }
 
@@ -60,21 +60,26 @@ export default class TransactionalPersistentStore implements LDFeatureStore {
           [data.key]: data,
         },
       },
-      undefined,
       callback,
+      undefined,
     );
   }
 
   applyChanges(
     basis: boolean,
     data: LDFeatureStoreDataStorage,
-    selector: String | undefined, // TODO: SDK-1044 - Utilize selector
     callback: () => void,
+    selector?: string,
   ): void {
-    this._memoryStore.applyChanges(basis, data, selector, () => {
-      // TODO: SDK-1047 conditional propgation to persistence based on parameter
-      this._nonTransPersistenceStore.applyChanges(basis, data, selector, callback);
-    });
+    this._memoryStore.applyChanges(
+      basis,
+      data,
+      () => {
+        // TODO: SDK-1047 conditional propgation to persistence based on parameter
+        this._nonTransPersistenceStore.applyChanges(basis, data, callback, selector);
+      },
+      selector,
+    );
 
     if (basis) {
       // basis causes memory store to become the active store


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
Will be done on target branch in the future as part of integration testing.

**Related issues**

SDK-1044

**Describe the solution you've provided**

Pipes selector through datasource and feature store layers / APIs.  InMemoryFeatureStore holds the selector in memory at runtime.  When datasources need the selector for making their requests, they invoke a selectorGetter lambda that is hooked up to the InMemoryFeatureStore.
