### PR TITLE
chore: Include vercel ai package in release-please deployments

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,7 @@ jobs:
       package-server-ai-released: ${{ steps.release.outputs['packages/sdk/server-ai--release_created'] }}
       package-server-ai-langchain-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-langchain--release_created'] }}
       package-server-ai-openai-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-openai--release_created'] }}
+      package-server-ai-vercel-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-vercel--release_created'] }}
       package-browser-telemetry-released: ${{ steps.release.outputs['packages/telemetry/browser-telemetry--release_created'] }}
       package-combined-browser-released: ${{ steps.release.outputs['packages/sdk/combined-browser--release_created'] }}
     steps:
@@ -501,4 +502,24 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/ai-providers/server-ai-openai
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-server-ai-vercel:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-server-ai']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-server-ai-vercel-released == 'true'}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+      - id: release-server-ai-vercel
+        name: Full release of packages/ai-providers/server-ai-vercel
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/ai-providers/server-ai-vercel
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds server-ai-vercel to release-please with a new gated release job.
> 
> - **CI/CD (release-please workflow)**:
>   - Outputs: add `package-server-ai-vercel-released`.
>   - Jobs: add `release-server-ai-vercel` (needs `release-please`, `release-server-ai`), runs full release for `packages/ai-providers/server-ai-vercel` when the new output is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b7a11fbd91664d5f808d000b8c33158f7dfc931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->