### PR TITLE
chore: do initial release of `combine-browser` sdk

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -129,7 +129,8 @@
     },
     "packages/telemetry/browser-telemetry": {},
     "packages/sdk/combined-browser": {
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "0.1.0"
     }
   },
   "plugins": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prepares the initial release configuration for the combined browser SDK.
> 
> - Updates `release-please-config.json` to add `release-as: "0.1.0"` for `packages/sdk/combined-browser` (keeps `bump-minor-pre-major: true`)
> - No source code changes; release metadata only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24af993ac5dd4ac27b76d061dddca46fbf861f4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->