### PR TITLE
feat: Add plugin support for node.

### DIFF
--- a/packages/sdk/server-node/__tests__/LDClientNode.plugin.test.ts
+++ b/packages/sdk/server-node/__tests__/LDClientNode.plugin.test.ts
@@ -1,0 +1,259 @@
+import { integrations, LDContext, LDLogger } from '@launchdarkly/js-server-sdk-common';
+
+import { LDOptions } from '../src/api/LDOptions';
+import { LDPlugin } from '../src/api/LDPlugin';
+import LDClientNode from '../src/LDClientNode';
+import NodeInfo from '../src/platform/NodeInfo';
+
+// Test for plugin registration
+it('registers plugins and executes hooks during initialization', async () => {
+  const logger: LDLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const mockHook: integrations.Hook = {
+    getMetadata(): integrations.HookMetadata {
+      return {
+        name: 'test-hook',
+      };
+    },
+    beforeEvaluation: jest.fn(() => ({})),
+    afterEvaluation: jest.fn(() => ({})),
+  };
+
+  const mockPlugin: LDPlugin = {
+    getMetadata: () => ({ name: 'test-plugin' }),
+    register: jest.fn(),
+    getHooks: () => [mockHook],
+  };
+
+  const client = new LDClientNode('test', { offline: true, logger, plugins: [mockPlugin] });
+
+  // Verify the plugin was registered
+  expect(mockPlugin.register).toHaveBeenCalled();
+
+  // Now test that hooks work by calling identify and variation
+  const context: LDContext = { key: 'user-key', kind: 'user' };
+
+  await client.variation('flag-key', context, false);
+
+  expect(mockHook.beforeEvaluation).toHaveBeenCalledWith(
+    {
+      context,
+      defaultValue: false,
+      flagKey: 'flag-key',
+      method: 'LDClient.variation',
+      environmentId: undefined,
+    },
+    {},
+  );
+
+  expect(mockHook.afterEvaluation).toHaveBeenCalled();
+});
+
+// Test for multiple plugins with hooks
+it('registers multiple plugins and executes all hooks', async () => {
+  const logger: LDLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const mockHook1: integrations.Hook = {
+    getMetadata(): integrations.HookMetadata {
+      return {
+        name: 'test-hook-1',
+      };
+    },
+    beforeEvaluation: jest.fn(() => ({})),
+    afterEvaluation: jest.fn(() => ({})),
+  };
+
+  const mockHook2: integrations.Hook = {
+    getMetadata(): integrations.HookMetadata {
+      return {
+        name: 'test-hook-2',
+      };
+    },
+    beforeEvaluation: jest.fn(() => ({})),
+    afterEvaluation: jest.fn(() => ({})),
+  };
+
+  const mockPlugin1: LDPlugin = {
+    getMetadata: () => ({ name: 'test-plugin-1' }),
+    register: jest.fn(),
+    getHooks: () => [mockHook1],
+  };
+
+  const mockPlugin2: LDPlugin = {
+    getMetadata: () => ({ name: 'test-plugin-2' }),
+    register: jest.fn(),
+    getHooks: () => [mockHook2],
+  };
+
+  const client = new LDClientNode('test', {
+    offline: true,
+    logger,
+    plugins: [mockPlugin1, mockPlugin2],
+  });
+
+  // Verify plugins were registered
+  expect(mockPlugin1.register).toHaveBeenCalled();
+  expect(mockPlugin2.register).toHaveBeenCalled();
+
+  // Test that both hooks work
+  const context: LDContext = { key: 'user-key', kind: 'user' };
+  await client.variation('flag-key', context, false);
+
+  expect(mockHook1.beforeEvaluation).toHaveBeenCalled();
+  expect(mockHook1.afterEvaluation).toHaveBeenCalled();
+  expect(mockHook2.beforeEvaluation).toHaveBeenCalled();
+  expect(mockHook2.afterEvaluation).toHaveBeenCalled();
+});
+
+it('passes correct environmentMetadata to plugin getHooks and register functions', async () => {
+  const logger: LDLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const mockHook: integrations.Hook = {
+    getMetadata(): integrations.HookMetadata {
+      return {
+        name: 'test-hook',
+      };
+    },
+    beforeEvaluation: jest.fn(() => ({})),
+    afterEvaluation: jest.fn(() => ({})),
+  };
+
+  const mockPlugin: LDPlugin = {
+    getMetadata: () => ({ name: 'test-plugin' }),
+    register: jest.fn(),
+    getHooks: jest.fn(() => [mockHook]),
+  };
+
+  const options: LDOptions = {
+    wrapperName: 'test-wrapper',
+    wrapperVersion: '2.0.0',
+    application: {
+      id: 'test-app',
+      name: 'TestApp',
+      version: '3.0.0',
+      versionName: '3',
+    },
+    offline: true,
+    logger,
+    plugins: [mockPlugin],
+  };
+
+  // eslint-disable-next-line no-new
+  new LDClientNode('test', options);
+  const platformInfo = new NodeInfo(options);
+  const sdkData = platformInfo.sdkData();
+  expect(sdkData.name).toBeDefined();
+  expect(sdkData.version).toBeDefined();
+
+  // Verify getHooks was called with correct environmentMetadata
+  expect(mockPlugin.getHooks).toHaveBeenCalledWith({
+    sdk: {
+      name: sdkData.userAgentBase,
+      version: sdkData.version,
+      wrapperName: options.wrapperName,
+      wrapperVersion: options.wrapperVersion,
+    },
+    application: {
+      id: options.application?.id,
+      name: options.application?.name,
+      version: options.application?.version,
+      versionName: options.application?.versionName,
+    },
+    sdkKey: 'test',
+  });
+
+  // Verify register was called with correct environmentMetadata
+  expect(mockPlugin.register).toHaveBeenCalledWith(
+    expect.any(Object), // client
+    {
+      sdk: {
+        name: sdkData.userAgentBase,
+        version: sdkData.version,
+        wrapperName: options.wrapperName,
+        wrapperVersion: options.wrapperVersion,
+      },
+      application: {
+        id: options.application?.id,
+        version: options.application?.version,
+        name: options.application?.name,
+        versionName: options.application?.versionName,
+      },
+      sdkKey: 'test',
+    },
+  );
+});
+
+it('passes correct environmentMetadata without optional fields', async () => {
+  const logger: LDLogger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const mockHook: integrations.Hook = {
+    getMetadata(): integrations.HookMetadata {
+      return {
+        name: 'test-hook',
+      };
+    },
+    beforeEvaluation: jest.fn(() => ({})),
+    afterEvaluation: jest.fn(() => ({})),
+  };
+
+  const mockPlugin: LDPlugin = {
+    getMetadata: () => ({ name: 'test-plugin' }),
+    register: jest.fn(),
+    getHooks: jest.fn(() => [mockHook]),
+  };
+
+  const options: LDOptions = {
+    offline: true,
+    logger,
+    plugins: [mockPlugin],
+  };
+
+  // eslint-disable-next-line no-new
+  new LDClientNode('test', options);
+
+  const platformInfo = new NodeInfo(options);
+  const sdkData = platformInfo.sdkData();
+  expect(sdkData.name).toBeDefined();
+  expect(sdkData.version).toBeDefined();
+
+  // Verify getHooks was called with correct environmentMetadata
+  expect(mockPlugin.getHooks).toHaveBeenCalledWith({
+    sdk: {
+      name: sdkData.userAgentBase,
+      version: sdkData.version,
+    },
+    sdkKey: 'test',
+  });
+
+  // Verify register was called with correct environmentMetadata
+  expect(mockPlugin.register).toHaveBeenCalledWith(
+    expect.any(Object), // client
+    {
+      sdk: {
+        name: sdkData.userAgentBase,
+        version: sdkData.version,
+      },
+      sdkKey: 'test',
+    },
+  );
+});

