### PR TITLE
docs: adding oxygen to contributing docs

### DIFF
--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -28,3 +28,6 @@ alwaysApply: true
   ```
 - Replace package name as needed
 - Running `yarn build` in individual packages won't rebuild dependencies
+
+## Opening pull requests
+- When creating a Pull Request, always create it as a Draft Pull Request unless explicitly instructed otherwise.

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -48,5 +48,3 @@ alwaysApply: true
 - Tests should be run using `yarn workspace <package name> test`
 - The package name can be found in the package.json file
 - Unit tests should be run for any packages that have been modified
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,7 @@ flowchart LR
     server-ai[sdk/server-ai]
     react-universal[sdk/react-universal]
     svelte[sdk/svelte]
+    shopify-oxygen[sdk/shopify-oxygen]
 
     %% Store packages
     redis[store/node-server-sdk-redis]
@@ -191,6 +192,7 @@ flowchart LR
     
     sdk-server --> server-node
     sdk-server --> server-ai
+    sdk-server --> shopify-oxygen
     
     sdk-server-edge --> cloudflare
     sdk-server-edge --> fastly


### PR DESCRIPTION
- adds oxygen sdk to repo organization section of contributing docs
- adds agents rules to prefer opening draft prs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation updates to improve repo guidance and accuracy.
> 
> - Updates `CONTRIBUTING.md` repo diagram to include `shopify-oxygen` and its dependency on `sdk-server`
> - Adds PR workflow rule in `.cursor/rules/development.mdc` to open PRs as Draft by default
> - Minor cleanup in `.cursor/rules/testing.mdc` (removes stray lines)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b0df7ba4599f386fb13bfb22e5eb2b275ac176d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->