### PR TITLE
feat: Add experimental FDv2 support for React Native.

### DIFF
--- a/packages/sdk/react-native/src/RNOptions.ts
+++ b/packages/sdk/react-native/src/RNOptions.ts
@@ -1,4 +1,8 @@
-import { ConnectionMode, LDOptions } from '@launchdarkly/js-client-sdk-common';
+import {
+  ConnectionMode,
+  LDClientDataSystemOptions,
+  LDOptions,
+} from '@launchdarkly/js-client-sdk-common';
 
 import { LDPlugin } from './LDPlugin';
 
@@ -60,6 +64,23 @@ export interface RNStorage {
   clear: (key: string) => Promise<void>;
 }
 
+/**
+ * Data system options for the React Native SDK.
+ *
+ * React Native supports the full range of automatic mode switching options,
+ * including lifecycle-based (foreground/background) and network-based switching.
+ *
+ * Note: Network-based automatic mode switching is not yet supported.
+ * Lifecycle-based switching (foreground/background) is fully functional.
+ *
+ * This interface is not stable, and not subject to any backwards compatibility
+ * guarantees or semantic versioning. It is in early access. If you want access
+ * to this feature please join the EAP.
+ * https://launchdarkly.com/docs/sdk/features/data-saving-mode
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RNDataSystemOptions extends LDClientDataSystemOptions {}
+
 export interface RNSpecificOptions {
   /**
    * Some platforms (windows, web, mac, linux) can continue executing code
@@ -118,6 +139,22 @@ export interface RNSpecificOptions {
    * Plugin support is currently experimental and subject to change.
    */
   plugins?: LDPlugin[];
+
+  /**
+   * @internal
+   *
+   * This feature is experimental and should NOT be considered ready for
+   * production use. It may change or be removed without notice and is not
+   * subject to backwards compatibility guarantees.
+   *
+   * Configuration for the FDv2 data system. When present, the SDK uses
+   * the FDv2 protocol for flag delivery instead of the default FDv1
+   * protocol.
+   *
+   * Note: Network-based automatic mode switching is not yet supported.
+   * Lifecycle-based switching (foreground/background) is fully functional.
+   */
+  dataSystem?: RNDataSystemOptions;
 }
 
 export default interface RNOptions extends LDOptions, RNSpecificOptions {}