--- a/packages/sdk/server-node/src/LDClientNode.ts
+++ b/packages/sdk/server-node/src/LDClientNode.ts
@@ -45,10 +45,13 @@ class LDClientNode extends LDClientImpl implements LDClient {
       }
     }
 
+    const baseOptions = { ...options, logger };
+    delete baseOptions.plugins;
+
     super(
       sdkKey,
       new NodePlatform({ ...options, logger }),
-      { ...options, logger },
+      baseOptions,
       {
         onError: (err: Error) => {
           if (emitter.listenerCount('error')) {

--- a/packages/sdk/server-node/src/api/LDOptions.ts
+++ b/packages/sdk/server-node/src/api/LDOptions.ts
@@ -1,0 +1,19 @@
+import { LDOptions as LDOptionsCommon } from '@launchdarkly/js-server-sdk-common';
+
+import { LDPlugin } from './LDPlugin';
+
+/**
+ * LaunchDarkly initialization options.
+ *
+ * @privateRemarks
+ * The plugins implementation is SDK specific, so these options exist to extend the base options
+ * with the node specific plugin configuration.
+ */
+export interface LDOptions extends LDOptionsCommon {
+  /**
+   * A list of plugins to be used with the SDK.
+   *
+   * Plugin support is currently experimental and subject to change.
+   */
+  plugins?: LDPlugin[];
+}

--- a/packages/sdk/server-node/src/api/LDPlugin.ts
+++ b/packages/sdk/server-node/src/api/LDPlugin.ts
@@ -1,0 +1,12 @@
+import { integrations, LDPluginBase } from '@launchdarkly/js-server-sdk-common';
+
+import { LDClient } from './LDClient';
+
+/**
+ * Interface for plugins to the LaunchDarkly SDK.
+ *
+ * @privateRemarks
+ * The plugin interface must be in the leaf-sdk implementations to ensure it uses the correct LDClient intrface.
+ * The LDClient in the shared server code doesn't match the LDClient interface of the individual SDKs.
+ */
+export interface LDPlugin extends LDPluginBase<LDClient, integrations.Hook> {}

--- a/packages/sdk/server-node/src/index.ts
+++ b/packages/sdk/server-node/src/index.ts
@@ -15,6 +15,8 @@ import { LDOptions } from './api/LDOptions';
 import LDClientImpl from './LDClientNode';
 
 export * from '@launchdarkly/js-server-sdk-common';
+// Override common options with node specific options.
+export { LDOptions };
 
 // To replace the exports from `export *` we need to name them.
 // So the below exports replace them with the Node specific variants.

--- a/packages/sdk/server-node/src/index.ts
+++ b/packages/sdk/server-node/src/index.ts
@@ -8,14 +8,10 @@
  *
  * @packageDocumentation
  */
-import {
-  BasicLogger,
-  BasicLoggerOptions,
-  LDLogger,
-  LDOptions,
-} from '@launchdarkly/js-server-sdk-common';
+import { BasicLogger, BasicLoggerOptions, LDLogger } from '@launchdarkly/js-server-sdk-common';
 
 import { LDClient } from './api/LDClient';
+import { LDOptions } from './api/LDOptions';
 import LDClientImpl from './LDClientNode';
 
 export * from '@launchdarkly/js-server-sdk-common';

--- a/packages/shared/sdk-server/src/createPluginEnvironmentMetadata.ts
+++ b/packages/shared/sdk-server/src/createPluginEnvironmentMetadata.ts
@@ -1,0 +1,35 @@
+import { LDPluginEnvironmentMetadata, Platform } from '@launchdarkly/js-sdk-common';
+
+import Configuration from './options/Configuration';
+
+/**
+ * Mutable utility type to allow building up a readonly object from a mutable one.
+ */
+type Mutable<T> = {
+  -readonly [P in keyof T]: Mutable<T[P]>;
+};
+
+export function createPluginEnvironmentMetadata(
+  _platform: Platform,
+  _sdkKey: string,
+  config: Configuration,
+) {
+  const environmentMetadata: Mutable<LDPluginEnvironmentMetadata> = {
+    sdk: {
+      name: _platform.info.sdkData().userAgentBase!,
+      version: _platform.info.sdkData().version!,
+    },
+    sdkKey: _sdkKey,
+  };
+
+  if (_platform.info.sdkData().wrapperName) {
+    environmentMetadata.sdk.wrapperName = _platform.info.sdkData().wrapperName;
+  }
+  if (_platform.info.sdkData().wrapperVersion) {
+    environmentMetadata.sdk.wrapperVersion = _platform.info.sdkData().wrapperVersion;
+  }
+  if (config.applicationInfo) {
+    environmentMetadata.application = config.applicationInfo;
+  }
+  return environmentMetadata;
+}

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -1,8 +1,8 @@
 import {
   ApplicationTags,
-  internal,
   LDClientContext,
   LDLogger,
+  LDPluginEnvironmentMetadata,
   NumberWithMinimum,
   OptionMessages,
   ServiceEndpoints,
@@ -16,6 +16,7 @@ import { LDBigSegmentsOptions, LDOptions, LDProxyOptions, LDTLSOptions } from '.
 import { Hook } from '../api/integrations';
 import { LDDataSourceUpdates, LDFeatureStore } from '../api/subsystems';
 import InMemoryFeatureStore from '../store/InMemoryFeatureStore';
+import { ServerInternalOptions } from './ServerInternalOptions';
 import { ValidatedOptions } from './ValidatedOptions';
 
 // Once things are internal to the implementation of the SDK we can depend on
@@ -219,7 +220,18 @@ export default class Configuration {
 
   public readonly enableEventCompression: boolean;
 
-  constructor(options: LDOptions = {}, internalOptions: internal.LDInternalOptions = {}) {
+  public readonly getImplementationHooks: (
+    environmentMetadata: LDPluginEnvironmentMetadata,
+  ) => Hook[];
+
+  public readonly applicationInfo?: {
+    id?: string;
+    version?: string;
+    name?: string;
+    versionName?: string;
+  };
+
+  constructor(options: LDOptions = {}, internalOptions: ServerInternalOptions = {}) {
     // The default will handle undefined, but not null.
     // Because we can be called from JS we need to be extra defensive.
     // eslint-disable-next-line no-param-reassign
@@ -288,5 +300,7 @@ export default class Configuration {
 
     this.hooks = validatedOptions.hooks;
     this.enableEventCompression = validatedOptions.enableEventCompression;
+    this.getImplementationHooks = internalOptions.getImplementationHooks ?? (() => []);
+    this.applicationInfo = validatedOptions.application;
   }
 }

--- a/packages/shared/sdk-server/src/options/ServerInternalOptions.ts
+++ b/packages/shared/sdk-server/src/options/ServerInternalOptions.ts
@@ -1,0 +1,7 @@
+import { internal, LDPluginEnvironmentMetadata } from '@launchdarkly/js-sdk-common';
+
+import { Hook } from '../integrations';
+
+export interface ServerInternalOptions extends internal.LDInternalOptions {
+  getImplementationHooks?: (environmentMetadata: LDPluginEnvironmentMetadata) => Hook[];
+}


### PR DESCRIPTION
This adds plugin support for the node server SDK.

Plugin support is leaf-SDK specific because plugins use the interface of the SDK. The interface of the SDK has slightly different capabilities based on implementation.

Unfortunately this isn't a simple problem to tackle with regards to organization. We could use composition with the common functionality being generic over the SDK interface. Doing so would require some breaking changes to all the SDK implementation, but could be worth it in the future.

For not though we have to settle for some complexity with the plugin interface being defined per-sdk and the call to the initialization code being per-sdk.

This was able to re-use the generic types and functions which means this isn't very much code.

This SDK had another complexity which is the event emitter. For convenient implementation of events we were using a mixin, but this mixin approach means we didn't have the full interface of the SDK available at the construction time of the SDK. So this PR moves the emitter implementation into the node client.