### PR TITLE
chore: Remove unused Payload.id field from FDv2 protocol handler

### DIFF
--- a/packages/shared/common/__tests__/internal/fdv2/PayloadStreamReader.test.ts
+++ b/packages/shared/common/__tests__/internal/fdv2/PayloadStreamReader.test.ts
@@ -31,7 +31,6 @@ it('it sets type to full when intent code is xfer-full', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
 });
@@ -53,7 +52,6 @@ it('it sets type to partial when intent code is xfer-changes', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('partial');
 });
@@ -72,7 +70,6 @@ it('it sets type to none and emits empty payload when intent code is none', () =
     data: '{"payloads": [{"intentCode": "none", "id": "mockId", "target": 42}]}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].version).toEqual(42);
   expect(receivedPayloads[0].type).toEqual('none');
 });
@@ -104,14 +101,12 @@ it('it handles xfer-full then xfer-changes', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(2);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
   expect(receivedPayloads[0].updates.length).toEqual(1);
   expect(receivedPayloads[0].updates[0].object).toEqual({ objectFieldA: 'objectValueA' });
   expect(receivedPayloads[0].updates[0].deleted).toEqual(undefined);
 
-  expect(receivedPayloads[1].id).toEqual('mockId');
   expect(receivedPayloads[1].state).toEqual('mockState');
   expect(receivedPayloads[1].type).toEqual('partial');
   expect(receivedPayloads[1].updates.length).toEqual(1);
@@ -145,7 +140,6 @@ it('it includes multiple types of updates in payload', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
   expect(receivedPayloads[0].updates.length).toEqual(3);
@@ -253,7 +247,7 @@ it('logs prescribed message when error event is encountered', () => {
   });
   expect(receivedPayloads.length).toEqual(1);
   expect(mockLogger.info).toHaveBeenCalledWith(
-    'An issue was encountered receiving updates for payload mockId with reason: Womp womp.',
+    'An issue was encountered receiving updates with reason: Womp womp.',
   );
 });
 
