### PR TITLE
fix: browser logging for non-existing flags

### DIFF
--- a/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
@@ -69,21 +69,21 @@ describe('sdk-client object', () => {
     expect(devTestFlag).toBe(true);
   });
 
-  test('variation flag not found', async () => {
+  test('variation flag not found should give a warning message', async () => {
     await ldc.identify({ kind: 'user', key: 'test-user' });
     const errorListener = jest.fn().mockName('errorListener');
     ldc.on('error', errorListener);
 
     const p = ldc.identify(context);
-    ldc.variation('does-not-exist', 'not-found');
+    const flagValue = ldc.variation('does-not-exist', 'not-found');
 
     await expect(p).resolves.toBeUndefined();
-    expect(errorListener).toHaveBeenCalledTimes(1);
-    const error = errorListener.mock.calls[0][1];
-    expect(error.message).toMatch(/unknown feature/i);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unknown feature'));
+    expect(flagValue).toBe('not-found');
   });
 
-  test('variationDetail flag not found', async () => {
+  test('variationDetail flag not found should return an error detail', async () => {
     await ldc.identify(context);
     const flag = ldc.variationDetail('does-not-exist', 'not-found');
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -543,11 +543,9 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
 
     if (foundItem === undefined || foundItem.flag.deleted) {
       const defVal = defaultValue ?? null;
-      const error = new LDClientError(
-        `Unknown feature flag "${flagKey}"; returning default value ${defVal}.`,
-      );
 
-      this.emitter.emit('error', this._activeContextTracker.getUnwrappedContext(), error);
+      this.logger?.warn(`Unknown feature flag "${flagKey}"; returning default value ${defVal}.`);
+
       if (hasContext) {
         this._eventProcessor?.sendEvent(
           this._eventFactoryDefault.unknownFlagEvent(flagKey, defVal, evalContext),


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

SDK-1736

**Describe the solution you've provided**

- When we call `variation` on a non-existent flag, we now should only get a warning message and the default flag value will be returned
- We will no longer emit an `error` to the client side emitter, but we will still return an error detail as well as send an error event to LD

**Additional context**

This behavior should now be consistent with what we have in v3 (https://github.com/launchdarkly/js-sdk-common/blob/main/src/index.js#L339). The reason for this change is that there is a valid chance that a missing flag is not considered a "error" level event on the application as developers can handle these cases with defaults (and more specialized handling by looking at the variation detail).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns unknown-flag behavior with v3 by de-escalating from client error events to warnings.
> 
> - In `LDClientImpl._variationInternal`, replace emitter `error` with `logger.warn` for unknown flags; still send `unknownFlagEvent` and return `createErrorEvaluationDetail(FLAG_NOT_FOUND, ...)`.
> - Update tests in `LDClientImpl.variation.test.ts` to expect a warning and default value for `variation`, and an error detail for `variationDetail`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a960a00a58201cfa693b48609f58e8362588e25d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->