### PR TITLE
chore: Pin GitHub actions to a digest to follow best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
Updates our renovate configuration which automates updating the actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables Renovate helper to pin GitHub Actions to immutable digests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 191ef902264cd5c27f6137ed1c7871cf33beb5a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->