### PR TITLE
chore: Update sdk_metadata features.

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -35,7 +35,7 @@
       "path": "packages/sdk/browser",
       "languages": ["JavaScript", "TypeScript"],
       "releases": {
-        "tag-prefix": "js-client-sdk-browser-"
+        "tag-prefix": "js-client-sdk-"
       },
       "userAgents": ["JSClient"],
       "features": {
@@ -80,7 +80,7 @@
       "path": "packages/sdk/combined-browser",
       "languages": ["JavaScript", "TypeScript"],
       "releases": {
-        "tag-prefix": "js-client-sdk-combined-browser-"
+        "tag-prefix": "browser-"
       },
       "userAgents": ["JSClient"],
       "features": {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A - This is a metadata update to document SDK feature support.

**Describe the solution you've provided**

This PR adds `features` objects to each SDK entry in `.sdk_metadata.json`, documenting which features each SDK supports and the version when each feature was introduced.

Features were mapped using:
- Canonical feature keys from [sdk-meta/feature_info.json](https://github.com/launchdarkly/sdk-meta/blob/main/products/feature_info.json)
- Version information from the [SDK features documentation](https://github.com/launchdarkly/ld-docs-private/blob/main/fern/topics/sdk/index.mdx)
- CHANGELOG.md files for verification and additional features

**SDKs updated:**
- **node-server**: 24 features (allFlags, appMetadata, bigSegments, contexts, eventCompression, experimentation, fdv2, fileDataSource, flagChanges, hooks, inlineContextCustomEvents, migrations, offlineMode, otel, pluginSupport, privateAttrs, relayProxyDaemon, relayProxyProxy, secureMode, storingDataRedis, testDataSource, track, variationDetail, webProxy)
- **react-native**: 15 features (allFlags, appMetadata, autoEnvAttrs, bigSegments, contexts, experimentation, flagChanges, hooks, multiEnv, offlineMode, pluginSupport, privateAttrs, relayProxyProxy, track, variationDetail)
- **cloudflare**: 6 features (allFlags, contexts, experimentation, migrations, secureMode, track)
- **vercel**: 5 features (allFlags, contexts, experimentation, secureMode, track)
- **akamai-base**: 2 features (contexts, migrations)
- **akamai-edgekv**: 2 features (contexts, migrations)

**Updates since last revision:**
- Removed the **fastly** SDK entry entirely from the metadata file because it is still on an unstable version (0.2.x). Per updated requirements, packages on major version 0 should be excluded.
- Fixed **migrations** version for akamai SDKs based on CHANGELOG verification:
  - **akamai-base**: `2.0` (migrations introduced in v2.0.0)
  - **akamai-edgekv**: `1.0.8` (migrations introduced in v1.0.8 - different versioning scheme)

**Items for reviewer attention:**
- The fastly SDK was removed from the metadata file because it's on version 0.x (unstable). Please verify this is the intended behavior.
- Please spot-check version numbers against the source documentation and CHANGELOGs, especially for the two Akamai SDKs which have different versioning schemes.

**Describe alternatives you've considered**

N/A

**Additional context**

Link to Devin run: https://app.devin.ai/sessions/d7e40e256e8e46d78df967041be52054
Requested by: Steven Zhang (@joker23)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds structured feature metadata across SDKs and expands the SDK catalog.
> 
> - Add `features` maps (with `introduced` versions) to `akamai-*`, `cloudflare`, `vercel`, `fastly`, `node-server`, `react-native`, and browser SDKs
> - Add new SDK entries: `browser`, `combined-browser`, `react-universal`, `server-ai`, `shopify-oxygen`, `svelte`
> - Rename Fastly display name to `Fastly Edge SDK`; minor formatting updates to `userAgents`
> - Change scope limited to `.sdk_metadata.json` (data-only)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8048be093a70820d1bbc3c9799e4905189c7790f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->