### PR TITLE
chore(docs): afterIdentify occurs at a different time than beforeIdentify

### DIFF
--- a/packages/shared/sdk-client/src/api/integrations/Hooks.ts
+++ b/packages/shared/sdk-client/src/api/integrations/Hooks.ts
@@ -181,8 +181,8 @@ export interface Hook {
   beforeIdentify?(hookContext: IdentifySeriesContext, data: IdentifySeriesData): IdentifySeriesData;
 
   /**
-   * This method is called during the execution of the identify process before the operation
-   * completes, but after any context modifications are performed.
+   * This method is called during the execution of the identify process, after the operation
+   * completes.
    *
    * @param hookContext Contains information about the evaluation being performed. This is not
    *  mutable.


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Found during https://launchdarkly.atlassian.net/browse/DOCS-2295, https://github.com/launchdarkly/ld-docs-private/pull/5935

**Describe the solution you've provided**

The `beforeIdentify` and `afterIdentify` methods in the `Hook` interface had identical documentation about when they're called, which is not how they actually behave.


