### PR TITLE
fix: update initialization method in combined browser SDK to createClient

### DIFF
--- a/packages/sdk/combined-browser/package.json
+++ b/packages/sdk/combined-browser/package.json
@@ -45,7 +45,7 @@
     "check": "yarn prettier && yarn lint && yarn build && yarn test"
   },
   "dependencies": {
-    "@launchdarkly/js-client-sdk": "0.7.0",
+    "@launchdarkly/js-client-sdk": "0.11.0",
     "@launchdarkly/observability": "0.2.0",
     "@launchdarkly/session-replay": "0.2.0"
   },

--- a/packages/sdk/combined-browser/src/index.ts
+++ b/packages/sdk/combined-browser/src/index.ts
@@ -3,14 +3,19 @@
  *
  * This SDK is intended for use in browser environments. It includes the observability and session replay plugins.
  *
- * In typical usage, you will call {@link initialize} once at startup time to obtain an instance of
+ * In typical usage, you will call {@link createClient} once at startup time to obtain an instance of
  * {@link LDClient}, which provides access to all of the SDK's functionality.
  *
  * For more information, see the [SDK Reference Guide](https://docs.launchdarkly.com/sdk/client-side/javascript).
  *
  * @packageDocumentation
  */
-import { initialize as initializeJsClient, LDClient, LDOptions } from '@launchdarkly/js-client-sdk';
+import {
+  createClient as createClientJs,
+  LDClient,
+  LDContext,
+  LDOptions,
+} from '@launchdarkly/js-client-sdk';
 import Observability, { ObserveOptions } from '@launchdarkly/observability';
 import SessionReplay, { RecordOptions } from '@launchdarkly/session-replay';
 
@@ -42,18 +47,29 @@ export interface LDBrowserOptions extends LDOptions {
  *
  * Usage:
  * ```
- * import { initialize } from '@launchdarkly/browser';
- * const client = initialize(clientSideId, context, options);
+ * import { createClient } from '@launchdarkly/browser';
+ * const client = createClient(clientSideId, context, options);
+ *
+ * // Attach event listeners and add any additional initialization logic here
+ *
+ * // Then start the client
+ * client.start();
  * ```
  *
  * @param clientSideId
  *   The client-side ID, also known as the environment ID.
+ * @param context
+ *   The initial context used to identify the user. @see {@link LDContext}
  * @param options
  *   Optional configuration settings.
  * @return
  *   The new client instance.
  */
-export function initialize(clientSideId: string, options?: LDBrowserOptions): LDClient {
+export function createClient(
+  clientSideId: string,
+  context: LDContext,
+  options?: LDBrowserOptions,
+): LDClient {
   const optionsWithPlugins = {
     ...options,
     plugins: [
@@ -62,5 +78,5 @@ export function initialize(clientSideId: string, options?: LDBrowserOptions): LD
       new SessionReplay(options?.tmpProjectId ?? '1', options?.sessionReplay),
     ],
   };
-  return initializeJsClient(clientSideId, optionsWithPlugins);
+  return createClientJs(clientSideId, context, optionsWithPlugins);
 }


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

SDK-1699

**Describe the solution you've provided**

- Updated the `@launchdarkly/js-client-sdk` dependency from 0.7.0 to 0.11.0.
- Refactored the SDK's initialization flow by replacing the `initialize` method with `createClient`, which now requires an initial context parameter.
- Adjusted usage examples and documentation to reflect the new client creation and initialization process.

**Additional context**

- Is this something we'd want to update? The version of browser sdk was fairly old before this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces initialize with createClient (now requiring an LDContext and start flow) and updates the js-client-sdk dependency to 0.11.0.
> 
> - **Browser SDK API**:
>   - Replace `initialize` with `createClient` in `packages/sdk/combined-browser/src/index.ts`.
>   - New signature requires `LDContext` and expects consumers to call `client.start()`.
>   - Update imports to use `createClient` and expose `LDContext` from `@launchdarkly/js-client-sdk`.
> - **Docs/Examples**:
>   - Adjust JSDoc usage to reflect `createClient(clientSideId, context, options)` and start sequence.
> - **Dependencies**:
>   - Bump `@launchdarkly/js-client-sdk` from `0.7.0` to `0.11.0` in `packages/sdk/combined-browser/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f993d3f72a25812a8b31a529ebe336248d8a8dcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->