### PR TITLE
ci: reverting android emulator action digest

### DIFF
--- a/.github/workflows/react-native-detox.yml
+++ b/.github/workflows/react-native-detox.yml
@@ -79,7 +79,7 @@ jobs:
           large-packages: false # Need this for packages that emulator depends on (specifically libx11-xcb1)
 
       - name: Detox test
-        uses: reactivecircus/android-emulator-runner@f0d1ed2dcad93c7479e8b2f2226c83af54494915 # renovate: ignoreDigest
+        uses: reactivecircus/android-emulator-runner@f0d1ed2dcad93c7479e8b2f2226c83af54494915 # v2
         with:
           api-level: 31
           arch: x86_64

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,12 @@
       "matchPackageNames": ["*"]
     },
     {
-      "description": "Disable digest pinning for a specific action",
+      "description": "Disable all updates for the android emulator runner action",
       "matchPackageNames": ["reactivecircus/android-emulator-runner"],
       "matchDepTypes": ["action"],
-      "pinDigests": false
+      "matchDatasources": ["github-tags"],
+      "matchManagers": ["github-actions"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tweaks Detox CI to preserve large packages and updates the android-emulator-runner digest while disabling Renovate updates for that action.
> 
> - **CI / GitHub Actions**:
>   - `react-native-detox.yml`: Set `jlumbroso/free-disk-space` input `large-packages: false` to keep required system packages.
>   - `reactivecircus/android-emulator-runner`: Update pinned digest (v2) in Detox test step.
> - **Renovate**:
>   - Add rule to disable updates for `reactivecircus/android-emulator-runner` in `github-actions` (datasource `github-tags`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d8bec28d3b3737feecc83d01ab6d861e9f7acde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->