### PR TITLE
chore: Update readme to use new metric tracking name

### DIFF
--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -134,7 +134,7 @@ const llm = await LangChainProvider.createLangChainModel(aiConfig);
 
 // Use with tracking
 const response = await aiConfig.tracker.trackMetricsOf(
-  (result) => LangChainProvider.createAIMetrics(result),
+  LangChainProvider.getAIMetricsFromResponse,
   () => llm.invoke(messages)
 );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update README example to use `LangChainProvider.getAIMetricsFromResponse` for tracking metrics instead of the previous inline factory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c90b5a672576a4d98d963acd783c73189c273ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->