### PR TITLE
feat: add initial polling retries to BrowserDataManager

### DIFF
--- a/packages/sdk/browser/__tests__/BrowserDataManager.test.ts
+++ b/packages/sdk/browser/__tests__/BrowserDataManager.test.ts
@@ -548,13 +548,7 @@ describe('given a BrowserDataManager with mocked dependencies', () => {
     const identifyResolve = jest.fn();
     const identifyReject = jest.fn();
 
-    const identifyOptions: BrowserIdentifyOptions = { initialPollingRetries: 3 };
-    const identifyPromise = dataManager.identify(
-      identifyResolve,
-      identifyReject,
-      context,
-      identifyOptions,
-    );
+    const identifyPromise = dataManager.identify(identifyResolve, identifyReject, context);
 
     // Fast-forward through the retry delays (2 retries * 1000ms each)
     await jest.advanceTimersByTimeAsync(2000);
@@ -585,21 +579,15 @@ describe('given a BrowserDataManager with mocked dependencies', () => {
     const identifyResolve = jest.fn();
     const identifyReject = jest.fn();
 
-    const identifyOptions: BrowserIdentifyOptions = { initialPollingRetries: 2 };
-    const identifyPromise = dataManager.identify(
-      identifyResolve,
-      identifyReject,
-      context,
-      identifyOptions,
-    );
+    const identifyPromise = dataManager.identify(identifyResolve, identifyReject, context);
 
-    // Fast-forward through the retry delays (2 retries * 1000ms each)
-    await jest.advanceTimersByTimeAsync(2000);
+    // Fast-forward through the retry delays (4 retries * 1000ms each)
+    await jest.advanceTimersByTimeAsync(4000);
 
     await identifyPromise;
 
-    // Should attempt initial request + 2 retries = 3 total attempts
-    expect(mockedFetch).toHaveBeenCalledTimes(3);
+    // Should attempt initial request + 3 retries = 4 total attempts
+    expect(mockedFetch).toHaveBeenCalledTimes(4);
     expect(identifyResolve).not.toHaveBeenCalled();
     expect(identifyReject).toHaveBeenCalled();
     expect(identifyReject).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));

--- a/packages/sdk/browser/src/BrowserIdentifyOptions.ts
+++ b/packages/sdk/browser/src/BrowserIdentifyOptions.ts
@@ -28,11 +28,4 @@ export interface BrowserIdentifyOptions extends Omit<LDIdentifyOptions, 'waitFor
    * For more information, see the [SDK Reference Guide](https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript).
    */
   bootstrap?: unknown;
-
-  /**
-   * The number of retries to attempt for the initial polling request.
-   *
-   * Defaults to 3.
-   */
-  initialPollingRetries?: number;
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Additional context**
- I did not implement a configuration to set the retry interval (pending comments on whether or not we want to reuse the backoff logic)
- I set the default retry limit to 3
- I made it so that if users set retry to less than 0 then we will log a warning and continue with limit set to default (3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds 3-attempt (1s interval) retry to initial polling in `BrowserDataManager`, with tests for success and max-retry failure.
> 
> - **Browser SDK**
>   - **`packages/sdk/browser/src/BrowserDataManager.ts`**:
>     - Add `_requestPayload` helper implementing retry for initial poll (max 3 retries, 1s delay) using `shouldRetry`, `sleep`, and `httpErrorMessage`.
>     - Refactor `_finishIdentifyFromPoll` to use `_requestPayload`; maintain error reporting via `DataSourceStatusManager`.
>     - Import new utilities from `@launchdarkly/js-client-sdk-common`.
>   - **Tests (`packages/sdk/browser/__tests__/BrowserDataManager.test.ts`)**:
>     - Add tests verifying retries until success and rejection after max retries using fake timers and mocked `fetch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6affd787c24e1c8dcecfebc7bfd483948deb5e8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->