### PR TITLE
fix: app crashing due to undefined settings constant accessor

### DIFF
--- a/packages/sdk/react-native/src/platform/locale.ts
+++ b/packages/sdk/react-native/src/platform/locale.ts
@@ -1,12 +1,15 @@
 import { NativeModules, Platform } from 'react-native';
-
 /**
- * Ripped from:
- * https://dev.to/medaimane/localization-and-internationalization-in-react-native-reaching-global-audiences-3acj
+ * Apps opted into Fabric (the new architecture of React Native) 
+ * may not have access to the SettingsManager.settings.AppleLocale property.
+ * It is now common to use the `getConstants` method to access these constant properties with Fabric enabled apps.
  */
-const locale =
-  Platform.OS === 'ios'
-    ? NativeModules.SettingsManager?.settings?.AppleLocale // iOS
-    : NativeModules.I18nManager?.localeIdentifier;
+const getAppleLocale = () => {
+  const settings = NativeModules.SettingsManager?.settings ?? NativeModules.SettingsManager?.getConstants()?.settings;
+  return settings?.AppleLocale;
+}
 
-export default locale;
+export default Platform.select({
+    ios: getAppleLocale(),
+    android: NativeModules.I18nManager?.localeIdentifier,
+})


### PR DESCRIPTION
The purpose of this PR is to fix a crash I found yesterday caused by an accessor that is undefined when newer versions of react native have Fabric enabled.

Our Build Setup:
`react-native: v0.80.0
`@launchdarkly/react-native-client-sdk: v10.1.5`

**Requirements**
- [x] add null coalescing operation to use `getConstants` to prevent undefined `settings` object
- [x] still default to old accessor if not undefined 

**Related issues**
I've not seen any related issues yet regarding your repo, though I did find this one [Stack Overflow post](https://stackoverflow.com/questions/79526197/cannot-read-property-applelocale-of-undefined).

**Describe the solution you've provided**
The solution I've provided is to use a null coalescing check to fallback to the new `getConstants` method on native modules if the `settings` object is undefined.

**Describe alternatives you've considered**
I searched to see if there are preferred alternatives and did not come up with any other solutions. I am open to feedback on that though :) 
