### PR TITLE
chore: adding versions of the GHA package used

### DIFF
--- a/actions/package-size/action.yml
+++ b/actions/package-size/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Find Size Comment
       # Only do commenting on non-forks. A fork does not have permissions for comments.
       if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
       id: fc
       with:
         issue-number: ${{ inputs.pr_number }}
@@ -44,7 +44,7 @@ runs:
 
     - name: Create comment
       if: steps.fc.outputs.comment-id == '' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ inputs.pr_number }}
         body: |
@@ -56,7 +56,7 @@ runs:
 
     - name: Update comment
       if: steps.fc.outputs.comment-id != '' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         edit-mode: replace


### PR DESCRIPTION
This PR will clarify the packages that are used in GHA to match the digests.
> More importantly, this is an attempt to trick renovate to stop auto updating package SHAs to point to latest in default branch on these packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Annotates pinned SHAs with version comments for `peter-evans/find-comment` (v3.1.0) and `peter-evans/create-or-update-comment` (v4.0.0) in `actions/package-size/action.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b095962afc4a604864d65008470f76893d798793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->