### PR TITLE
fix: remove requirement for toVercelAISDK in agent defaults

### DIFF
--- a/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
+++ b/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
@@ -33,4 +33,4 @@ export interface LDAIAgentConfig {
 /**
  * Default values for an agent.
  */
-export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker'>;
+export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker' | 'toVercelAISDK'>;


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

[Provide links to any issues in this repository or elsewhere relating to this pull request.](https://launchdarkly.atlassian.net/jira/software/c/projects/REL/boards/239?selectedIssue=REL-9248)

**Describe the solution you've provided**

Removes the requirement for `toVercelAISDK` to be specified as part of the Agent defaults. This is not a method that the implementer should have to/would be able to provide.

Before - parameter was required on the default type:

<img width="1068" height="497" alt="Screenshot 2025-08-25 at 12 15 57 PM" src="https://github.com/user-attachments/assets/337a43c9-2615-4a42-abd5-5d84f2f95657" />

After - parameter is no longer required on the type:

<img width="788" height="489" alt="Screenshot 2025-08-25 at 12 11 49 PM" src="https://github.com/user-attachments/assets/ddff9ae0-670a-40fb-b3d7-ab9a4fcb3e93" />

**Describe alternatives you've considered**

This is a bug fix, so there are not alternative approaches

**Additional context**

Discussed offline with @abarker-launchdarkly  , we should move these non-required/decorator methods to a single union for exclusion once we add additional methods that need excluded so that they don't have to be specified in multiple places.
