### PR TITLE
chore: remove initial release props from release please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,8 +14,6 @@
     },
     "packages/sdk/shopify-oxygen": {
       "bump-minor-pre-major": true,
-      "release-as": "0.1.0",
-      "bootstrap-sha": "e70e4846d03f7ca2b6ef267efa90a24810e9364a",
       "extra-files": [
         "src/platform/OxygenInfo.ts"
       ]
@@ -129,8 +127,7 @@
     },
     "packages/telemetry/browser-telemetry": {},
     "packages/sdk/combined-browser": {
-      "bump-minor-pre-major": true,
-      "release-as": "0.1.0"
+      "bump-minor-pre-major": true
     }
   },
   "plugins": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies `release-please-config.json` by removing initial-release settings.
> 
> - Removed `release-as` and `bootstrap-sha` from `packages/sdk/shopify-oxygen`
> - Removed `release-as` from `packages/sdk/combined-browser`
> - No functional/code changes outside release configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f061349484b6efa414acf99f6b18fe1471b970a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->