### PR TITLE
chore: Additional unit test coverage and better error handling

### DIFF
--- a/packages/ai-providers/server-ai-vercel/src/VercelProvider.ts
+++ b/packages/ai-providers/server-ai-vercel/src/VercelProvider.ts
@@ -250,12 +250,19 @@ export class VercelProvider extends AIProvider {
 
     // favor totalUsage over usage for cumulative usage across all steps
     let usage: LDTokenUsage | undefined;
+
     if (stream.totalUsage) {
-      const usageData = await stream.totalUsage;
-      usage = VercelProvider.mapUsageDataToLDTokenUsage(usageData);
-    } else if (stream.usage) {
-      const usageData = await stream.usage;
-      usage = VercelProvider.mapUsageDataToLDTokenUsage(usageData);
+      const usageData = await stream.totalUsage.catch(() => undefined);
+      if (usageData) {
+        usage = VercelProvider.mapUsageDataToLDTokenUsage(usageData);
+      }
+    }
+
+    if (!usage && stream.usage) {
+      const usageData = await stream.usage.catch(() => undefined);
+      if (usageData) {
+        usage = VercelProvider.mapUsageDataToLDTokenUsage(usageData);
+      }
     }
 
     const success = finishReason !== 'error';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds extensive tests for VercelProvider mapping/streaming behavior and makes getAIMetricsFromStream robust to rejected usage promises with fallback logic.
> 
> - **Tests (`__tests__/VercelProvider.test.ts`)**:
>   - Add coverage for `toVercelAISDK`:
>     - Handles undefined model/messages, merges additional messages, maps parameters, supports provider map, and throws on undetermined model/provider.
>   - Add coverage for `getAIMetricsFromStream`:
>     - Extracts usage from `totalUsage` (preferred) or `usage`, handles missing/errored `finishReason`, absent usage, rejected `usage`/`totalUsage`, and supports v4/v5 token fields.
> - **Source (`src/VercelProvider.ts`)**:
>   - Update `getAIMetricsFromStream` to catch rejections from `totalUsage`/`usage` and fall back gracefully; leave success based on `finishReason`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e59922b9d46e683ccec4d27676f38a9e6f79402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->