### PR TITLE
feat: [SEC-7263] Add dependency-scan GitHub Actions workflow

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -10,7 +10,7 @@ jobs:
   generate-nodejs-sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
@@ -22,7 +22,7 @@ jobs:
     needs:
       - generate-nodejs-sbom
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Evaluate SBOM Policy
         uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to generate Software Bill of Materials (SBOM) for Node.js dependencies and evaluate them against security policies as part of SEC-7263.

## Changes

- **New workflow**: `.github/workflows/dependency-scan.yml`
  - Generates Node.js SBOM using `launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main`
  - Evaluates SBOM against policies using `launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main`
  - Triggers on pull requests and pushes to main branch

## Requirements

- [x] I have added test coverage for new or changed functionality (N/A - workflow addition)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions (will be validated by CI)

## Related issues

Security ticket: SEC-7263

## Describe the solution you've provided

This implements a two-stage dependency scanning workflow:
1. **Generate SBOM**: Creates a software bill of materials for all Node.js dependencies
2. **Evaluate Policy**: Analyzes the SBOM against LaunchDarkly's security policies to identify license violations or security issues

The workflow uses LaunchDarkly's public GitHub Actions (`gh-actions`) since this is a public repository.

## Human Review Checklist

Please verify:
- [ ] Action references (`launchdarkly/gh-actions/actions/dependency-scan/*@main`) are correct and accessible
- [ ] Artifact pattern `bom-*` matches what the generate-sbom action produces
- [ ] Workflow configuration is appropriate for this monorepo structure
- [ ] No additional permissions or configurations are needed for this repository

## Additional context

- Part of organization-wide initiative to add dependency scanning to all npm ecosystem repositories
- This workflow will help identify license compliance issues and security vulnerabilities in dependencies
- Uses public `gh-actions` repository since `js-core` is a public repository

**Link to Devin run**: https://app.devin.ai/sessions/434bb14b7bac4d81b9979b88965be92b  
**Requested by**: @pkaeding