--- a/packages/sdk/react-native/src/RNOptions.ts
+++ b/packages/sdk/react-native/src/RNOptions.ts
@@ -67,11 +67,8 @@ export interface RNStorage {
 /**
  * Data system options for the React Native SDK.
  *
- * React Native supports the full range of automatic mode switching options,
- * including lifecycle-based (foreground/background) and network-based switching.
- *
  * Note: Network-based automatic mode switching is not yet supported.
- * Lifecycle-based switching (foreground/background) is fully functional.
+ * Lifecycle-based switching is.
  *
  * This interface is not stable, and not subject to any backwards compatibility
  * guarantees or semantic versioning. It is in early access. If you want access

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -49,7 +49,6 @@ import RNStateDetector from './RNStateDetector';
  */
 export default class ReactNativeLDClient extends LDClientImpl {
   private _connectionManager?: ConnectionManager;
-  private _isFdv2: boolean;
 
   /**
    * Creates an instance of the LaunchDarkly client.
@@ -137,9 +136,7 @@ export default class ReactNativeLDClient extends LDClientImpl {
       internalOptions,
     );
 
-    this._isFdv2 = !!options.dataSystem;
-
-    if (this._isFdv2) {
+    if (this.isFDv2) {
       const fdv2DataManager = this.dataManager as FDv2DataManagerControl;
 
       this.setEventSendingEnabled(true, false);
@@ -226,7 +223,7 @@ export default class ReactNativeLDClient extends LDClientImpl {
    */
   async setConnectionMode(mode?: FDv2ConnectionMode): Promise<void>;
   async setConnectionMode(mode?: ConnectionMode | FDv2ConnectionMode): Promise<void> {
-    if (this._isFdv2) {
+    if (this.isFDv2) {
       // FDv2 path
       if (mode !== undefined && !(mode in MODE_TABLE)) {
         this.logger.warn(
@@ -260,14 +257,14 @@ export default class ReactNativeLDClient extends LDClientImpl {
    */
   getConnectionMode(): FDv2ConnectionMode;
   getConnectionMode(): ConnectionMode | FDv2ConnectionMode {
-    if (this._isFdv2) {
+    if (this.isFDv2) {
       return (this.dataManager as FDv2DataManagerControl).getCurrentMode();
     }
     return (this.dataManager as MobileDataManager).getConnectionMode();
   }
 
   isOffline() {
-    if (this._isFdv2) {
+    if (this.isFDv2) {
       return (this.dataManager as FDv2DataManagerControl).getCurrentMode() === 'offline';
     }
     return (this.dataManager as MobileDataManager).getConnectionMode() === 'offline';

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -231,7 +231,7 @@ export default class ReactNativeLDClient extends LDClientImpl {
       if (mode !== undefined && !(mode in MODE_TABLE)) {
         this.logger.warn(
           `setConnectionMode called with invalid mode '${mode}'. ` +
-          `Valid modes: ${Object.keys(MODE_TABLE).join(', ')}.`,
+            `Valid modes: ${Object.keys(MODE_TABLE).join(', ')}.`,
         );
         return;
       }

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -49,7 +49,8 @@ import RNStateDetector from './RNStateDetector';
  */
 export default class ReactNativeLDClient extends LDClientImpl {
   private _connectionManager?: ConnectionManager;
-  private _stateDetector?: RNStateDetector;
+  private _isFdv2: boolean;
+
   /**
    * Creates an instance of the LaunchDarkly client.
    *
@@ -136,9 +137,9 @@ export default class ReactNativeLDClient extends LDClientImpl {
       internalOptions,
     );
 
-    const isFDv2 = !!options.dataSystem;
+    this._isFdv2 = !!options.dataSystem;
 
-    if (isFDv2) {
+    if (this._isFdv2) {
       const fdv2DataManager = this.dataManager as FDv2DataManagerControl;
 
       this.setEventSendingEnabled(true, false);
@@ -146,7 +147,6 @@ export default class ReactNativeLDClient extends LDClientImpl {
 
       // Wire state detection directly to FDv2 data manager.
       const stateDetector = new RNStateDetector();
-      this._stateDetector = stateDetector;
 
       if (validatedRnOptions.automaticBackgroundHandling) {
         stateDetector.setApplicationStateListener((state) => {
@@ -226,7 +226,19 @@ export default class ReactNativeLDClient extends LDClientImpl {
    */
   async setConnectionMode(mode?: FDv2ConnectionMode): Promise<void>;
   async setConnectionMode(mode?: ConnectionMode | FDv2ConnectionMode): Promise<void> {
-    if (this._connectionManager) {
+    if (this._isFdv2) {
+      // FDv2 path
+      if (mode !== undefined && !(mode in MODE_TABLE)) {
+        this.logger.warn(
+          `setConnectionMode called with invalid mode '${mode}'. ` +
+          `Valid modes: ${Object.keys(MODE_TABLE).join(', ')}.`,
+        );
+        return;
+      }
+      (this.dataManager as FDv2DataManagerControl).setConnectionMode(
+        mode as FDv2ConnectionMode | undefined,
+      );
+    } else {
       // FDv1 path
       if (mode === undefined || mode === 'one-shot' || mode === 'background') {
         this.logger.warn(
@@ -234,20 +246,8 @@ export default class ReactNativeLDClient extends LDClientImpl {
         );
         return;
       }
-      this._connectionManager.setConnectionMode(mode as ConnectionMode);
-      this._connectionManager.setOffline(mode === 'offline');
-    } else {
-      // FDv2 path
-      if (mode !== undefined && !(mode in MODE_TABLE)) {
-        this.logger.warn(
-          `setConnectionMode called with invalid mode '${mode}'. ` +
-            `Valid modes: ${Object.keys(MODE_TABLE).join(', ')}.`,
-        );
-        return;
-      }
-      (this.dataManager as FDv2DataManagerControl).setConnectionMode(
-        mode as FDv2ConnectionMode | undefined,
-      );
+      this._connectionManager?.setConnectionMode(mode as ConnectionMode);
+      this._connectionManager?.setOffline(mode === 'offline');
     }
   }
 
@@ -260,16 +260,16 @@ export default class ReactNativeLDClient extends LDClientImpl {
    */
   getConnectionMode(): FDv2ConnectionMode;
   getConnectionMode(): ConnectionMode | FDv2ConnectionMode {
-    if (this._connectionManager) {
-      return (this.dataManager as MobileDataManager).getConnectionMode();
+    if (this._isFdv2) {
+      return (this.dataManager as FDv2DataManagerControl).getCurrentMode();
     }
-    return (this.dataManager as FDv2DataManagerControl).getCurrentMode();
+    return (this.dataManager as MobileDataManager).getConnectionMode();
   }
 
   isOffline() {
-    if (this._connectionManager) {
-      return (this.dataManager as MobileDataManager).getConnectionMode() === 'offline';
+    if (this._isFdv2) {
+      return (this.dataManager as FDv2DataManagerControl).getCurrentMode() === 'offline';
     }
-    return (this.dataManager as FDv2DataManagerControl).getCurrentMode() === 'offline';
+    return (this.dataManager as MobileDataManager).getConnectionMode() === 'offline';
   }
 }

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -4,6 +4,10 @@ import {
   BasicLogger,
   type Configuration,
   ConnectionMode,
+  createDefaultSourceFactoryProvider,
+  createFDv2DataManagerBase,
+  FDv2ConnectionMode,
+  type FDv2DataManagerControl,
   FlagManager,
   internal,
   LDClientImpl,
@@ -12,13 +16,21 @@ import {
   LDHeaders,
   LDPluginEnvironmentMetadata,
   MOBILE_DATA_SYSTEM_DEFAULTS,
+  MOBILE_TRANSITION_TABLE,
   mobileFdv1Endpoints,
+  MODE_TABLE,
+  resolveForegroundMode,
 } from '@launchdarkly/js-client-sdk-common';
 
 import MobileDataManager from './MobileDataManager';
 import validateOptions, { filterToBaseOptions } from './options';
 import createPlatform from './platform';
-import { ConnectionDestination, ConnectionManager } from './platform/ConnectionManager';
+import {
+  ApplicationState,
+  ConnectionDestination,
+  ConnectionManager,
+  NetworkState,
+} from './platform/ConnectionManager';
 import LDOptions from './RNOptions';
 import RNStateDetector from './RNStateDetector';
 
@@ -36,7 +48,8 @@ import RNStateDetector from './RNStateDetector';
  * ```
  */
 export default class ReactNativeLDClient extends LDClientImpl {
-  private _connectionManager: ConnectionManager;
+  private _connectionManager?: ConnectionManager;
+  private _stateDetector?: RNStateDetector;
   /**
    * Creates an instance of the LaunchDarkly client.
    *
@@ -72,62 +85,114 @@ export default class ReactNativeLDClient extends LDClientImpl {
     const platform = createPlatform(logger, options, validatedRnOptions.storage);
     const endpoints = mobileFdv1Endpoints();
 
+    const dataManagerFactory = (
+      flagManager: FlagManager,
+      configuration: Configuration,
+      baseHeaders: LDHeaders,
+      emitter: LDEmitter,
+      diagnosticsManager?: internal.DiagnosticsManager,
+    ) => {
+      if (configuration.dataSystem) {
+        return createFDv2DataManagerBase({
+          platform,
+          flagManager,
+          credential: sdkKey,
+          config: configuration,
+          baseHeaders,
+          emitter,
+          transitionTable: MOBILE_TRANSITION_TABLE,
+          foregroundMode: resolveForegroundMode(
+            configuration.dataSystem,
+            MOBILE_DATA_SYSTEM_DEFAULTS,
+          ),
+          backgroundMode: configuration.dataSystem.backgroundConnectionMode ?? 'background',
+          modeTable: MODE_TABLE,
+          sourceFactoryProvider: createDefaultSourceFactoryProvider(),
+          fdv1Endpoints: mobileFdv1Endpoints(),
+          buildQueryParams: () => [], // Mobile uses Authorization header, not query params
+        });
+      }
+
+      return new MobileDataManager(
+        platform,
+        flagManager,
+        sdkKey,
+        configuration,
+        validatedRnOptions,
+        endpoints.polling,
+        endpoints.streaming,
+        baseHeaders,
+        emitter,
+        diagnosticsManager,
+      );
+    };
+
     super(
       sdkKey,
       autoEnvAttributes,
       platform,
       { ...filterToBaseOptions(options), logger },
-      (
-        flagManager: FlagManager,
-        configuration: Configuration,
-        baseHeaders: LDHeaders,
-        emitter: LDEmitter,
-        diagnosticsManager?: internal.DiagnosticsManager,
-      ) =>
-        new MobileDataManager(
-          platform,
-          flagManager,
-          sdkKey,
-          configuration,
-          validatedRnOptions,
-          endpoints.polling,
-          endpoints.streaming,
-          baseHeaders,
-          emitter,
-          diagnosticsManager,
-        ),
+      dataManagerFactory,
       internalOptions,
     );
 
-    this.setEventSendingEnabled(!this.isOffline(), false);
+    const isFDv2 = !!options.dataSystem;
 
-    const dataManager = this.dataManager as MobileDataManager;
-    const destination: ConnectionDestination = {
-      setNetworkAvailability: (available: boolean) => {
-        dataManager.setNetworkAvailability(available);
-      },
-      setEventSendingEnabled: (enabled: boolean, flush: boolean) => {
-        this.setEventSendingEnabled(enabled, flush);
-      },
-      setConnectionMode: async (mode: ConnectionMode) => {
-        // Pass the connection mode to the base implementation.
-        // The RN implementation will pass the connection mode through the connection manager.
-        dataManager.setConnectionMode(mode);
-      },
-    };
+    if (isFDv2) {
+      const fdv2DataManager = this.dataManager as FDv2DataManagerControl;
 
-    const initialConnectionMode = options.initialConnectionMode ?? 'streaming';
-    this._connectionManager = new ConnectionManager(
-      logger,
-      {
-        initialConnectionMode,
-        automaticNetworkHandling: validatedRnOptions.automaticNetworkHandling,
-        automaticBackgroundHandling: validatedRnOptions.automaticBackgroundHandling,
-        runInBackground: validatedRnOptions.runInBackground,
-      },
-      destination,
-      new RNStateDetector(),
-    );
+      this.setEventSendingEnabled(true, false);
+      fdv2DataManager.setFlushCallback(() => this.flush());
+
+      // Wire state detection directly to FDv2 data manager.
+      const stateDetector = new RNStateDetector();
+      this._stateDetector = stateDetector;
+
+      if (validatedRnOptions.automaticBackgroundHandling) {
+        stateDetector.setApplicationStateListener((state) => {
+          fdv2DataManager.setLifecycleState(
+            state === ApplicationState.Foreground ? 'foreground' : 'background',
+          );
+        });
+      }
+
+      if (validatedRnOptions.automaticNetworkHandling) {
+        stateDetector.setNetworkStateListener((state) => {
+          fdv2DataManager.setNetworkState(
+            state === NetworkState.Available ? 'available' : 'unavailable',
+          );
+        });
+      }
+    } else {
+      const initialConnectionMode = options.initialConnectionMode ?? 'streaming';
+      this.setEventSendingEnabled(initialConnectionMode !== 'offline', false);
+
+      const dataManager = this.dataManager as MobileDataManager;
+      const destination: ConnectionDestination = {
+        setNetworkAvailability: (available: boolean) => {
+          dataManager.setNetworkAvailability(available);
+        },
+        setEventSendingEnabled: (enabled: boolean, flush: boolean) => {
+          this.setEventSendingEnabled(enabled, flush);
+        },
+        setConnectionMode: async (mode: ConnectionMode) => {
+          dataManager.setConnectionMode(mode);
+        },
+      };
+
+      this._connectionManager = new ConnectionManager(
+        logger,
+        {
+          initialConnectionMode,
+          automaticNetworkHandling: validatedRnOptions.automaticNetworkHandling,
+          automaticBackgroundHandling: validatedRnOptions.automaticBackgroundHandling,
+          runInBackground: validatedRnOptions.runInBackground,
+        },
+        destination,
+        new RNStateDetector(),
+      );
+    }
+
     internal.safeRegisterPlugins(
       logger,
       this.environmentMetadata,
@@ -136,24 +201,66 @@ export default class ReactNativeLDClient extends LDClientImpl {
     );
   }
 
-  async setConnectionMode(mode: ConnectionMode): Promise<void> {
-    // Set the connection mode before setting offline, in case there is any mode transition work
-    // such as flushing on entering the background.
-    this._connectionManager.setConnectionMode(mode);
-    // For now the data source connection and the event processing state are connected.
-    this._connectionManager.setOffline(mode === 'offline');
+  /**
+   * @internal
+   *
+   * This feature is experimental and should NOT be considered ready for
+   * production use. It may change or be removed without notice and is not
+   * subject to backwards compatibility guarantees.
+   *
+   * Sets the connection mode for the SDK's data system.
+   *
+   * When the FDv2 data system is enabled (`dataSystem` option), this method
+   * accepts FDv2 connection modes (`'streaming'`, `'polling'`, `'offline'`,
+   * `'one-shot'`, `'background'`). Pass `undefined` to clear an explicit
+   * override and return to automatic mode selection.
+   *
+   * Without FDv2, this method accepts FDv1 connection modes
+   * (`'streaming'`, `'polling'`, `'offline'`).
+   *
+   * @param mode The connection mode to use, or `undefined` to clear the
+   *   override (FDv2 only).
+   */
+  async setConnectionMode(mode?: ConnectionMode | FDv2ConnectionMode): Promise<void> {
+    if (this._connectionManager) {
+      // FDv1 path
+      if (mode === undefined || mode === 'one-shot' || mode === 'background') {
+        this.logger.warn(
+          `setConnectionMode('${mode}') is only supported with the FDv2 data system (dataSystem option).`,
+        );
+        return;
+      }
+      this._connectionManager.setConnectionMode(mode as ConnectionMode);
+      this._connectionManager.setOffline(mode === 'offline');
+    } else {
+      // FDv2 path
+      if (mode !== undefined && !(mode in MODE_TABLE)) {
+        this.logger.warn(
+          `setConnectionMode called with invalid mode '${mode}'. ` +
+            `Valid modes: ${Object.keys(MODE_TABLE).join(', ')}.`,
+        );
+        return;
+      }
+      (this.dataManager as FDv2DataManagerControl).setConnectionMode(
+        mode as FDv2ConnectionMode | undefined,
+      );
+    }
   }
 
   /**
    * Gets the SDK connection mode.
    */
-  getConnectionMode(): ConnectionMode {
-    const dataManager = this.dataManager as MobileDataManager;
-    return dataManager.getConnectionMode();
+  getConnectionMode(): ConnectionMode | FDv2ConnectionMode {
+    if (this._connectionManager) {
+      return (this.dataManager as MobileDataManager).getConnectionMode();
+    }
+    return (this.dataManager as FDv2DataManagerControl).getCurrentMode();
   }
 
   isOffline() {
-    const dataManager = this.dataManager as MobileDataManager;
-    return dataManager.getConnectionMode() === 'offline';
+    if (this._connectionManager) {
+      return (this.dataManager as MobileDataManager).getConnectionMode() === 'offline';
+    }
+    return (this.dataManager as FDv2DataManagerControl).getCurrentMode() === 'offline';
   }
 }

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -202,25 +202,29 @@ export default class ReactNativeLDClient extends LDClientImpl {
   }
 
   /**
+   * Sets the SDK connection mode.
+   *
+   * @param mode The connection mode to use (`'streaming'`, `'polling'`, or `'offline'`).
+   */
+  async setConnectionMode(mode: ConnectionMode): Promise<void>;
+  /**
    * @internal
    *
-   * This feature is experimental and should NOT be considered ready for
+   * This overload is experimental and should NOT be considered ready for
    * production use. It may change or be removed without notice and is not
    * subject to backwards compatibility guarantees.
    *
-   * Sets the connection mode for the SDK's data system.
+   * Sets the connection mode for the FDv2 data system.
    *
    * When the FDv2 data system is enabled (`dataSystem` option), this method
-   * accepts FDv2 connection modes (`'streaming'`, `'polling'`, `'offline'`,
-   * `'one-shot'`, `'background'`). Pass `undefined` to clear an explicit
-   * override and return to automatic mode selection.
-   *
-   * Without FDv2, this method accepts FDv1 connection modes
-   * (`'streaming'`, `'polling'`, `'offline'`).
+   * additionally accepts `'one-shot'` and `'background'` modes. Pass
+   * `undefined` to clear an explicit override and return to automatic mode
+   * selection.
    *
    * @param mode The connection mode to use, or `undefined` to clear the
    *   override (FDv2 only).
    */
+  async setConnectionMode(mode?: FDv2ConnectionMode): Promise<void>;
   async setConnectionMode(mode?: ConnectionMode | FDv2ConnectionMode): Promise<void> {
     if (this._connectionManager) {
       // FDv1 path
@@ -250,6 +254,11 @@ export default class ReactNativeLDClient extends LDClientImpl {
   /**
    * Gets the SDK connection mode.
    */
+  getConnectionMode(): ConnectionMode;
+  /**
+   * @internal
+   */
+  getConnectionMode(): FDv2ConnectionMode;
   getConnectionMode(): ConnectionMode | FDv2ConnectionMode {
     if (this._connectionManager) {
       return (this.dataManager as MobileDataManager).getConnectionMode();

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -10,6 +10,7 @@ import {
   type FDv2DataManagerControl,
   FlagManager,
   internal,
+  type LDClientDataSystemOptions,
   LDClientImpl,
   LDClientInternalOptions,
   LDEmitter,
@@ -47,8 +48,33 @@ import RNStateDetector from './RNStateDetector';
  * </LDProvider>
  * ```
  */
+function shouldAutoSwitchLifecycle(
+  config: LDClientDataSystemOptions['automaticModeSwitching'],
+): boolean {
+  if (config === true) {
+    return true;
+  }
+  if (typeof config === 'object' && config.type === 'automatic') {
+    return config.lifecycle ?? true;
+  }
+  return false;
+}
+
+function shouldAutoSwitchNetwork(
+  config: LDClientDataSystemOptions['automaticModeSwitching'],
+): boolean {
+  if (config === true) {
+    return true;
+  }
+  if (typeof config === 'object' && config.type === 'automatic') {
+    return config.network ?? true;
+  }
+  return false;
+}
+
 export default class ReactNativeLDClient extends LDClientImpl {
   private _connectionManager?: ConnectionManager;
+  private _stateDetector?: RNStateDetector;
 
   /**
    * Creates an instance of the LaunchDarkly client.
@@ -142,10 +168,13 @@ export default class ReactNativeLDClient extends LDClientImpl {
       this.setEventSendingEnabled(true, false);
       fdv2DataManager.setFlushCallback(() => this.flush());
 
-      // Wire state detection directly to FDv2 data manager.
+      // Wire state detection directly to FDv2 data manager using the
+      // validated automaticModeSwitching config from the data system.
+      const { automaticModeSwitching } = this.dataSystemConfig ?? {};
       const stateDetector = new RNStateDetector();
+      this._stateDetector = stateDetector;
 
-      if (validatedRnOptions.automaticBackgroundHandling) {
+      if (shouldAutoSwitchLifecycle(automaticModeSwitching)) {
         stateDetector.setApplicationStateListener((state) => {
           fdv2DataManager.setLifecycleState(
             state === ApplicationState.Foreground ? 'foreground' : 'background',
@@ -153,7 +182,7 @@ export default class ReactNativeLDClient extends LDClientImpl {
         });
       }
 
-      if (validatedRnOptions.automaticNetworkHandling) {
+      if (shouldAutoSwitchNetwork(automaticModeSwitching)) {
         stateDetector.setNetworkStateListener((state) => {
           fdv2DataManager.setNetworkState(
             state === NetworkState.Available ? 'available' : 'unavailable',
@@ -196,6 +225,12 @@ export default class ReactNativeLDClient extends LDClientImpl {
       this,
       validatedRnOptions.plugins,
     );
+  }
+
+  override async close(): Promise<void> {
+    this._stateDetector?.stopListening();
+    this._connectionManager?.close();
+    return super.close();
   }
 
   /**

--- a/packages/sdk/react-native/src/index.ts
+++ b/packages/sdk/react-native/src/index.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 import ReactNativeLDClient from './ReactNativeLDClient';
-import RNOptions, { RNStorage } from './RNOptions';
+import RNOptions, { RNDataSystemOptions, RNStorage } from './RNOptions';
 
 export * from '@launchdarkly/js-client-sdk-common';
 
@@ -21,4 +21,4 @@ export type {
   LDEvaluationDetail,
 } from './hooks/variation/LDEvaluationDetail';
 
-export { ReactNativeLDClient, RNOptions as LDOptions, RNStorage };
+export { ReactNativeLDClient, RNOptions as LDOptions, RNDataSystemOptions, RNStorage };

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -83,6 +83,7 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
   private _eventSendingEnabled: boolean = false;
   private _baseHeaders: LDHeaders;
   protected dataManager: DataManager;
+  protected readonly isFDv2: boolean;
   protected readonly environmentMetadata: LDPluginEnvironmentMetadata;
   private _hookRunner: HookRunner;
   private _inspectorManager: InspectorManager;
@@ -161,6 +162,7 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
       this.emitter,
       this._diagnosticsManager,
     );
+    this.isFDv2 = !!this._config.dataSystem;
 
     const hooks: Hook[] = [...this._config.hooks];
 

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -45,6 +45,7 @@ import {
 } from './context/createActiveContextTracker';
 import { ensureKey } from './context/ensureKey';
 import { DataManager, DataManagerFactory } from './DataManager';
+import type { InternalDataSystemOptions } from './datasource/LDClientDataSystemOptions';
 import createDiagnosticsManager from './diagnostics/createDiagnosticsManager';
 import {
   createErrorEvaluationDetail,
@@ -84,6 +85,7 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
   private _baseHeaders: LDHeaders;
   protected dataManager: DataManager;
   protected readonly isFDv2: boolean;
+  protected readonly dataSystemConfig?: InternalDataSystemOptions;
   protected readonly environmentMetadata: LDPluginEnvironmentMetadata;
   private _hookRunner: HookRunner;
   private _inspectorManager: InspectorManager;
@@ -163,6 +165,7 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
       this._diagnosticsManager,
     );
     this.isFDv2 = !!this._config.dataSystem;
+    this.dataSystemConfig = this._config.dataSystem;
 
     const hooks: Hook[] = [...this._config.hooks];
 


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an alternative flag-delivery/data-connection path (FDv2) with new lifecycle/network-driven mode switching and expanded connection modes, which could impact online/offline behavior and resource cleanup.
> 
> **Overview**
> **Adds experimental FDv2 support** to the React Native SDK via a new `dataSystem` option (`RNDataSystemOptions`) and exports it from `index.ts`.
> 
> `ReactNativeLDClient` now conditionally instantiates an FDv2 data manager (otherwise keeps the existing `MobileDataManager`/`ConnectionManager` flow), wires lifecycle/network state changes directly into FDv2 automatic mode switching, and updates `setConnectionMode`/`getConnectionMode` to support FDv2-only modes (`one-shot`, `background`, and clearing overrides).
> 
> Improves shutdown behavior by stopping state listeners and closing the connection manager in an overridden `close()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3283ecd6cb85cbaaf6fee15430e14b4f224873b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
