### PR TITLE
fix(ai-sdk): Remove Vercel mapping method from LD

### DIFF
--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -109,8 +109,7 @@ export class LDAIClientImpl implements LDAIClient {
       defaultValue,
     );
 
-    const mapper = new LDAIConfigMapper(model, provider, undefined);
-    const agent: Omit<LDAIAgent, 'toVercelAISDK'> = {
+    const agent: LDAIAgent = {
       tracker,
       enabled,
     };
@@ -131,13 +130,7 @@ export class LDAIClientImpl implements LDAIClient {
       agent.instructions = this._interpolateTemplate(instructions, allVariables);
     }
 
-    return {
-      ...agent,
-      toVercelAISDK: <TMod>(
-        sdkProvider: VercelAISDKProvider<TMod> | Record<string, VercelAISDKProvider<TMod>>,
-        options?: VercelAISDKMapOptions | undefined,
-      ): VercelAISDKConfig<TMod> => mapper.toVercelAISDK(sdkProvider, options),
-    };
+    return agent;
   }
 
   async config(

--- a/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
+++ b/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
@@ -33,4 +33,4 @@ export interface LDAIAgentConfig {
 /**
  * Default values for an agent.
  */
-export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker'>;
+export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker' | 'toVercelAISDK'>;

--- a/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
+++ b/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
@@ -3,7 +3,7 @@ import { LDAIConfig } from '../config';
 /**
  * AI Config agent and tracker.
  */
-export interface LDAIAgent extends Omit<LDAIConfig, 'messages'> {
+export interface LDAIAgent extends Omit<LDAIConfig, 'messages' | 'toVercelAISDK'> {
   /**
    * Instructions for the agent.
    */

--- a/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
+++ b/packages/sdk/server-ai/src/api/agents/LDAIAgent.ts
@@ -33,4 +33,4 @@ export interface LDAIAgentConfig {
 /**
  * Default values for an agent.
  */
-export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker' | 'toVercelAISDK'>;
+export type LDAIAgentDefaults = Omit<LDAIAgent, 'tracker'>;


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality -- removed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Private JIRA issue

**Describe the solution you've provided**

Removes the implementation of the `toVercelAISDK` from the `LDAIAgent` implementation as the return type does not conform to the agents data model.

**Describe alternatives you've considered**

This method will need to be updated to work specifically with agents. Specifically, the `instructions` and `tools` fields will need to be mapped to [Vercel's agent contract](https://vercel.com/docs/agents)

**Additional context**

When built locally, the `toVercelAISDK` method is no longer required to be implemented in the default values:

<img width="564" height="317" alt="Screenshot 2025-08-26 at 9 08 13 AM" src="https://github.com/user-attachments/assets/5a1f93d0-0bf0-4417-8e61-8e470ce616a9" />
