### PR TITLE
feat: add scoped clients to server sdks

### DIFF
--- a/packages/sdk/react/__tests__/server/createLDServerSession.test.ts
+++ b/packages/sdk/react/__tests__/server/createLDServerSession.test.ts
@@ -150,6 +150,58 @@ it('allFlagsState() forwards options to base client', async () => {
   expect(client.allFlagsState).toHaveBeenCalledWith(context, options);
 });
 
+describe('given a client with forContext', () => {
+  function makeMockScopedBaseClient() {
+    const base = makeMockBaseClient();
+    const forContext = jest.fn((ctx: LDContext) => ({
+      currentContext: () => ctx,
+      boolVariation: (key: string, def: boolean) => base.boolVariation(key, ctx, def),
+      numberVariation: (key: string, def: number) => base.numberVariation(key, ctx, def),
+      stringVariation: (key: string, def: string) => base.stringVariation(key, ctx, def),
+      jsonVariation: (key: string, def: unknown) => base.jsonVariation(key, ctx, def),
+      boolVariationDetail: (key: string, def: boolean) => base.boolVariationDetail(key, ctx, def),
+      numberVariationDetail: (key: string, def: number) =>
+        base.numberVariationDetail(key, ctx, def),
+      stringVariationDetail: (key: string, def: string) =>
+        base.stringVariationDetail(key, ctx, def),
+      jsonVariationDetail: (key: string, def: unknown) => base.jsonVariationDetail(key, ctx, def),
+      allFlagsState: (options?: LDFlagsStateOptions) => base.allFlagsState(ctx, options),
+    }));
+    return { ...base, forContext } as any;
+  }
+
+  it('uses forContext when available', () => {
+    const client = makeMockScopedBaseClient();
+    createLDServerSession(client, context);
+    expect(client.forContext).toHaveBeenCalledWith(context, {
+      wrapperName: 'react-client-sdk',
+      wrapperVersion: '0.0.0',
+    });
+  });
+
+  it('delegates boolVariation through scoped client', async () => {
+    const client = makeMockScopedBaseClient();
+    client.boolVariation.mockResolvedValue(true);
+    const session = createLDServerSession(client, context);
+    const result = await session.boolVariation('my-flag', false);
+    expect(result).toBe(true);
+    expect(client.boolVariation).toHaveBeenCalledWith('my-flag', context, false);
+  });
+
+  it('getContext() returns the scoped client currentContext', () => {
+    const client = makeMockScopedBaseClient();
+    const session = createLDServerSession(client, context);
+    expect(session.getContext()).toEqual(context);
+  });
+
+  it('initialized() delegates to the base client', () => {
+    const client = makeMockScopedBaseClient();
+    client.initialized.mockReturnValue(false);
+    const session = createLDServerSession(client, context);
+    expect(session.initialized()).toBe(false);
+  });
+});
+
 describe('given a browser environment (window defined)', () => {
   let originalWindow: typeof globalThis.window;
 

--- a/packages/sdk/react/src/server/LDServerBaseClient.ts
+++ b/packages/sdk/react/src/server/LDServerBaseClient.ts
@@ -3,6 +3,8 @@ import {
   LDEvaluationDetailTyped,
   LDFlagsState,
   LDFlagsStateOptions,
+  LDScopedClient,
+  LDScopedClientOptions,
 } from '@launchdarkly/js-server-sdk-common';
 
 /**
@@ -88,4 +90,14 @@ export interface LDServerBaseClient {
    * Builds an object encapsulating the state of all feature flags for a given context.
    */
   allFlagsState(context: LDContext, options?: LDFlagsStateOptions): Promise<LDFlagsState>;
+
+  /**
+   * Creates a scoped client bound to the given evaluation context.
+   *
+   * @remarks
+   * When present, {@link createLDServerSession} will delegate to the scoped client
+   * instead of manually wrapping each method. Clients that do not implement this
+   * method (e.g., edge SDKs) fall back to the manual wrapping behavior.
+   */
+  forContext?(context: LDContext, options?: LDScopedClientOptions): LDScopedClient;
 }

--- a/packages/sdk/react/src/server/LDServerSession.ts
+++ b/packages/sdk/react/src/server/LDServerSession.ts
@@ -53,6 +53,27 @@ export function createLDServerWrapper(
     );
   }
 
