### PR TITLE
test: pin `detox` package version to avoid breaking patches

### DIFF
--- a/packages/sdk/react-native/example/package.json
+++ b/packages/sdk/react-native/example/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^20.10.5",
     "@types/react": "~18.2.55",
     "@types/react-native-dotenv": "^0.2.1",
-    "detox": "20.46.0",
+    "detox": "20.46.3",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
SDK-1711

This PR reverts `detox` and locked it in `20.46.0` as `20.46.1` is breaking the build. There is nothing really obvious on the changes that would have caused the breakage so we will need to investigate more later.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates E2E-related tooling for the React Native example app.
> 
> - Pins `detox` to `20.46.3` (was caret range)
> - Upgrades `@config-plugins/detox` to `11.0.0`
> - Removes `@types/detox` from `devDependencies`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff22f9a9abcf1f62e4622bbfbc2cda83b85c88c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->