### PR TITLE
feat: additional FDv2 functionality

### DIFF
--- a/packages/shared/common/src/api/subsystem/DataSystem/CallbackHandler.ts
+++ b/packages/shared/common/src/api/subsystem/DataSystem/CallbackHandler.ts
@@ -22,8 +22,6 @@ export class CallbackHandler {
       return;
     }
 
-    // TODO: SDK-1044 track selector for future synchronizer to use
-    // report data up
     this._dataCallback(basis, data);
   }
 

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -36,7 +36,6 @@ interface TransitionRequest {
  */
 export class CompositeDataSource implements DataSource {
   // TODO: SDK-856 async notification if initializer takes too long
-  // TODO: SDK-1044 utilize selector from initializers
 
   private _initPhaseActive: boolean;
   private _initFactories: DataSourceList<LDDataSourceFactory>;


### PR DESCRIPTION
This PR is nearly an empty commit and removes a completed TODO with a `feat` commit to trigger a release.

Up to this point, no FDv2 changes in shared/common had been made in a `feat` commit, so`js-sdk-common` didn't have a release triggered since May 21st.  This was overlooked as additional functionality was merged into main in other packages that did get released.