@@ -309,13 +303,11 @@ it('discards partially transferred data when an error is encountered', () => {
     data: '{"state": "mockState2", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(2);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
   expect(receivedPayloads[0].updates.length).toEqual(1);
   expect(receivedPayloads[0].updates[0].object).toEqual({ objectFieldB: 'objectValueB' });
   expect(receivedPayloads[0].updates[0].deleted).toEqual(undefined);
-  expect(receivedPayloads[1].id).toEqual('mockId2');
   expect(receivedPayloads[1].state).toEqual('mockState2');
   expect(receivedPayloads[1].type).toEqual('full');
   expect(receivedPayloads[1].updates.length).toEqual(3);
@@ -350,7 +342,6 @@ it('silently ignores unrecognized kinds', () => {
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
   expect(receivedPayloads[0].updates.length).toEqual(1);
@@ -380,7 +371,6 @@ it('ignores additional payloads beyond the first payload in the server-intent me
     data: '{"state": "mockState", "version": 1}',
   });
   expect(receivedPayloads.length).toEqual(1);
-  expect(receivedPayloads[0].id).toEqual('mockId');
   expect(receivedPayloads[0].state).toEqual('mockState');
   expect(receivedPayloads[0].type).toEqual('full');
   expect(receivedPayloads[0].updates.length).toEqual(1);

--- a/packages/shared/common/__tests__/internal/fdv2/protocolHandler.test.ts
+++ b/packages/shared/common/__tests__/internal/fdv2/protocolHandler.test.ts
@@ -65,7 +65,6 @@ it('emits a full payload after xfer-full and payload-transferred', () => {
   if (action.type !== 'payload') return;
 
   expect(action.payload.type).toBe('full');
-  expect(action.payload.id).toBe('p1');
   expect(action.payload.version).toBe(52);
   expect(action.payload.state).toBe('(p:p1:52)');
   expect(action.payload.updates).toHaveLength(2);
@@ -114,7 +113,6 @@ it('returns a none-type payload immediately on intent-none', () => {
   if (action.type !== 'payload') return;
 
   expect(action.payload.type).toBe('none');
-  expect(action.payload.id).toBe('p1');
   expect(action.payload.version).toBe(42);
   expect(action.payload.updates).toHaveLength(0);
   expect(action.payload.state).toBeUndefined();

--- a/packages/shared/common/src/internal/fdv2/protocolHandler.ts
+++ b/packages/shared/common/src/internal/fdv2/protocolHandler.ts
@@ -35,7 +35,6 @@ export type PayloadType = 'full' | 'partial' | 'none';
  * - `none`: no changes are needed; the SDK is up-to-date.
  */
 export interface Payload {
-  id: string;
   version: number;
   state?: string;
   type: PayloadType;
@@ -86,7 +85,6 @@ export function createProtocolHandler(
   logger?: LDLogger,
 ): ProtocolHandler {
   let protocolState: ProtocolState = 'inactive';
-  let tempId: string | undefined;
   let tempType: PayloadType = 'partial';
   let tempUpdates: Update[] = [];
 
@@ -96,7 +94,6 @@ export function createProtocolHandler(
 
   function resetAll(): void {
     protocolState = 'inactive';
-    tempId = undefined;
     tempType = 'partial';
     tempUpdates = [];
   }
@@ -112,17 +109,14 @@ export function createProtocolHandler(
   }
 
   function processIntentNone(intent: PayloadIntent): ProtocolAction {
-    if (!intent.id || isNullish(intent.target)) {
-      logger?.warn(
-        `Ignoring 'none' intent with missing fields: id=${intent.id}, target=${intent.target}`,
-      );
+    if (isNullish(intent.target)) {
+      logger?.warn(`Ignoring 'none' intent with missing fields: target=${intent.target}`);
       return ACTION_NONE;
     }
 
     return {
       type: 'payload',
       payload: {
-        id: intent.id,
         version: intent.target,
         type: 'none',
         updates: [],
@@ -147,19 +141,16 @@ export function createProtocolHandler(
         protocolState = 'full';
         tempUpdates = [];
         tempType = 'full';
-        tempId = payload.id;
         return ACTION_NONE;
       case 'xfer-changes':
         protocolState = 'changes';
         tempUpdates = [];
         tempType = 'partial';
-        tempId = payload.id;
         return ACTION_NONE;
       case 'none':
         protocolState = 'changes';
         tempUpdates = [];
         tempType = 'partial';
-        tempId = payload.id;
         return processIntentNone(payload);
       default:
         logger?.warn(`Unable to process intent code '${payload?.intentCode}'.`);
@@ -168,7 +159,7 @@ export function createProtocolHandler(
   }
 
   function processPutObject(data: PutObject): ProtocolAction {
-    if (protocolState === 'inactive' || !tempId) {
+    if (protocolState === 'inactive') {
       logger?.warn('Received put-object before server-intent was established. Ignoring.');
       return ACTION_NONE;
     }
@@ -196,7 +187,7 @@ export function createProtocolHandler(
   }
 
   function processDeleteObject(data: DeleteObject): ProtocolAction {
-    if (protocolState === 'inactive' || !tempId) {
+    if (protocolState === 'inactive') {
       logger?.warn('Received delete-object before server-intent was established. Ignoring.');
       return ACTION_NONE;
     }
@@ -227,7 +218,7 @@ export function createProtocolHandler(
       };
     }
 
-    if (!tempId || isNullish(data.state) || isNullish(data.version)) {
+    if (isNullish(data.state) || isNullish(data.version)) {
       logger?.warn(
         `Ignoring payload-transferred with missing fields: state=${data.state}, version=${data.version}`,
       );
@@ -238,7 +229,6 @@ export function createProtocolHandler(
     const result: ProtocolAction = {
       type: 'payload',
       payload: {
-        id: tempId,
         version: data.version,
         state: data.state,
         type: tempType,
@@ -259,9 +249,7 @@ export function createProtocolHandler(
   }
 
   function processError(data: any): ProtocolAction {
-    logger?.info(
-      `An issue was encountered receiving updates for payload ${tempId} with reason: ${data.reason}.`,
-    );
+    logger?.info(`An issue was encountered receiving updates with reason: ${data.reason}.`);
     resetAfterError();
     return { type: 'serverError', id: data.payload_id, reason: data.reason };
   }

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/Conditions.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/Conditions.test.ts
@@ -38,10 +38,7 @@ function makeInterrupted(): FDv2SourceResult {
 }
 
 function makeChangeSet(): FDv2SourceResult {
-  return changeSet(
-    { id: 'test', version: 1, state: 'test-state', type: 'full', updates: [] },
-    false,
-  );
+  return changeSet({ version: 1, state: 'test-state', type: 'full', updates: [] }, false);
 }
 
 // -- fallback condition --

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv1PollingSynchronizer.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv1PollingSynchronizer.test.ts
@@ -58,7 +58,6 @@ it('produces a changeSet with full payload from a successful poll', async () => 
   expect(result.type).toBe('changeSet');
   if (result.type === 'changeSet') {
     expect(result.payload.type).toBe('full');
-    expect(result.payload.id).toBe('FDv1Fallback');
     expect(result.payload.version).toBe(1);
     expect(result.payload.updates).toHaveLength(2);
 

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv2SourceResult.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv2SourceResult.test.ts
@@ -32,7 +32,7 @@ it('creates a changeSet result with a payload', () => {
 });
 
 it('creates a changeSet result with fdv1Fallback flag', () => {
-  const payload = { id: 'id', version: 1, type: 'full' as const, updates: [] };
+  const payload = { version: 1, type: 'full' as const, updates: [] };
   const result = changeSet(payload, true);
 
   expect(result.type).toBe('changeSet');

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/orchestrationTestHelpers.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/orchestrationTestHelpers.ts
@@ -75,7 +75,6 @@ export function makePayload(
   opts: { state?: string; type?: internal.PayloadType } = {},
 ): internal.Payload {
   return {
-    id: 'test-payload',
     version: 1,
     state: opts.state ?? 'test-selector',
     type: opts.type ?? 'full',

--- a/packages/shared/sdk-client/src/datasource/fdv2/CacheInitializer.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/CacheInitializer.ts
@@ -69,7 +69,6 @@ async function loadFromCache(config: CacheInitializerConfig): Promise<FDv2Source
   );
 
   const payload: internal.Payload = {
-    id: 'cache',
     version: 0,
     // No `state` field. The orchestrator sees a changeSet without a selector,
     // records dataReceived=true, and continues to the next initializer.

--- a/packages/shared/sdk-client/src/datasource/fdv2/FDv1PollingSynchronizer.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/FDv1PollingSynchronizer.ts
@@ -20,8 +20,6 @@ import {
 } from './FDv2SourceResult';
 import { Synchronizer } from './Synchronizer';
 
-const PAYLOAD_ID = 'FDv1Fallback';
-
 function flagsToPayload(flags: Flags): internal.Payload {
   const updates: internal.Update[] = Object.entries(flags).map(([key, flag]) => ({
     kind: 'flag',
@@ -31,7 +29,6 @@ function flagsToPayload(flags: Flags): internal.Payload {
   }));
 
   return {
-    id: PAYLOAD_ID,
     version: 1,
     type: 'full',
     updates,

--- a/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
@@ -120,7 +120,6 @@ export async function poll(
     // (Spec Requirement 10.1.2)
     if (response.status === 304) {
       const nonePayload: internal.Payload = {
-        id: '',
         version: 0,
         type: 'none',
         updates: [],

--- a/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
@@ -63,7 +63,6 @@ describe('given a one shot initializer', () => {
       initMetadata: undefined,
       payload: {
         type: 'full',
-        id: `mockId`,
         state: `mockState`,
         updates: [
           {

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -85,7 +85,6 @@ describe('given a polling processor', () => {
       },
       payload: {
         type: 'full',
-        id: `mockId`,
         state: `mockState`,
         updates: [
           {
@@ -123,7 +122,6 @@ describe('given a polling processor', () => {
       },
       payload: {
         type: 'full',
-        id: `FDv1Fallback`,
         state: `FDv1Fallback`,
         updates: [
           {

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
@@ -248,7 +248,6 @@ describe('given a stream processor with mock event source', () => {
       },
       payload: {
         type: 'full',
-        id: `mockId`,
         state: `mockState`,
         updates: [
           {


### PR DESCRIPTION
SDK-2005

## Summary
- Removes the `id` field from the internal `Payload` interface and all `tempId` plumbing in the protocol handler
- The field was populated from `PayloadIntent.id` but never read by any downstream consumer
- Wire protocol types (`PayloadIntent.id`, `PayloadTransferred.id`, `ErrorObject.payload_id`) are unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes an unused field and related plumbing; behavioral changes are limited to slightly different validation/log messages around intent/transfer events.
> 
> **Overview**
> Removes the internal FDv2 `Payload.id` field and the protocol handler’s `tempId` tracking, so emitted payloads are keyed only by `version`/`state`/`type`/`updates`.
> 
> Updates SDK client/server components and tests to stop constructing or asserting on `payload.id` (including cache initialization, polling/FDv1 fallback payloads, and FDv2 source result helpers), and simplifies protocol-handler warnings/log messages accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11185e6c85eeec1376f620ee122c948e5b844d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->