+  if (client.forContext) {
+    const scoped = client.forContext(context, {
+      wrapperName: 'react-client-sdk',
+      wrapperVersion: '0.0.0', // x-release-please-version
+    });
+    return {
+      initialized: () => client.initialized(),
+      getContext: () => scoped.currentContext(),
+      boolVariation: scoped.boolVariation,
+      numberVariation: scoped.numberVariation,
+      stringVariation: scoped.stringVariation,
+      jsonVariation: scoped.jsonVariation,
+      boolVariationDetail: scoped.boolVariationDetail,
+      numberVariationDetail: scoped.numberVariationDetail,
+      stringVariationDetail: scoped.stringVariationDetail,
+      jsonVariationDetail: scoped.jsonVariationDetail,
+      allFlagsState: scoped.allFlagsState,
+    };
+  }
+
+  // Fallback for clients without forContext (e.g., edge SDKs)
   return {
     initialized: () => client.initialized(),
     getContext: () => context,

--- a/packages/shared/common/src/internal/events/EventProcessor.ts
+++ b/packages/shared/common/src/internal/events/EventProcessor.ts
@@ -205,6 +205,17 @@ export default class EventProcessor implements LDEventProcessor {
     this._eventSender.sendEventData(LDEventType.DiagnosticEvent, event);
   }
 
+  sendScopedClientDiagnosticEvent(wrapperName: string, wrapperVersion?: string): void {
+    if (!this._diagnosticsManager) {
+      return;
+    }
+    const event = this._diagnosticsManager.createInitEvent();
+    event.sdk.wrapperName = wrapperName;
+    event.sdk.wrapperVersion = wrapperVersion;
+    event.creationDate = Date.now();
+    this._postDiagnosticEvent(event);
+  }
+
   close() {
     clearInterval(this._flushTimer);
     if (this._flushUsersTimer) {

--- a/packages/shared/sdk-server/__tests__/LDScopedClient.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDScopedClient.test.ts
@@ -1,0 +1,607 @@
+import { LDSingleKindContext } from '@launchdarkly/js-sdk-common';
+
+import { LDClientImpl } from '../src';
+import { LDClient, LDMigrationStage, LDScopedClient } from '../src/api';
+import createScopedClient from '../src/createScopedClient';
+import TestData from '../src/integrations/test_data/TestData';
+import { createBasicPlatform } from './createBasicPlatform';
+import TestLogger, { LogLevel } from './Logger';
+import makeCallbacks from './makeCallbacks';
+
+function createMockClient(overrides?: Partial<LDClient>): LDClient {
+  return {
+    initialized: jest.fn(() => true),
+    waitForInitialization: jest.fn(),
+    variation: jest.fn(async () => 'value'),
+    variationDetail: jest.fn(async () => ({
+      value: 'value',
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    })),
+    boolVariation: jest.fn(async () => true),
+    numberVariation: jest.fn(async () => 42),
+    stringVariation: jest.fn(async () => 'hello'),
+    jsonVariation: jest.fn(async () => ({ key: 'value' })),
+    boolVariationDetail: jest.fn(async () => ({
+      value: true,
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    })),
+    numberVariationDetail: jest.fn(async () => ({
+      value: 42,
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    })),
+    stringVariationDetail: jest.fn(async () => ({
+      value: 'hello',
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    })),
+    jsonVariationDetail: jest.fn(async () => ({
+      value: { key: 'value' },
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    })),
+    migrationVariation: jest.fn(async () => ({
+      value: 'off' as LDMigrationStage,
+      tracker: {} as any,
+    })),
+    allFlagsState: jest.fn(async () => ({
+      valid: true,
+      toJSON: () => ({}),
+      allValues: () => ({}),
+      getFlagValue: () => null,
+      getFlagReason: () => null,
+    })) as any,
+    track: jest.fn(),
+    trackMigration: jest.fn(),
+    identify: jest.fn(),
+    flush: jest.fn(async () => {}),
+    close: jest.fn(),
+    isOffline: jest.fn(() => false),
+    secureModeHash: jest.fn(() => 'hash'),
+    forContext: jest.fn(),
+    addHook: jest.fn(),
+    get logger() {
+      return (
+        overrides?.logger ??
+        ({
+          error: jest.fn(),
+          warn: jest.fn(),
+          info: jest.fn(),
+          debug: jest.fn(),
+        } as any)
+      );
+    },
+    ...overrides,
+  } as LDClient;
+}
+
+describe('LDScopedClient via LDClientImpl', () => {
+  let client: LDClientImpl;
+  let td: TestData;
+
+  beforeEach(async () => {
+    td = new TestData();
+    client = new LDClientImpl(
+      'sdk-key-scoped-client-test',
+      createBasicPlatform(),
+      {
+        updateProcessor: td.getFactory(),
+        sendEvents: false,
+      },
+      makeCallbacks(true),
+    );
+    await client.waitForInitialization({ timeout: 10 });
+  });
+
+  afterEach(() => {
+    client.close();
+  });
+
+  describe('context initialization', () => {
+    it('initializes from a single-kind context', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1', name: 'Alice' });
+      const ctx = scoped.currentContext() as LDSingleKindContext;
+
+      expect(ctx.kind).toBe('user');
+      expect(ctx.key).toBe('user-1');
+      expect(ctx.name).toBe('Alice');
+    });
+
+    it('initializes from a multi-kind context', () => {
+      const scoped = client.forContext({
+        kind: 'multi',
+        user: { key: 'user-1', name: 'Alice' },
+        org: { key: 'org-1', name: 'Acme' },
+      });
+      const ctx = scoped.currentContext();
+
+      expect(ctx).toEqual({
+        kind: 'multi',
+        user: { key: 'user-1', name: 'Alice' },
+        org: { key: 'org-1', name: 'Acme' },
+      });
+    });
+
+    it('logs a warning when created with an invalid context', () => {
+      const logger = new TestLogger();
+      const logClient = new LDClientImpl(
+        'sdk-key-scoped-invalid-ctx-test',
+        createBasicPlatform(),
+        {
+          updateProcessor: td.getFactory(),
+          sendEvents: false,
+          logger,
+        },
+        makeCallbacks(true),
+      );
+
+      // @ts-ignore — intentionally passing invalid context
+      logClient.forContext(null);
+
+      logger.expectMessages([{ level: LogLevel.Warn, matches: /invalid context/ }]);
+
+      logClient.close();
+    });
+  });
+
+  describe('addContext', () => {
+    it('adds a new context kind', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      scoped.addContext({ kind: 'org', key: 'org-1', name: 'Acme' });
+
+      const ctx = scoped.currentContext();
+      expect(ctx).toEqual({
+        kind: 'multi',
+        user: { key: 'user-1' },
+        org: { key: 'org-1', name: 'Acme' },
+      });
+    });
+
+    it('rejects a duplicate context kind with a warning', () => {
+      const logger = new TestLogger();
+      const logClient = new LDClientImpl(
+        'sdk-key-scoped-logger-test',
+        createBasicPlatform(),
+        {
+          updateProcessor: td.getFactory(),
+          sendEvents: false,
+          logger,
+        },
+        makeCallbacks(true),
+      );
+
+      const scoped = logClient.forContext({ kind: 'user', key: 'user-1', name: 'Alice' });
+      scoped.addContext({ kind: 'user', key: 'user-2', name: 'Bob' });
+
+      // Original context should be preserved
+      const ctx = scoped.currentContext() as LDSingleKindContext;
+      expect(ctx.key).toBe('user-1');
+      expect(ctx.name).toBe('Alice');
+
+      // Warning should have been logged
+      expect(logger.getCount(LogLevel.Warn)).toBe(1);
+      logger.expectMessages([
+        { level: LogLevel.Warn, matches: /Tried to add a duplicate user context to scoped client/ },
+      ]);
+
+      logClient.close();
+    });
+  });
+
+  describe('overwriteContextByKind', () => {
+    it('replaces an existing context kind', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1', name: 'Alice' });
+      scoped.overwriteContextByKind({ kind: 'user', key: 'user-2', name: 'Bob' });
+
+      const ctx = scoped.currentContext() as LDSingleKindContext;
+      expect(ctx.kind).toBe('user');
+      expect(ctx.key).toBe('user-2');
+      expect(ctx.name).toBe('Bob');
+    });
+
+    it('adds a new kind if it does not exist', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      scoped.overwriteContextByKind({ kind: 'org', key: 'org-1' });
+
+      const ctx = scoped.currentContext();
+      expect(ctx).toEqual({
+        kind: 'multi',
+        user: { key: 'user-1' },
+        org: { key: 'org-1' },
+      });
+    });
+  });
+
+  describe('chaining', () => {
+    it('supports chaining addContext calls', () => {
+      const scoped = client
+        .forContext({ kind: 'user', key: 'user-1' })
+        .addContext({ kind: 'org', key: 'org-1' })
+        .addContext({ kind: 'device', key: 'device-1' });
+
+      const ctx = scoped.currentContext();
+      expect((ctx as any).kind).toBe('multi');
+      expect((ctx as any).user).toEqual({ key: 'user-1' });
+      expect((ctx as any).org).toEqual({ key: 'org-1' });
+      expect((ctx as any).device).toEqual({ key: 'device-1' });
+    });
+
+    it('supports chaining overwriteContextByKind', () => {
+      const scoped = client
+        .forContext({ kind: 'user', key: 'user-1' })
+        .overwriteContextByKind({ kind: 'user', key: 'user-2' });
+
+      const ctx = scoped.currentContext() as LDSingleKindContext;
+      expect(ctx.key).toBe('user-2');
+    });
+
+    it('supports mixed chaining', () => {
+      const scoped = client
+        .forContext({ kind: 'user', key: 'user-1' })
+        .addContext({ kind: 'org', key: 'org-1' })
+        .overwriteContextByKind({ kind: 'user', key: 'user-2' });
+
+      const ctx = scoped.currentContext();
+      expect((ctx as any).user).toEqual({ key: 'user-2' });
+      expect((ctx as any).org).toEqual({ key: 'org-1' });
+    });
+  });
+
+  describe('currentContext', () => {
+    it('returns a single-kind context when only one kind exists', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      const ctx = scoped.currentContext() as LDSingleKindContext;
+
+      expect(ctx.kind).toBe('user');
+      expect(ctx.key).toBe('user-1');
+    });
+
+    it('returns a multi-kind context when multiple kinds exist', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      scoped.addContext({ kind: 'org', key: 'org-1' });
+      scoped.addContext({ kind: 'device', key: 'device-1' });
+
+      const ctx = scoped.currentContext();
+      expect((ctx as any).kind).toBe('multi');
+      expect((ctx as any).user).toEqual({ key: 'user-1' });
+      expect((ctx as any).org).toEqual({ key: 'org-1' });
+      expect((ctx as any).device).toEqual({ key: 'device-1' });
+    });
+
+    it('reflects the context at time of call', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      const ctx1 = scoped.currentContext();
+
+      scoped.addContext({ kind: 'org', key: 'org-1' });
+      const ctx2 = scoped.currentContext();
+
+      expect((ctx1 as LDSingleKindContext).kind).toBe('user');
+      expect((ctx2 as any).kind).toBe('multi');
+    });
+  });
+
+  describe('variation delegation', () => {
+    it('evaluates a flag using the accumulated context', async () => {
+      await td.update(td.flag('test-flag').booleanFlag().variationForAll(true));
+
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      const result = await scoped.boolVariation('test-flag', false);
+
+      expect(result).toBe(true);
+    });
+
+    it('evaluates with context added after creation', async () => {
+      await td.update(td.flag('test-flag').booleanFlag().variationForAll(true));
+
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      scoped.addContext({ kind: 'org', key: 'org-1' });
+
+      const result = await scoped.boolVariation('test-flag', false);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('client accessor', () => {
+    it('returns the base client', () => {
+      const scoped = client.forContext({ kind: 'user', key: 'user-1' });
+      expect(scoped.client).toBe(client);
+    });
+  });
+
+  describe('independence', () => {
+    it('scoped clients from the same base are independent', () => {
+      const scoped1 = client.forContext({ kind: 'user', key: 'user-1' });
+      const scoped2 = client.forContext({ kind: 'user', key: 'user-2' });
+
+      scoped1.addContext({ kind: 'org', key: 'org-1' });
+
+      // scoped2 should NOT have the org context
+      const ctx2 = scoped2.currentContext() as LDSingleKindContext;
+      expect(ctx2.kind).toBe('user');
+      expect(ctx2.key).toBe('user-2');
+      expect((ctx2 as any).org).toBeUndefined();
+    });
+  });
+});
+
+// Test delegation via mock client for precise argument verification
+describe('LDScopedClient delegation', () => {
+  let mockClient: LDClient;
+  let scoped: LDScopedClient;
+  const userContext: LDSingleKindContext = { kind: 'user', key: 'user-1' };
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    scoped = createScopedClient(mockClient, userContext);
+  });
+
+  describe('variation methods', () => {
+    it('delegates variation with currentContext', async () => {
+      await scoped.variation('flag', 'default');
+      expect(mockClient.variation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        'default',
+      );
+    });
+
+    it('delegates variationDetail with currentContext', async () => {
+      await scoped.variationDetail('flag', 'default');
+      expect(mockClient.variationDetail).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        'default',
+      );
+    });
+
+    it('delegates boolVariation with currentContext', async () => {
+      await scoped.boolVariation('flag', false);
+      expect(mockClient.boolVariation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        false,
+      );
+    });
+
+    it('delegates numberVariation with currentContext', async () => {
+      await scoped.numberVariation('flag', 0);
+      expect(mockClient.numberVariation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        0,
+      );
+    });
+
+    it('delegates stringVariation with currentContext', async () => {
+      await scoped.stringVariation('flag', '');
+      expect(mockClient.stringVariation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        '',
+      );
+    });
+
+    it('delegates jsonVariation with currentContext', async () => {
+      await scoped.jsonVariation('flag', null);
+      expect(mockClient.jsonVariation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        null,
+      );
+    });
+
+    it('delegates boolVariationDetail with currentContext', async () => {
+      await scoped.boolVariationDetail('flag', false);
+      expect(mockClient.boolVariationDetail).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        false,
+      );
+    });
+
+    it('delegates numberVariationDetail with currentContext', async () => {
+      await scoped.numberVariationDetail('flag', 0);
+      expect(mockClient.numberVariationDetail).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        0,
+      );
+    });
+
+    it('delegates stringVariationDetail with currentContext', async () => {
+      await scoped.stringVariationDetail('flag', '');
+      expect(mockClient.stringVariationDetail).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        '',
+      );
+    });
+
+    it('delegates jsonVariationDetail with currentContext', async () => {
+      await scoped.jsonVariationDetail('flag', null);
+      expect(mockClient.jsonVariationDetail).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        null,
+      );
+    });
+
+    it('delegates migrationVariation with currentContext', async () => {
+      await scoped.migrationVariation('flag', LDMigrationStage.Off);
+      expect(mockClient.migrationVariation).toHaveBeenCalledWith(
+        'flag',
+        { kind: 'user', key: 'user-1' },
+        LDMigrationStage.Off,
+      );
+    });
+  });
+
+  describe('flags state', () => {
+    it('delegates allFlagsState with currentContext', async () => {
+      await scoped.allFlagsState({ clientSideOnly: true });
+      expect(mockClient.allFlagsState).toHaveBeenCalledWith(
+        { kind: 'user', key: 'user-1' },
+        { clientSideOnly: true },
+      );
+    });
+  });
+
+  describe('track methods', () => {
+    it('delegates track with currentContext', () => {
+      scoped.track('event-key');
+      expect(mockClient.track).toHaveBeenCalledWith('event-key', { kind: 'user', key: 'user-1' });
+    });
+
+    it('delegates trackData with currentContext and data', () => {
+      scoped.trackData('event-key', { info: 'data' });
+      expect(mockClient.track).toHaveBeenCalledWith(
+        'event-key',
+        { kind: 'user', key: 'user-1' },
+        { info: 'data' },
+      );
+    });
+
+    it('delegates trackMetric with currentContext, metric value, and optional data', () => {
+      scoped.trackMetric('event-key', 42, { info: 'data' });
+      expect(mockClient.track).toHaveBeenCalledWith(
+        'event-key',
+        { kind: 'user', key: 'user-1' },
+        { info: 'data' },
+        42,
+      );
+    });
+
+    it('delegates trackMetric without data', () => {
+      scoped.trackMetric('event-key', 42);
+      expect(mockClient.track).toHaveBeenCalledWith(
+        'event-key',
+        { kind: 'user', key: 'user-1' },
+        undefined,
+        42,
+      );
+    });
+
+    it('delegates trackMigration', () => {
+      const event = { kind: 'migration_op' } as any;
+      scoped.trackMigration(event);
+      expect(mockClient.trackMigration).toHaveBeenCalledWith(event);
+    });
+
+    it('uses the context at time of track call', () => {
+      const sc = createScopedClient(mockClient, { kind: 'user', key: 'user-1' });
+
+      sc.addContext({ kind: 'org', key: 'org-1' });
+      sc.track('event-key');
+
+      expect(mockClient.track).toHaveBeenCalledWith('event-key', {
+        kind: 'multi',
+        user: { key: 'user-1' },
+        org: { key: 'org-1' },
+      });
+    });
+  });
+
+  describe('does not expose lifecycle methods', () => {
+    it('does not have close method', () => {
+      expect((scoped as any).close).toBeUndefined();
+    });
+
+    it('does not have flush method', () => {
+      expect((scoped as any).flush).toBeUndefined();
+    });
+
+    it('does not have initialized method', () => {
+      expect((scoped as any).initialized).toBeUndefined();
+    });
+  });
+});
+
+describe('wrapper diagnostic reporting', () => {
+  let client: LDClientImpl;
+  let sendScopedClientDiagnosticEvent: jest.SpyInstance;
+  let td: TestData;
+
+  beforeEach(async () => {
+    td = new TestData();
+    client = new LDClientImpl(
+      'sdk-key-wrapper-test',
+      createBasicPlatform(),
+      {
+        updateProcessor: td.getFactory(),
+        sendEvents: true,
+      },
+      makeCallbacks(true),
+    );
+    await client.waitForInitialization({ timeout: 10 });
+
+    // eslint-disable-next-line no-underscore-dangle
+    const ep = (client as any)._eventProcessor;
+    sendScopedClientDiagnosticEvent = jest.spyOn(ep, 'sendScopedClientDiagnosticEvent');
+  });
+
+  afterEach(() => {
+    client.close();
+  });
+
+  it('sends a diagnostic-init event immediately on forContext', () => {
+    client.forContext(
+      { kind: 'user', key: 'user-1' },
+      { wrapperName: 'test-wrapper', wrapperVersion: '1.0.0' },
+    );
+
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenCalledTimes(1);
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenCalledWith('test-wrapper', '1.0.0');
+  });
+
+  it('deduplicates by (wrapperName, wrapperVersion) tuple', () => {
+    client.forContext({ kind: 'user', key: 'user-1' }, { wrapperName: 'w', wrapperVersion: '1.0' });
+    client.forContext({ kind: 'user', key: 'user-2' }, { wrapperName: 'w', wrapperVersion: '1.0' });
+    client.forContext({ kind: 'user', key: 'user-3' }, { wrapperName: 'w', wrapperVersion: '1.0' });
+
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats different versions as distinct identities', () => {
+    client.forContext({ kind: 'user', key: 'user-1' }, { wrapperName: 'w', wrapperVersion: '1.0' });
+    client.forContext({ kind: 'user', key: 'user-2' }, { wrapperName: 'w', wrapperVersion: '2.0' });
+
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenCalledTimes(2);
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenNthCalledWith(1, 'w', '1.0');
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenNthCalledWith(2, 'w', '2.0');
+  });
+
+  it('treats name with version vs name without version as distinct', () => {
+    client.forContext({ kind: 'user', key: 'user-1' }, { wrapperName: 'w', wrapperVersion: '1.0' });
+    client.forContext({ kind: 'user', key: 'user-2' }, { wrapperName: 'w' });
+
+    expect(sendScopedClientDiagnosticEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not send a diagnostic event without wrapperName', () => {
+    client.forContext({ kind: 'user', key: 'user-1' });
+    client.forContext({ kind: 'user', key: 'user-2' }, {});
+    client.forContext({ kind: 'user', key: 'user-3' }, { wrapperVersion: '1.0.0' });
+
+    expect(sendScopedClientDiagnosticEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not send when events are disabled', async () => {
+    const noEventsClient = new LDClientImpl(
+      'sdk-key-no-events',
+      createBasicPlatform(),
+      {
+        updateProcessor: td.getFactory(),
+        sendEvents: false,
+      },
+      makeCallbacks(true),
+    );
+    await noEventsClient.waitForInitialization({ timeout: 10 });
+
+    noEventsClient.forContext({ kind: 'user', key: 'user-1' }, { wrapperName: 'test-wrapper' });
+
+    // No crash, no event sent (NullEventProcessor, instanceof check fails)
+    noEventsClient.close();
+  });
+});

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -28,6 +28,8 @@ import {
   LDMigrationStage,
   LDMigrationVariation,
   LDOptions,
+  LDScopedClient,
+  LDScopedClientOptions,
   LDTransactionalFeatureStore,
 } from './api';
 import { Hook } from './api/integrations/Hook';
@@ -42,6 +44,7 @@ import {
 import BigSegmentsManager from './BigSegmentsManager';
 import BigSegmentStoreStatusProvider from './BigSegmentStatusProviderImpl';
 import { createPluginEnvironmentMetadata } from './createPluginEnvironmentMetadata';
+import createScopedClient from './createScopedClient';
 import { createPayloadListener } from './data_sources/createPayloadListenerFDv2';
 import { createStreamListeners } from './data_sources/createStreamListeners';
 import DataSourceUpdates from './data_sources/DataSourceUpdates';
@@ -486,6 +489,8 @@ export default class LDClientImpl implements LDClient {
   private _updateProcessor?: subsystem.LDStreamProcessor;
 
   private _dataSource?: subsystem.DataSource;
+
+  private _reportedWrapperIdentities = new Map<string, Set<string>>();
 
   private _eventFactoryDefault = new EventFactory(false);
 
@@ -1160,6 +1165,28 @@ export default class LDClientImpl implements LDClient {
 
   addHook(hook: Hook): void {
     this._hookRunner.addHook(hook);
+  }
+
+  forContext(context: LDContext, options?: LDScopedClientOptions): LDScopedClient {
+    if (options?.wrapperName) {
+      const version = options.wrapperVersion ?? '';
+      const reportedVersions = this._reportedWrapperIdentities.get(options.wrapperName);
+      if (!reportedVersions?.has(version)) {
+        if (!reportedVersions) {
+          this._reportedWrapperIdentities.set(options.wrapperName, new Set([version]));
+        } else {
+          reportedVersions.add(version);
+        }
+        this._sendWrapperDiagnosticEvent(options.wrapperName, options.wrapperVersion);
+      }
+    }
+    return createScopedClient(this, context);
+  }
+
+  private _sendWrapperDiagnosticEvent(wrapperName: string, wrapperVersion?: string): void {
+    if (this._eventProcessor instanceof internal.EventProcessor) {
+      this._eventProcessor.sendScopedClientDiagnosticEvent(wrapperName, wrapperVersion);
+    }
   }
 
   private _variationInternal(

--- a/packages/shared/sdk-server/src/api/LDClient.ts
+++ b/packages/shared/sdk-server/src/api/LDClient.ts
@@ -6,11 +6,12 @@ import {
   LDLogger,
 } from '@launchdarkly/js-sdk-common';
 
-import { LDMigrationOpEvent, LDMigrationVariation } from './data';
+import { LDMigrationOpEvent, LDMigrationVariation, LDScopedClientOptions } from './data';
 import { LDFlagsState } from './data/LDFlagsState';
 import { LDFlagsStateOptions } from './data/LDFlagsStateOptions';
 import { LDMigrationStage } from './data/LDMigrationStage';
 import { Hook } from './integrations/Hook';
+import { LDScopedClient } from './LDScopedClient';
 import { LDWaitForInitializationOptions } from './LDWaitForInitializationOptions';
 
 /**
@@ -452,6 +453,21 @@ export interface LDClient {
    *   fails, so be sure to attach a rejection handler to it.
    */
   flush(callback?: (err: Error | null, res: boolean) => void): Promise<void>;
+
+  /**
+   * Creates a scoped client bound to the given evaluation context.
+   *
+   * @remarks
+   * The scoped client wraps this base client with a mutable context container,
+   * providing a client-side-like API where variation and track calls do not require
+   * a context parameter. Multiple scoped clients created from the same base client
+   * are fully independent.
+   *
+   * @param context The initial evaluation context for the scoped client.
+   * @param options Optional scoped client options for wrapper reporting.
+   * @returns A new {@link LDScopedClient} bound to the given context.
+   */
+  forContext(context: LDContext, options?: LDScopedClientOptions): LDScopedClient;
 
   /**
    * Add a hook to the client. In order to register a hook before the client

--- a/packages/shared/sdk-server/src/api/LDScopedClient.ts
+++ b/packages/shared/sdk-server/src/api/LDScopedClient.ts
@@ -1,0 +1,189 @@
+import {
+  LDContext,
+  LDEvaluationDetail,
+  LDEvaluationDetailTyped,
+  LDFlagValue,
+  LDSingleKindContext,
+} from '@launchdarkly/js-sdk-common';
+
+import { LDMigrationOpEvent, LDMigrationVariation } from './data';
+import { LDFlagsState } from './data/LDFlagsState';
+import { LDFlagsStateOptions } from './data/LDFlagsStateOptions';
+import { LDMigrationStage } from './data/LDMigrationStage';
+import type { LDClient } from './LDClient';
+
+/**
+ * A scoped client wraps a base {@link LDClient} with one or more evaluation contexts,
+ * providing a client-side-like API where variation and track calls do not require
+ * a context parameter.
+ *
+ * @remarks
+ * The scoped client maintains a mutable, additive container of contexts that can be
+ * built up incrementally as more information becomes available during a request.
+ * Context kinds can be added or overwritten, but not removed.
+ *
+ * Create a scoped client using {@link LDClient.forContext}.
+ *
+ * The scoped client is **not** an independent SDK instance — it delegates all
+ * operations to the underlying base client. Multiple scoped clients created from
+ * the same base client are fully independent.
+ */
+export interface LDScopedClient {
+  /**
+   * Adds a single-kind context to this scoped client's context container.
+   *
+   * @remarks
+   * If a context with the same kind already exists, the duplicate is rejected
+   * and a warning is logged. Use {@link overwriteContextByKind} for intentional
+   * replacement.
+   *
+   * @param context A single-kind context to add.
+   * @returns This scoped client, for chaining.
+   */
+  addContext(context: LDSingleKindContext): LDScopedClient;
+
+  /**
+   * Replaces an existing context of the same kind, or adds it if the kind
+   * does not yet exist.
+   *
+   * @remarks
+   * This is the escape hatch for updating context attributes when new information
+   * becomes available during a request lifecycle.
+   *
+   * @param context A single-kind context to set.
+   * @returns This scoped client, for chaining.
+   */
+  overwriteContextByKind(context: LDSingleKindContext): LDScopedClient;
+
+  /**
+   * Returns the evaluation context representing all contexts added to
+   * this scoped client.
+   *
+   * @returns The combined evaluation context.
+   */
+  currentContext(): LDContext;
+
+  /**
+   * The underlying base {@link LDClient}.
+   */
+  readonly client: LDClient;
+
+  /**
+   * Determines the variation of a feature flag for the current context.
+   *
+   * @param key The unique key of the feature flag.
+   * @param defaultValue The default value of the flag.
+   * @returns A Promise resolved with the result value.
+   */
+  variation(key: string, defaultValue: LDFlagValue): Promise<LDFlagValue>;
+
+  /**
+   * Determines the variation of a feature flag for the current context,
+   * along with information about how it was calculated.
+   *
+   * @param key The unique key of the feature flag.
+   * @param defaultValue The default value of the flag.
+   * @returns A Promise resolved with the evaluation detail.
+   */
+  variationDetail(key: string, defaultValue: LDFlagValue): Promise<LDEvaluationDetail>;
+
+  /**
+   * Determines the boolean variation of a feature flag for the current context.
+   */
+  boolVariation(key: string, defaultValue: boolean): Promise<boolean>;
+
+  /**
+   * Determines the numeric variation of a feature flag for the current context.
+   */
+  numberVariation(key: string, defaultValue: number): Promise<number>;
+
+  /**
+   * Determines the string variation of a feature flag for the current context.
+   */
+  stringVariation(key: string, defaultValue: string): Promise<string>;
+
+  /**
+   * Determines the JSON variation of a feature flag for the current context.
+   */
+  jsonVariation(key: string, defaultValue: unknown): Promise<unknown>;
+
+  /**
+   * Determines the boolean variation of a feature flag, along with evaluation details.
+   */
+  boolVariationDetail(
+    key: string,
+    defaultValue: boolean,
+  ): Promise<LDEvaluationDetailTyped<boolean>>;
+
+  /**
+   * Determines the numeric variation of a feature flag, along with evaluation details.
+   */
+  numberVariationDetail(
+    key: string,
+    defaultValue: number,
+  ): Promise<LDEvaluationDetailTyped<number>>;
+
+  /**
+   * Determines the string variation of a feature flag, along with evaluation details.
+   */
+  stringVariationDetail(
+    key: string,
+    defaultValue: string,
+  ): Promise<LDEvaluationDetailTyped<string>>;
+
+  /**
+   * Determines the JSON variation of a feature flag, along with evaluation details.
+   */
+  jsonVariationDetail(
+    key: string,
+    defaultValue: unknown,
+  ): Promise<LDEvaluationDetailTyped<unknown>>;
+
+  /**
+   * Returns the migration stage of the migration feature flag for the current context.
+   *
+   * @param key The unique key of the feature flag.
+   * @param defaultValue The default migration stage.
+   * @returns A Promise resolved with the migration variation.
+   */
+  migrationVariation(key: string, defaultValue: LDMigrationStage): Promise<LDMigrationVariation>;
+
+  /**
+   * Builds an object encapsulating the state of all feature flags for the current context.
+   *
+   * @param options Optional flags state options.
+   * @returns A Promise resolved with the flags state.
+   */
+  allFlagsState(options?: LDFlagsStateOptions): Promise<LDFlagsState>;
+
+  /**
+   * Tracks that the current context performed an event.
+   *
+   * @param key The name of the event.
+   */
+  track(key: string): void;
+
+  /**
+   * Tracks that the current context performed an event with additional data.
+   *
+   * @param key The name of the event.
+   * @param data Additional information to associate with the event.
+   */
+  trackData(key: string, data: any): void;
+
+  /**
+   * Tracks a numeric metric event for the current context.
+   *
+   * @param key The name of the event.
+   * @param metricValue A numeric value used by LaunchDarkly experimentation.
+   * @param data Optional additional information to associate with the event.
+   */
+  trackMetric(key: string, metricValue: number, data?: any): void;
+
+  /**
+   * Track the details of a migration.
+   *
+   * @param event Event containing information about the migration operation.
+   */
+  trackMigration(event: LDMigrationOpEvent): void;
+}

--- a/packages/shared/sdk-server/src/api/data/LDScopedClientOptions.ts
+++ b/packages/shared/sdk-server/src/api/data/LDScopedClientOptions.ts
@@ -1,0 +1,27 @@
+/**
+ * Options for creating a scoped client via {@link LDClient.forContext}.
+ *
+ * @remarks
+ * These options enable higher-level SDK wrappers built on top of scoped clients
+ * to identify themselves for wrapper reporting. If no options are provided,
+ * the scoped client behaves as a plain scoped client with no wrapper reporting.
+ */
+export interface LDScopedClientOptions {
+  /**
+   * The name of the wrapper SDK built on top of the scoped client.
+   *
+   * @remarks
+   * When provided, the SDK will emit a `diagnostic-init` event upon scoped client
+   * creation with wrapper identification. This enables LaunchDarkly to measure
+   * wrapper SDK adoption.
+   */
+  wrapperName?: string;
+
+  /**
+   * The version of the wrapper SDK.
+   *
+   * @remarks
+   * Ignored if {@link wrapperName} is not set.
+   */
+  wrapperVersion?: string;
+}

--- a/packages/shared/sdk-server/src/api/data/index.ts
+++ b/packages/shared/sdk-server/src/api/data/index.ts
@@ -3,3 +3,4 @@ export * from './LDFlagsState';
 export * from './LDMigrationStage';
 export * from './LDMigrationOpEvent';
 export * from './LDMigrationVariation';
+export * from './LDScopedClientOptions';

--- a/packages/shared/sdk-server/src/api/index.ts
+++ b/packages/shared/sdk-server/src/api/index.ts
@@ -1,6 +1,7 @@
 export * from './data';
 export * from './options';
 export * from './LDClient';
+export * from './LDScopedClient';
 export * from './LDMigration';
 export * from './interfaces/DataKind';
 export * from './subsystems/LDFeatureStore';

--- a/packages/shared/sdk-server/src/createScopedClient.ts
+++ b/packages/shared/sdk-server/src/createScopedClient.ts
@@ -1,0 +1,121 @@
+import {
+  Context,
+  LDContext,
+  LDContextCommon,
+  LDMultiKindContext,
+  LDSingleKindContext,
+} from '@launchdarkly/js-sdk-common';
+
+import { LDClient, LDScopedClient } from './api';
+
+function setKind(
+  kind: string,
+  context: LDSingleKindContext,
+  contextsByKind: Map<string, LDContextCommon>,
+): void {
+  const { kind: _, ...attrs } = context;
+  contextsByKind.set(kind, attrs as LDContextCommon);
+}
+
+function buildContext(contextsByKind: Map<string, LDContextCommon>): LDContext {
+  if (contextsByKind.size === 1) {
+    const [kind, attrs] = contextsByKind.entries().next().value!;
+    return { ...attrs, kind } as LDSingleKindContext;
+  }
+
+  const multi: LDMultiKindContext = { kind: 'multi' };
+  contextsByKind.forEach((attrs, kind) => {
+    multi[kind] = attrs;
+  });
+  return multi;
+}
+
+/**
+ * Creates an {@link LDScopedClient} that wraps a base {@link LDClient}
+ * with a mutable, additive context container.
+ */
+export default function createScopedClient(
+  baseClient: LDClient,
+  initialContext: LDContext,
+): LDScopedClient {
+  const contextsByKind: Map<string, LDContextCommon> = new Map();
+  let cachedContext: LDContext | undefined;
+
+  const parsed = Context.fromLDContext(initialContext);
+  if (parsed.valid) {
+    parsed.getContexts().forEach(([kind, attrs]) => {
+      const { kind: _, ...rest } = attrs as LDContextCommon & { kind?: string };
+      contextsByKind.set(kind, rest as LDContextCommon);
+    });
+  } else {
+    baseClient.logger?.warn(
+      'Scoped client created with invalid context; evaluations will use default values.',
+    );
+  }
+
+  function currentContext(): LDContext {
+    if (!cachedContext) {
+      cachedContext = buildContext(contextsByKind);
+    }
+    return cachedContext;
+  }
+
+  function invalidateCache(): void {
+    cachedContext = undefined;
+  }
+
+  const scopedClient: LDScopedClient = {
+    client: baseClient,
+
+    addContext(context: LDSingleKindContext): LDScopedClient {
+      const { kind } = context;
+      if (contextsByKind.has(kind)) {
+        baseClient.logger?.warn(`Tried to add a duplicate ${kind} context to scoped client`);
+        return scopedClient;
+      }
+      setKind(kind, context, contextsByKind);
+      invalidateCache();
+      return scopedClient;
+    },
+
+    overwriteContextByKind(context: LDSingleKindContext): LDScopedClient {
+      setKind(context.kind, context, contextsByKind);
+      invalidateCache();
+      return scopedClient;
+    },
+
+    currentContext,
+
+    variation: (key, defaultValue) => baseClient.variation(key, currentContext(), defaultValue),
+    variationDetail: (key, defaultValue) =>
+      baseClient.variationDetail(key, currentContext(), defaultValue),
+    boolVariation: (key, defaultValue) =>
+      baseClient.boolVariation(key, currentContext(), defaultValue),
+    numberVariation: (key, defaultValue) =>
+      baseClient.numberVariation(key, currentContext(), defaultValue),
+    stringVariation: (key, defaultValue) =>
+      baseClient.stringVariation(key, currentContext(), defaultValue),
+    jsonVariation: (key, defaultValue) =>
+      baseClient.jsonVariation(key, currentContext(), defaultValue),
+    boolVariationDetail: (key, defaultValue) =>
+      baseClient.boolVariationDetail(key, currentContext(), defaultValue),
+    numberVariationDetail: (key, defaultValue) =>
+      baseClient.numberVariationDetail(key, currentContext(), defaultValue),
+    stringVariationDetail: (key, defaultValue) =>
+      baseClient.stringVariationDetail(key, currentContext(), defaultValue),
+    jsonVariationDetail: (key, defaultValue) =>
+      baseClient.jsonVariationDetail(key, currentContext(), defaultValue),
+    migrationVariation: (key, defaultValue) =>
+      baseClient.migrationVariation(key, currentContext(), defaultValue),
+
+    allFlagsState: (options?) => baseClient.allFlagsState(currentContext(), options),
+
+    track: (key) => baseClient.track(key, currentContext()),
+    trackData: (key, data) => baseClient.track(key, currentContext(), data),
+    trackMetric: (key, metricValue, data?) =>
+      baseClient.track(key, currentContext(), data, metricValue),
+    trackMigration: (event) => baseClient.trackMigration(event),
+  };
+
+  return scopedClient;
+}

--- a/packages/shared/sdk-server/src/index.ts
+++ b/packages/shared/sdk-server/src/index.ts
@@ -1,4 +1,5 @@
 import BigSegmentStoreStatusProviderImpl from './BigSegmentStatusProviderImpl';
+import createScopedClient from './createScopedClient';
 import LDClientImpl from './LDClientImpl';
 import { createMigration, LDMigrationError, LDMigrationSuccess } from './Migration';
 
@@ -13,6 +14,7 @@ export * as internalServer from './internal';
 
 export {
   LDClientImpl,
+  createScopedClient,
   BigSegmentStoreStatusProviderImpl,
   LDMigrationError,
   LDMigrationSuccess,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -289,6 +289,7 @@
       "bump-minor-pre-major": true,
       "extra-files": [
         "src/client/LDReactClient.tsx",
+        "src/server/LDServerSession.ts",
         {
           "type": "json",
           "path": "examples/hello-react/package.json",


### PR DESCRIPTION
> [!WARNING]  
> I will most likely break this PR down to smaller parts to deliver this feature. So please don't merge.

This PR adds in scoped clients to server sdks. The implementation is based on the go server sdk. This PR also modifies the React SDK to utilize the scoped client init reporting (mostly as an example of how it is used)

