### PR TITLE
chore: pin @types/node to fix CI check failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "//": "Pin jsonc-parser because v3.3.0 breaks rollup-plugin-esbuild",
   "resolutions": {
     "jsonc-parser": "3.2.0",
-    "parse5": "7.2.1"
+    "parse5": "7.2.1",
+    "@types/node": "24.1.0"
   }
 }


### PR DESCRIPTION
This PR pins @types/node at 24.1.0 in order to fix CI check failures

24.3.0 is causing errors such as:
```
../../../node_modules/@types/node/child_process.d.ts(309,9): error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
```