### PR TITLE
fix: Prevent context attributes from influencing judge template parsing

### DIFF
--- a/packages/sdk/server-ai/__tests__/Judge.test.ts
+++ b/packages/sdk/server-ai/__tests__/Judge.test.ts
@@ -872,6 +872,22 @@ describe('Judge', () => {
       expect(messages[0].content).toBe('HISTORY | HISTORY');
     });
 
+    it('does not allow cross-placeholder injection via message_history value', () => {
+      const template = 'History: {{message_history}}\nResponse: {{response_to_evaluate}}';
+      const judge = makeJudge(template);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const constructMessages = (judge as any)._constructEvaluationMessages.bind(judge);
+      // message_history value contains the other placeholder literally
+      const messages = constructMessages('{{response_to_evaluate}}', 'REAL OUTPUT');
+
+      expect(messages).toHaveLength(1);
+      // The literal text {{response_to_evaluate}} from the history value must survive
+      expect(messages[0].content).toBe(
+        'History: {{response_to_evaluate}}\nResponse: REAL OUTPUT',
+      );
+    });
+
     it('preserves Mustache-like syntax inside history and response values', () => {
       const template = 'History: {{message_history}}\nResponse: {{response_to_evaluate}}';
       const judge = makeJudge(template);

--- a/packages/sdk/server-ai/__tests__/Judge.test.ts
+++ b/packages/sdk/server-ai/__tests__/Judge.test.ts
@@ -883,9 +883,7 @@ describe('Judge', () => {
 
       expect(messages).toHaveLength(1);
       // The literal text {{response_to_evaluate}} from the history value must survive
-      expect(messages[0].content).toBe(
-        'History: {{response_to_evaluate}}\nResponse: REAL OUTPUT',
-      );
+      expect(messages[0].content).toBe('History: {{response_to_evaluate}}\nResponse: REAL OUTPUT');
     });
 
     it('preserves Mustache-like syntax inside history and response values', () => {

--- a/packages/sdk/server-ai/__tests__/Judge.test.ts
+++ b/packages/sdk/server-ai/__tests__/Judge.test.ts
@@ -796,4 +796,96 @@ describe('Judge', () => {
       );
     });
   });
+
+  describe('template injection prevention', () => {
+    /**
+     * Regression tests for template injection vulnerability.
+     *
+     * These tests verify that the judge's message interpolation uses simple string
+     * replacement instead of Mustache templating. Attacker-controlled values from
+     * pass 1 (e.g. Mustache delimiter-change tags) must be treated as inert literal
+     * text by pass 2.
+     */
+
+    function makeJudge(content: string): Judge {
+      const config: LDAIJudgeConfig = {
+        key: 'test-judge',
+        enabled: true,
+        messages: [{ role: 'user', content }],
+        model: { name: 'gpt-4' },
+        provider: { name: 'openai' },
+        tracker: mockTracker,
+        evaluationMetricKey: 'metric',
+      };
+      return new Judge(config, mockTracker, mockProvider, mockLogger);
+    }
+
+    const injectionVariants = [
+      { name: 'delimiter change brackets', payload: '{{=[ ]=}}' },
+      { name: 'delimiter change angle', payload: '{{=<% %>=}}' },
+      { name: 'partial', payload: '{{> evil}}' },
+      { name: 'comment', payload: '{{! drop everything }}' },
+      { name: 'triple stache', payload: '{{{raw}}}' },
+      { name: 'section', payload: '{{#section}}inject{{/section}}' },
+      { name: 'inverted section', payload: '{{^section}}inject{{/section}}' },
+    ];
+
+    it.each(injectionVariants)(
+      'injection variant "$name" in message_history does not blind the judge',
+      ({ payload }) => {
+        const afterPass1 = `Auditing ${payload}: {{message_history}}`;
+        const judge = makeJudge(afterPass1);
+
+        // eslint-disable-next-line no-underscore-dangle
+        const constructMessages = (judge as any)._constructEvaluationMessages.bind(judge);
+        const messages = constructMessages('ACTUAL HISTORY', 'some output');
+
+        expect(messages).toHaveLength(1);
+        expect(messages[0].content).toContain('ACTUAL HISTORY');
+        expect(messages[0].content).not.toContain('{{message_history}}');
+      },
+    );
+
+    it('injection via response is neutralized', () => {
+      const afterPass1 = 'History: {{message_history}}\nResponse: {{response_to_evaluate}}';
+      const judge = makeJudge(afterPass1);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const constructMessages = (judge as any)._constructEvaluationMessages.bind(judge);
+      const maliciousResponse = '{{=[ ]=}} INJECTION ATTEMPT';
+      const messages = constructMessages('normal history', maliciousResponse);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toContain(maliciousResponse);
+      expect(messages[0].content).not.toContain('{{response_to_evaluate}}');
+    });
+
+    it('substitutes multiple occurrences of the same placeholder', () => {
+      const template = '{{message_history}} | {{message_history}}';
+      const judge = makeJudge(template);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const constructMessages = (judge as any)._constructEvaluationMessages.bind(judge);
+      const messages = constructMessages('HISTORY', 'RESPONSE');
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('HISTORY | HISTORY');
+    });
+
+    it('preserves Mustache-like syntax inside history and response values', () => {
+      const template = 'History: {{message_history}}\nResponse: {{response_to_evaluate}}';
+      const judge = makeJudge(template);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const constructMessages = (judge as any)._constructEvaluationMessages.bind(judge);
+      const historyWithMustache = 'How do I use {{user}} in Mustache?';
+      const responseWithMustache = 'Use {{user}} like this: {{#user}}Hello{{/user}}';
+
+      const messages = constructMessages(historyWithMustache, responseWithMustache);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toContain(historyWithMustache);
+      expect(messages[0].content).toContain(responseWithMustache);
+    });
+  });
 });

