### PR TITLE
chore: manual dep update

### DIFF
--- a/packages/sdk/combined-browser/package.json
+++ b/packages/sdk/combined-browser/package.json
@@ -45,7 +45,7 @@
     "check": "yarn prettier && yarn lint && yarn build && yarn test"
   },
   "dependencies": {
-    "@launchdarkly/js-client-sdk": "0.11.0",
+    "@launchdarkly/js-client-sdk": "0.12.0",
     "@launchdarkly/observability": "0.2.0",
     "@launchdarkly/session-replay": "0.2.0"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -127,10 +127,10 @@
     "packages/tooling/jest": {
       "bump-minor-pre-major": true
     },
-    "packages/telemetry/browser-telemetry": {}
-  },
-  "packages/sdk/combined-browser": {
-    "bump-minor-pre-major": true
+    "packages/telemetry/browser-telemetry": {},
+    "packages/sdk/combined-browser": {
+      "bump-minor-pre-major": true
+    }
   },
   "plugins": [
     {


### PR DESCRIPTION
This PR should address build breaking on combined browser test

This PR also fixes `release-please-config.json` and move the `combined-browser` entry to the right place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency version in the combined browser SDK package.
> 
> - Bumps `@launchdarkly/js-client-sdk` from `0.11.0` to `0.12.0` in `packages/sdk/combined-browser/package.json`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 434bdb118e3705f35155027dab2adf4e0c8418a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->