--- a/packages/sdk/server-ai/src/api/judge/Judge.ts
+++ b/packages/sdk/server-ai/src/api/judge/Judge.ts
@@ -177,12 +177,8 @@ export class Judge {
   }
 
   /**
-   * Interpolates message content with variables using simple string replacement.
-   *
-   * Uses literal string replacement instead of a template engine to prevent
-   * template injection: attacker-controlled values from pass 1 (e.g. Mustache
-   * delimiter-change tags like {{=[ ]=}}) would otherwise be interpreted as
-   * control syntax by a second Mustache pass, blinding the judge.
+   * Use string replacement to prevent context attributes like {{=[ ]=}}) from
+   * influencing judge template parsing.
    */
   private _interpolateMessage(content: string, variables: Record<string, string>): string {
     return Object.entries(variables).reduce(

--- a/packages/sdk/server-ai/src/api/judge/Judge.ts
+++ b/packages/sdk/server-ai/src/api/judge/Judge.ts
@@ -181,9 +181,8 @@ export class Judge {
    * influencing judge template parsing.
    */
   private _interpolateMessage(content: string, variables: Record<string, string>): string {
-    return Object.entries(variables).reduce(
-      (result, [key, value]) => result.split(`{{${key}}}`).join(value),
-      content,
+    return content.replace(/\{\{(\w+)\}\}/g, (match, key) =>
+      Object.prototype.hasOwnProperty.call(variables, key) ? variables[key] : match,
     );
   }
 

--- a/packages/sdk/server-ai/src/api/judge/Judge.ts
+++ b/packages/sdk/server-ai/src/api/judge/Judge.ts
@@ -177,7 +177,7 @@ export class Judge {
   }
 
   /**
-   * Use string replacement to prevent context attributes like {{=[ ]=}}) from
+   * Use string replacement to prevent context attributes like {{=[ ]=}} from
    * influencing judge template parsing.
    */
   private _interpolateMessage(content: string, variables: Record<string, string>): string {

--- a/packages/sdk/server-ai/src/api/judge/Judge.ts
+++ b/packages/sdk/server-ai/src/api/judge/Judge.ts
@@ -185,11 +185,10 @@ export class Judge {
    * control syntax by a second Mustache pass, blinding the judge.
    */
   private _interpolateMessage(content: string, variables: Record<string, string>): string {
-    let result = content;
-    for (const [key, value] of Object.entries(variables)) {
-      result = result.split(`{{${key}}}`).join(value);
-    }
-    return result;
+    return Object.entries(variables).reduce(
+      (result, [key, value]) => result.split(`{{${key}}}`).join(value),
+      content,
+    );
   }
 
   /**

--- a/packages/sdk/server-ai/src/api/judge/Judge.ts
+++ b/packages/sdk/server-ai/src/api/judge/Judge.ts
@@ -1,5 +1,3 @@
-import Mustache from 'mustache';
-
 import { LDLogger } from '@launchdarkly/js-server-sdk-common';
 
 import { ChatResponse } from '../chat/types';
@@ -179,10 +177,19 @@ export class Judge {
   }
 
   /**
-   * Interpolates message content with variables using Mustache templating.
+   * Interpolates message content with variables using simple string replacement.
+   *
+   * Uses literal string replacement instead of a template engine to prevent
+   * template injection: attacker-controlled values from pass 1 (e.g. Mustache
+   * delimiter-change tags like {{=[ ]=}}) would otherwise be interpreted as
+   * control syntax by a second Mustache pass, blinding the judge.
    */
   private _interpolateMessage(content: string, variables: Record<string, string>): string {
-    return Mustache.render(content, variables, undefined, { escape: (item: any) => item });
+    let result = content;
+    for (const [key, value] of Object.entries(variables)) {
+      result = result.split(`{{${key}}}`).join(value);
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Addresses SEC-8020. Mirrors the fix applied in the Go server SDK ([`go-server-sdk@3317871`](https://github.com/launchdarkly/go-server-sdk/commit/33178710)). A matching Python SDK PR has also been opened in `launchdarkly/python-server-sdk-ai`.

**Describe the solution you've provided**

The Judge's `_interpolateMessage` previously used `Mustache.render()` to substitute `{{message_history}}` and `{{response_to_evaluate}}` placeholders (pass 2). Because pass 1 (`LDAIClientImpl`) already resolves user/context attributes via Mustache, an attacker who controls a context attribute could inject Mustache control sequences (e.g. `{{=[ ]=}}` delimiter-change tags) that corrupt pass 2, effectively blinding the judge to the actual conversation content.

This PR replaces the Mustache call in `_interpolateMessage` with a literal `Object.entries().reduce()` using `split().join()` for string replacement. Since the judge only ever substitutes two known placeholders, a full template engine is unnecessary. The `mustache` dependency remains because `LDAIClientImpl` still uses it for general config interpolation (pass 1).

**Key changes:**
- `Judge.ts`: Remove `Mustache` import; replace `Mustache.render()` with `reduce` + `split().join()` over the known placeholder keys.
- `Judge.test.ts`: Add `template injection prevention` describe block with regression tests covering delimiter changes, partials, comments, triple-stache, sections, inverted sections, injection via response, multiple placeholder occurrences, and preservation of Mustache-like syntax inside substituted values.

**Describe alternatives you've considered**

- Using `String.prototype.replaceAll()` — not available with the `es2020` target; `split().join()` is the standard workaround.
- Using a `for...of` loop — disallowed by the repo's ESLint `no-restricted-syntax` rule; `reduce` is the idiomatic alternative.
- Escaping Mustache special characters in the input before rendering — more complex and fragile than removing the template engine entirely for this use case.

**Additional context**

Reviewers should verify:
- The `split().join()` pattern correctly handles all occurrences of each placeholder (it does — `split` with a string literal is equivalent to a global literal replace).
- The `mustache` package remains in `dependencies` since `LDAIClientImpl.ts` still imports it for pass 1.
- Tests access `_constructEvaluationMessages` via `(judge as any)` cast — this is the simplest way to exercise the interpolation logic end-to-end without mocking the full provider invocation.

Link to Devin session: https://app.devin.ai/sessions/651e799b906748a4834bafefb4a3e3e5
Requested by: @jsonbailey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches judge prompt construction logic to mitigate a template-injection vulnerability; while localized, it changes how placeholders are detected/replaced and could affect existing judge message templates that relied on Mustache behavior.
> 
> **Overview**
> **Hardens `Judge` prompt construction against template injection.** `Judge._interpolateMessage` no longer uses `Mustache.render`; it now performs a literal `{{key}}` string replacement for known variables so attacker-controlled strings like `{{=[ ]=}}` cannot alter parsing in the second interpolation pass.
> 
> Adds a new `template injection prevention` test suite covering delimiter changes, sections/partials/comments, injection via response/history, multiple placeholder occurrences, and ensuring Mustache-like syntax in substituted values is preserved as literal text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24a3717145c7463813401231679d8c181af5f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->