### PR TITLE
fix(electron-sdk): localstorage indexing

### DIFF
--- a/packages/sdk/electron/__tests__/ElectronClient.mainProcess.test.ts
+++ b/packages/sdk/electron/__tests__/ElectronClient.mainProcess.test.ts
@@ -288,6 +288,101 @@ describe('given an initialized ElectronClient with enableIPC: false and polling'
   });
 });
 
+function makeMemoryStorage() {
+  const data = new Map<string, string>();
+  return {
+    get: jest.fn(async (key: string) => data.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => {
+      data.set(key, value);
+    }),
+    clear: jest.fn(async (key: string) => {
+      data.delete(key);
+    }),
+    keys: () => Array.from(data.keys()),
+  };
+}
+
+describe('maxCachedContexts', () => {
+  it('evicts the oldest cached context when the limit is exceeded', async () => {
+    const storage = makeMemoryStorage();
+    const mockedFetch = mockFetch(JSON.stringify(remoteFlagsMockData), 200);
+    (ElectronPlatform as jest.Mock).mockReturnValue({
+      crypto: new ElectronCrypto(),
+      info: new ElectronInfo(),
+      requests: {
+        createEventSource: jest.fn(),
+        fetch: mockedFetch,
+        getEventSourceCapabilities: jest.fn(),
+      },
+      encoding: new ElectronEncoding(),
+      storage,
+    });
+
+    const client = createClient(clientSideId, DEFAULT_INITIAL_CONTEXT, {
+      initialConnectionMode: 'polling',
+      enableIPC: false,
+      diagnosticOptOut: true,
+      sendEvents: false,
+      maxCachedContexts: 1,
+    });
+    await client.start();
+
+    // After start, context A's flags are cached.
+    // Storage should contain: context index + context A data + context A freshness
+    const keysAfterStart = storage.keys();
+    const contextDataKeys = keysAfterStart.filter(
+      (k) => !k.includes('ContextIndex') && !k.includes('_freshness'),
+    );
+    expect(contextDataKeys).toHaveLength(1);
+
+    // Identify a second context — context A should be evicted (maxCachedContexts: 1)
+    await client.identify({ kind: 'user', key: 'context-b' });
+
+    const keysAfterIdentify = storage.keys();
+    const contextDataKeysAfter = keysAfterIdentify.filter(
+      (k) => !k.includes('ContextIndex') && !k.includes('_freshness'),
+    );
+    expect(contextDataKeysAfter).toHaveLength(1);
+
+    // The surviving key should be different from the first one (context B replaced context A)
+    expect(contextDataKeysAfter[0]).not.toEqual(contextDataKeys[0]);
+  });
+
+  it('does not cache flags when maxCachedContexts is 0', async () => {
+    const storage = makeMemoryStorage();
+    const mockedFetch = mockFetch(JSON.stringify(remoteFlagsMockData), 200);
+    (ElectronPlatform as jest.Mock).mockReturnValue({
+      crypto: new ElectronCrypto(),
+      info: new ElectronInfo(),
+      requests: {
+        createEventSource: jest.fn(),
+        fetch: mockedFetch,
+        getEventSourceCapabilities: jest.fn(),
+      },
+      encoding: new ElectronEncoding(),
+      storage,
+    });
+
+    const client = createClient(clientSideId, DEFAULT_INITIAL_CONTEXT, {
+      initialConnectionMode: 'polling',
+      enableIPC: false,
+      diagnosticOptOut: true,
+      sendEvents: false,
+      maxCachedContexts: 0,
+    });
+    await client.start();
+
+    // Flags should still evaluate correctly from the network response
+    expect(client.boolVariation('on-off-flag', false)).toBe(true);
+
+    // But no context data should be persisted to storage
+    const contextDataKeys = storage
+      .keys()
+      .filter((k) => !k.includes('ContextIndex') && !k.includes('_freshness'));
+    expect(contextDataKeys).toHaveLength(0);
+  });
+});
+
 describe('given an initialized ElectronClient with enableIPC: false and streaming', () => {
   const logger: LDLogger = {
     debug: jest.fn(),

--- a/packages/sdk/electron/__tests__/platform/ElectronPlatform.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronPlatform.test.ts
@@ -1,0 +1,52 @@
+import type { LDLogger } from '@launchdarkly/js-client-sdk-common';
+
+import ElectronPlatform from '../../src/platform/ElectronPlatform';
+
+const failingStorage = {
+  get: jest.fn().mockRejectedValue(new Error('disk read failed')),
+  set: jest.fn().mockRejectedValue(new Error('disk write failed')),
+  clear: jest.fn().mockRejectedValue(new Error('disk clear failed')),
+};
+
+jest.mock('../../src/platform/ElectronStorage', () => ({
+  getElectronStorage: () => failingStorage,
+}));
+
+const logger: LDLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+let platform: ElectronPlatform;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  platform = new ElectronPlatform(logger, {});
+});
+
+it('logs error and returns null when storage get fails', async () => {
+  const result = await platform.storage!.get('some-key');
+
+  expect(result).toBeNull();
+  expect(logger.error).toHaveBeenCalledWith(
+    expect.stringContaining('Error getting key from storage: some-key'),
+  );
+});
+
+it('logs error and swallows when storage set fails', async () => {
+  await platform.storage!.set('some-key', 'some-value');
+
+  expect(logger.error).toHaveBeenCalledWith(
+    expect.stringContaining('Error setting key in storage: some-key'),
+  );
+});
+
+it('logs error and swallows when storage clear fails', async () => {
+  await platform.storage!.clear('some-key');
+
+  expect(logger.error).toHaveBeenCalledWith(
+    expect.stringContaining('Error clearing key from storage: some-key'),
+  );
+});

--- a/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
@@ -94,14 +94,14 @@ it('handles error when clearing values', async () => {
   const storage = new ElectronStorage(logger);
   await storage.clear('key1');
 
-  expect(await storage.get('key1')).toEqual('value1');
+  // Cache is updated synchronously — the in-memory state reflects the clear
+  // even if the disk write failed. The data will be flushed on the next write.
+  expect(await storage.get('key1')).toBeNull();
 
   expect(logger.debug).not.toHaveBeenCalled();
   expect(logger.info).not.toHaveBeenCalled();
   expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith(
-    'Error clearing key from storage: key1, reason: write failed',
-  );
+  expect(logger.error).toHaveBeenCalledWith('Error flushing storage to disk: write failed');
 });
 
 it('handles failed initialization when getting values', async () => {
@@ -225,14 +225,14 @@ it('handles error when setting values', async () => {
   const storage = new ElectronStorage(logger);
   await storage.set('key3', 'value3');
 
-  expect(await storage.get('key3')).toBeNull();
+  // Cache is updated synchronously — the in-memory state reflects the set
+  // even if the disk write failed. The data will be flushed on the next write.
+  expect(await storage.get('key3')).toEqual('value3');
 
   expect(logger.debug).not.toHaveBeenCalled();
   expect(logger.info).not.toHaveBeenCalled();
   expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith(
-    'Error setting key in storage: key3, reason: write failed',
-  );
+  expect(logger.error).toHaveBeenCalledWith('Error flushing storage to disk: write failed');
 });
 
 it('getElectronStorage returns the same instance on subsequent calls', () => {

--- a/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
@@ -11,8 +11,7 @@ jest.mock('electron', () => ({
   },
 }));
 
-const namespace = 'test_namespace';
-const storageFile = `/user/data/ldcache-${namespace}`;
+const storageFile = '/user/data/ldcache';
 const tempFile = `${storageFile}.tmp`;
 
 const logger: LDLogger = {
@@ -30,7 +29,7 @@ it('handles failed initialization when clearing values', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.clear('key1');
 
   expect(logger.debug).not.toHaveBeenCalled();
@@ -47,7 +46,7 @@ it('can clear values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.clear('key1');
 
   expect(await storage.get('key1')).toBeNull();
@@ -70,7 +69,7 @@ it('does nothing when clearing a non-existent key', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.clear('key3');
 
   expect(fs.writeFile).not.toHaveBeenCalled();
@@ -88,7 +87,7 @@ it('handles error when clearing values', async () => {
   );
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.clear('key1');
 
   expect(await storage.get('key1')).toEqual('value1');
@@ -105,7 +104,7 @@ it('handles failed initialization when getting values', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   const value = await storage.get('key1');
 
   expect(value).toBeNull();
@@ -124,7 +123,7 @@ it('can get values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   const value = await storage.get('key1');
 
   expect(value).toEqual('value1');
@@ -140,7 +139,7 @@ it('returns null when getting a non-existent key', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   const value = await storage.get('key3');
 
   expect(value).toBeNull();
@@ -155,7 +154,7 @@ it('handles failed initialization when setting values', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.set('key3', 'value3');
 
   expect(logger.debug).not.toHaveBeenCalled();
@@ -172,7 +171,7 @@ it('can set values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.set('key3', 'value3');
 
   expect(await storage.get('key3')).toEqual('value3');
@@ -195,7 +194,7 @@ it('can set values with existing keys', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.set('key1', 'new-value1');
 
   expect(await storage.get('key1')).toEqual('new-value1');
@@ -219,7 +218,7 @@ it('handles error when setting values', async () => {
   );
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(namespace, logger);
+  const storage = new ElectronStorage(logger);
   await storage.set('key3', 'value3');
 
   expect(await storage.get('key3')).toBeNull();

--- a/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
@@ -1,7 +1,5 @@
 import * as fs from 'fs/promises';
 
-import type { LDLogger } from '@launchdarkly/js-client-sdk-common';
-
 import ElectronStorage, {
   getElectronStorage,
   resetElectronStorage,
@@ -17,32 +15,17 @@ jest.mock('electron', () => ({
 const storageFile = '/user/data/ldcache';
 const tempFile = `${storageFile}.tmp`;
 
-const logger: LDLogger = {
-  debug: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-};
-
 beforeEach(() => {
   jest.clearAllMocks();
   resetElectronStorage();
 });
 
-it('handles failed initialization when clearing values', async () => {
+it('throws on clear when initialization failed', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(logger);
-  await storage.clear('key1');
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith('Error initializing storage: write failed');
-  expect(logger.error).toHaveBeenCalledWith(
-    'Error clearing key from storage: key1, reason: Storage is not initialized',
-  );
+  const storage = new ElectronStorage();
+  await expect(storage.clear('key1')).rejects.toThrow('Storage is not initialized: write failed');
 });
 
 it('can clear values', async () => {
@@ -50,7 +33,7 @@ it('can clear values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   await storage.clear('key1');
 
   expect(await storage.get('key1')).toBeNull();
@@ -61,11 +44,6 @@ it('can clear values', async () => {
     expect.anything(),
   );
   expect(fs.rename).toHaveBeenCalledWith(tempFile, storageFile);
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
 it('does nothing when clearing a non-existent key', async () => {
@@ -73,53 +51,34 @@ it('does nothing when clearing a non-existent key', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   await storage.clear('key3');
 
   expect(fs.writeFile).not.toHaveBeenCalled();
   expect(fs.rename).not.toHaveBeenCalled();
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
-it('handles error when clearing values', async () => {
+it('updates cache even when disk flush fails on clear', async () => {
   (fs.readFile as jest.Mock).mockReturnValueOnce(
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(logger);
-  await storage.clear('key1');
+  const storage = new ElectronStorage();
+  // The flush error propagates so the per-client wrapper can log it
+  await expect(storage.clear('key1')).rejects.toThrow('write failed');
 
   // Cache is updated synchronously — the in-memory state reflects the clear
-  // even if the disk write failed. The data will be flushed on the next write.
+  // even if the disk write failed.
   expect(await storage.get('key1')).toBeNull();
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith('Error flushing storage to disk: write failed');
 });
 
-it('handles failed initialization when getting values', async () => {
+it('throws on get when initialization failed', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(logger);
-  const value = await storage.get('key1');
-
-  expect(value).toBeNull();
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith('Error initializing storage: write failed');
-  expect(logger.error).toHaveBeenCalledWith(
-    'Error getting key from storage: key1, reason: Storage is not initialized',
-  );
+  const storage = new ElectronStorage();
+  await expect(storage.get('key1')).rejects.toThrow('Storage is not initialized: write failed');
 });
 
 it('can get values', async () => {
@@ -127,15 +86,10 @@ it('can get values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   const value = await storage.get('key1');
 
   expect(value).toEqual('value1');
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
 it('returns null when getting a non-existent key', async () => {
@@ -143,30 +97,19 @@ it('returns null when getting a non-existent key', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   const value = await storage.get('key3');
 
   expect(value).toBeNull();
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
-it('handles failed initialization when setting values', async () => {
+it('throws on set when initialization failed', async () => {
   (fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('file not found'));
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(logger);
-  await storage.set('key3', 'value3');
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith('Error initializing storage: write failed');
-  expect(logger.error).toHaveBeenCalledWith(
-    'Error setting key in storage: key3, reason: Storage is not initialized',
+  const storage = new ElectronStorage();
+  await expect(storage.set('key3', 'value3')).rejects.toThrow(
+    'Storage is not initialized: write failed',
   );
 });
 
@@ -175,7 +118,7 @@ it('can set values', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   await storage.set('key3', 'value3');
 
   expect(await storage.get('key3')).toEqual('value3');
@@ -186,11 +129,6 @@ it('can set values', async () => {
     expect.anything(),
   );
   expect(fs.rename).toHaveBeenCalledWith(tempFile, storageFile);
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
 it('can set values with existing keys', async () => {
@@ -198,7 +136,7 @@ it('can set values with existing keys', async () => {
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
 
-  const storage = new ElectronStorage(logger);
+  const storage = new ElectronStorage();
   await storage.set('key1', 'new-value1');
 
   expect(await storage.get('key1')).toEqual('new-value1');
@@ -209,41 +147,32 @@ it('can set values with existing keys', async () => {
     expect.anything(),
   );
   expect(fs.rename).toHaveBeenCalledWith(tempFile, storageFile);
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).not.toHaveBeenCalled();
 });
 
-it('handles error when setting values', async () => {
+it('updates cache even when disk flush fails on set', async () => {
   (fs.readFile as jest.Mock).mockReturnValueOnce(
     JSON.stringify({ key1: 'value1', key2: 'value2' }),
   );
   (fs.writeFile as jest.Mock).mockRejectedValueOnce(new Error('write failed'));
 
-  const storage = new ElectronStorage(logger);
-  await storage.set('key3', 'value3');
+  const storage = new ElectronStorage();
+  // The flush error propagates so the per-client wrapper can log it
+  await expect(storage.set('key3', 'value3')).rejects.toThrow('write failed');
 
   // Cache is updated synchronously — the in-memory state reflects the set
-  // even if the disk write failed. The data will be flushed on the next write.
+  // even if the disk write failed.
   expect(await storage.get('key3')).toEqual('value3');
-
-  expect(logger.debug).not.toHaveBeenCalled();
-  expect(logger.info).not.toHaveBeenCalled();
-  expect(logger.warn).not.toHaveBeenCalled();
-  expect(logger.error).toHaveBeenCalledWith('Error flushing storage to disk: write failed');
 });
 
 it('getElectronStorage returns the same instance on subsequent calls', () => {
-  const a = getElectronStorage(logger);
-  const b = getElectronStorage(logger);
+  const a = getElectronStorage();
+  const b = getElectronStorage();
   expect(a).toBe(b);
 });
 
 it('resetElectronStorage causes a fresh instance on next call', () => {
-  const a = getElectronStorage(logger);
+  const a = getElectronStorage();
   resetElectronStorage();
-  const b = getElectronStorage(logger);
+  const b = getElectronStorage();
   expect(a).not.toBe(b);
 });

--- a/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronStorage.test.ts
@@ -2,7 +2,10 @@ import * as fs from 'fs/promises';
 
 import type { LDLogger } from '@launchdarkly/js-client-sdk-common';
 
-import ElectronStorage from '../../src/platform/ElectronStorage';
+import ElectronStorage, {
+  getElectronStorage,
+  resetElectronStorage,
+} from '../../src/platform/ElectronStorage';
 
 jest.mock('fs/promises');
 jest.mock('electron', () => ({
@@ -23,6 +26,7 @@ const logger: LDLogger = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  resetElectronStorage();
 });
 
 it('handles failed initialization when clearing values', async () => {
@@ -229,4 +233,17 @@ it('handles error when setting values', async () => {
   expect(logger.error).toHaveBeenCalledWith(
     'Error setting key in storage: key3, reason: write failed',
   );
+});
+
+it('getElectronStorage returns the same instance on subsequent calls', () => {
+  const a = getElectronStorage(logger);
+  const b = getElectronStorage(logger);
+  expect(a).toBe(b);
+});
+
+it('resetElectronStorage causes a fresh instance on next call', () => {
+  const a = getElectronStorage(logger);
+  resetElectronStorage();
+  const b = getElectronStorage(logger);
+  expect(a).not.toBe(b);
 });

--- a/packages/sdk/electron/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/electron/contract-tests/entity/src/ClientEntity.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { app } from 'electron';
 import fs from 'node:fs';
@@ -257,15 +256,10 @@ export class ClientEntity {
 export async function createEntity(options: CreateInstanceParams) {
   const logger = makeLogger(options.tag);
 
-  // Need to keep track of this to know where electron is storing the caches.
-  // We can make this a bit more robust by either mocking out the storage path
-  // or allowing users to define a custom storage. That way we can isolate each
-  // client's cache.
   const clientSideId = options.configuration.credential || 'unknown-env-id';
   logger.info(`Creating client with configuration: ${JSON.stringify(options.configuration)}`);
 
-  const namespace = createHash('sha256').update(clientSideId).digest?.('base64url');
-  const storagePath = path.join(app.getPath('userData'), `ldcache-${namespace}`);
+  const storagePath = path.join(app.getPath('userData'), 'ldcache');
 
   const timeoutMs =
     options.configuration.startWaitTimeMs !== null &&

--- a/packages/sdk/electron/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/electron/contract-tests/entity/src/ClientEntity.ts
@@ -4,7 +4,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { createClient, LDClient, LDLogger, LDOptions } from '@launchdarkly/electron-client-sdk';
+import {
+  createClient,
+  LDClient,
+  LDLogger,
+  LDOptions,
+  resetElectronStorage,
+} from '@launchdarkly/electron-client-sdk';
 import {
   CommandParams,
   CommandType,
@@ -146,6 +152,9 @@ export class ClientEntity {
       if (fs.existsSync(`${this._storagePath}.tmp`)) {
         fs.rmSync(`${this._storagePath}.tmp`, { recursive: true });
       }
+      // Reset the singleton so the next client gets a fresh storage instance
+      // that reads from disk instead of returning stale in-memory data.
+      resetElectronStorage();
       this._logger.info('Test ended');
     } catch (error) {
       this._logger.error(`Error closing client: ${error}`);

--- a/packages/sdk/electron/contract-tests/entity/src/main.ts
+++ b/packages/sdk/electron/contract-tests/entity/src/main.ts
@@ -15,9 +15,6 @@ if (process.argv.includes('--build')) {
 const capabilities = [
   'client-side',
   'mobile',
-  // This is a required feature since electron SDK uses a shared localstorage for all clients.
-  // Which would cause issues with flag evaluations when multiple clients are created.
-  'singleton',
   'service-endpoints',
   'tags',
   'user-type',

--- a/packages/sdk/electron/src/ElectronClient.ts
+++ b/packages/sdk/electron/src/ElectronClient.ts
@@ -95,7 +95,7 @@ export class ElectronClient extends LDClientImpl {
       credentialType: useClientSideId ? 'clientSideId' : 'mobileKey',
     };
 
-    const platform = new ElectronPlatform(logger, credential, options);
+    const platform = new ElectronPlatform(logger, options);
     const endpoints = useClientSideId ? browserFdv1Endpoints(credential) : mobileFdv1Endpoints();
 
     super(

--- a/packages/sdk/electron/src/index.ts
+++ b/packages/sdk/electron/src/index.ts
@@ -6,6 +6,9 @@ import type { LDPlugin } from './LDPlugin';
 
 export * from './LDCommon';
 
+/** @internal */
+export { resetElectronStorage } from './platform/ElectronStorage';
+
 export type {
   ElectronOptions as LDOptions,
   LDClient,

--- a/packages/sdk/electron/src/platform/ElectronPlatform.ts
+++ b/packages/sdk/electron/src/platform/ElectronPlatform.ts
@@ -21,9 +21,8 @@ export default class ElectronPlatform implements platform.Platform {
 
   requests: platform.Requests;
 
-  constructor(logger: LDLogger, clientSideId: string, options: ElectronOptions) {
-    const namespace = this.crypto.createHash('sha256').update(clientSideId).digest?.('base64url');
-    this.storage = new ElectronStorage(namespace!, logger);
+  constructor(logger: LDLogger, options: ElectronOptions) {
+    this.storage = new ElectronStorage(logger);
     this.requests = new ElectronRequests(
       options.tlsParams,
       options.proxyOptions,

--- a/packages/sdk/electron/src/platform/ElectronPlatform.ts
+++ b/packages/sdk/electron/src/platform/ElectronPlatform.ts
@@ -22,7 +22,31 @@ export default class ElectronPlatform implements platform.Platform {
   requests: platform.Requests;
 
   constructor(logger: LDLogger, options: ElectronOptions) {
-    this.storage = getElectronStorage(logger);
+    const globalStorage = getElectronStorage();
+    this.storage = {
+      async get(key: string): Promise<string | null> {
+        try {
+          return await globalStorage.get(key);
+        } catch (error) {
+          logger.error(`Error getting key from storage: ${key}, reason: ${error}`);
+          return null;
+        }
+      },
+      async set(key: string, value: string): Promise<void> {
+        try {
+          await globalStorage.set(key, value);
+        } catch (error) {
+          logger.error(`Error setting key in storage: ${key}, reason: ${error}`);
+        }
+      },
+      async clear(key: string): Promise<void> {
+        try {
+          await globalStorage.clear(key);
+        } catch (error) {
+          logger.error(`Error clearing key from storage: ${key}, reason: ${error}`);
+        }
+      },
+    };
     this.requests = new ElectronRequests(
       options.tlsParams,
       options.proxyOptions,

--- a/packages/sdk/electron/src/platform/ElectronPlatform.ts
+++ b/packages/sdk/electron/src/platform/ElectronPlatform.ts
@@ -5,7 +5,7 @@ import ElectronCrypto from './ElectronCrypto';
 import ElectronEncoding from './ElectronEncoding';
 import ElectronInfo from './ElectronInfo';
 import ElectronRequests from './ElectronRequests';
-import ElectronStorage from './ElectronStorage';
+import { getElectronStorage } from './ElectronStorage';
 
 // NOTE: Because Electron main process runs on Node.js, this platform should be
 // very similar to the Node server sdk platform.
@@ -22,7 +22,7 @@ export default class ElectronPlatform implements platform.Platform {
   requests: platform.Requests;
 
   constructor(logger: LDLogger, options: ElectronOptions) {
-    this.storage = new ElectronStorage(logger);
+    this.storage = getElectronStorage(logger);
     this.requests = new ElectronRequests(
       options.tlsParams,
       options.proxyOptions,

--- a/packages/sdk/electron/src/platform/ElectronStorage.ts
+++ b/packages/sdk/electron/src/platform/ElectronStorage.ts
@@ -2,17 +2,18 @@ import * as electron from 'electron';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import type { LDLogger, Storage } from '@launchdarkly/js-client-sdk-common';
+import type { Storage } from '@launchdarkly/js-client-sdk-common';
 
 export default class ElectronStorage implements Storage {
   private readonly _storageFile: string;
   private readonly _tempFile: string;
   private readonly _initialized: Promise<boolean>;
+  private _initError?: Error;
   private _cache: Map<string, string>;
   private _flushPending: boolean = false;
   private _flushQueue: Promise<void> = Promise.resolve();
 
-  constructor(private readonly _logger?: LDLogger) {
+  constructor() {
     this._storageFile = path.join(electron.app.getPath('userData'), 'ldcache');
     this._tempFile = `${this._storageFile}.tmp`;
     this._cache = new Map<string, string>();
@@ -22,25 +23,22 @@ export default class ElectronStorage implements Storage {
   private async _initialize(): Promise<boolean> {
     try {
       try {
-        // Clean up any leftover temp files from crashed writes
         await fs.unlink(this._tempFile);
       } catch {
         // Ignore error if file doesn't exist
       }
 
       try {
-        // Populate cache if file exists
         const data = await fs.readFile(this._storageFile, 'utf8');
         const parsed = JSON.parse(data);
         this._cache = new Map(Object.entries(parsed));
       } catch {
-        // If file doesn't exist, initialize with empty object
         await this._atomicWriteToFile(this._cache);
       }
 
       return true;
     } catch (error) {
-      this._logError('Error initializing storage', error);
+      this._initError = error instanceof Error ? error : new Error(String(error));
       return false;
     }
   }
@@ -48,65 +46,44 @@ export default class ElectronStorage implements Storage {
   private async _atomicWriteToFile(data: Map<string, string>): Promise<void> {
     try {
       const content = JSON.stringify(Object.fromEntries(data));
-
-      // Write to temporary file first
       await fs.writeFile(this._tempFile, content, { encoding: 'utf8', mode: 0o600 });
-
-      // Rename temporary file to target file (atomic operation on most filesystems)
       await fs.rename(this._tempFile, this._storageFile);
     } catch (error) {
       try {
         await fs.unlink(this._tempFile);
-      } catch (cleanupError) {
-        this._logError('Error cleaning up temporary file', cleanupError);
+      } catch {
+        // Ignore cleanup errors
       }
       throw error;
     }
   }
 
-  private _logError(message: string, error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : error;
-    this._logger?.error(`${message}: ${errorMessage}`);
-  }
-
   private async _throwIfNotInitialized() {
     const initialized = await this._initialized;
     if (!initialized) {
-      throw new Error('Storage is not initialized');
+      const reason = this._initError ? `: ${this._initError.message}` : '';
+      throw new Error(`Storage is not initialized${reason}`);
     }
   }
 
   async clear(key: string): Promise<void> {
-    try {
-      await this._throwIfNotInitialized();
-      if (this._cache.has(key)) {
-        this._cache.delete(key);
-        await this._scheduleFlush();
-      }
-    } catch (error) {
-      this._logError(`Error clearing key from storage: ${key}, reason`, error);
+    await this._throwIfNotInitialized();
+    if (this._cache.has(key)) {
+      this._cache.delete(key);
+      await this._scheduleFlush();
     }
   }
 
   async get(key: string): Promise<string | null> {
-    try {
-      await this._throwIfNotInitialized();
-      const value = this._cache.get(key);
-      return value ?? null;
-    } catch (error) {
-      this._logError(`Error getting key from storage: ${key}, reason`, error);
-      return null;
-    }
+    await this._throwIfNotInitialized();
+    const value = this._cache.get(key);
+    return value ?? null;
   }
 
   async set(key: string, value: string): Promise<void> {
-    try {
-      await this._throwIfNotInitialized();
-      this._cache.set(key, value);
-      await this._scheduleFlush();
-    } catch (error) {
-      this._logError(`Error setting key in storage: ${key}, reason`, error);
-    }
+    await this._throwIfNotInitialized();
+    this._cache.set(key, value);
+    await this._scheduleFlush();
   }
 
   private _scheduleFlush(): Promise<void> {
@@ -114,15 +91,14 @@ export default class ElectronStorage implements Storage {
       return this._flushQueue;
     }
     this._flushPending = true;
-    this._flushQueue = this._flushQueue
-      .then(async () => {
-        this._flushPending = false;
-        await this._atomicWriteToFile(new Map(this._cache));
-      })
-      .catch((error) => {
-        this._logError('Error flushing storage to disk', error);
-      });
-    return this._flushQueue;
+
+    const flush = this._flushQueue.then(async () => {
+      this._flushPending = false;
+      await this._atomicWriteToFile(new Map(this._cache));
+    });
+
+    this._flushQueue = flush.catch(() => {});
+    return flush;
   }
 }
 
@@ -130,9 +106,9 @@ export default class ElectronStorage implements Storage {
 // the same limitations as the browser sdk using the shared localStorage cache.
 let instance: ElectronStorage | undefined;
 
-export function getElectronStorage(logger?: LDLogger): ElectronStorage {
+export function getElectronStorage(): ElectronStorage {
   if (!instance) {
-    instance = new ElectronStorage(logger);
+    instance = new ElectronStorage();
   }
   return instance;
 }

--- a/packages/sdk/electron/src/platform/ElectronStorage.ts
+++ b/packages/sdk/electron/src/platform/ElectronStorage.ts
@@ -10,11 +10,8 @@ export default class ElectronStorage implements Storage {
   private readonly _initialized: Promise<boolean>;
   private _cache: Map<string, string>;
 
-  constructor(
-    private readonly _namespace: string,
-    private readonly _logger?: LDLogger,
-  ) {
-    this._storageFile = path.join(electron.app.getPath('userData'), `ldcache-${this._namespace}`);
+  constructor(private readonly _logger?: LDLogger) {
+    this._storageFile = path.join(electron.app.getPath('userData'), 'ldcache');
     this._tempFile = `${this._storageFile}.tmp`;
     this._cache = new Map<string, string>();
     this._initialized = this._initialize();

--- a/packages/sdk/electron/src/platform/ElectronStorage.ts
+++ b/packages/sdk/electron/src/platform/ElectronStorage.ts
@@ -9,6 +9,8 @@ export default class ElectronStorage implements Storage {
   private readonly _tempFile: string;
   private readonly _initialized: Promise<boolean>;
   private _cache: Map<string, string>;
+  private _flushPending: boolean = false;
+  private _flushQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly _logger?: LDLogger) {
     this._storageFile = path.join(electron.app.getPath('userData'), 'ldcache');
@@ -58,7 +60,7 @@ export default class ElectronStorage implements Storage {
       } catch (cleanupError) {
         this._logError('Error cleaning up temporary file', cleanupError);
       }
-      throw error; // Re-throw the original error
+      throw error;
     }
   }
 
@@ -78,11 +80,8 @@ export default class ElectronStorage implements Storage {
     try {
       await this._throwIfNotInitialized();
       if (this._cache.has(key)) {
-        const cacheCopy = new Map(this._cache);
-        cacheCopy.delete(key);
-        await this._atomicWriteToFile(cacheCopy);
-        // Only update cache if write was successful
-        this._cache = cacheCopy;
+        this._cache.delete(key);
+        await this._scheduleFlush();
       }
     } catch (error) {
       this._logError(`Error clearing key from storage: ${key}, reason`, error);
@@ -103,14 +102,27 @@ export default class ElectronStorage implements Storage {
   async set(key: string, value: string): Promise<void> {
     try {
       await this._throwIfNotInitialized();
-      const cacheCopy = new Map(this._cache);
-      cacheCopy.set(key, value);
-      await this._atomicWriteToFile(cacheCopy);
-      // Only update cache if write was successful
-      this._cache = cacheCopy;
+      this._cache.set(key, value);
+      await this._scheduleFlush();
     } catch (error) {
       this._logError(`Error setting key in storage: ${key}, reason`, error);
     }
+  }
+
+  private _scheduleFlush(): Promise<void> {
+    if (this._flushPending) {
+      return this._flushQueue;
+    }
+    this._flushPending = true;
+    this._flushQueue = this._flushQueue
+      .then(async () => {
+        this._flushPending = false;
+        await this._atomicWriteToFile(new Map(this._cache));
+      })
+      .catch((error) => {
+        this._logError('Error flushing storage to disk', error);
+      });
+    return this._flushQueue;
   }
 }
 

--- a/packages/sdk/electron/src/platform/ElectronStorage.ts
+++ b/packages/sdk/electron/src/platform/ElectronStorage.ts
@@ -113,3 +113,19 @@ export default class ElectronStorage implements Storage {
     }
   }
 }
+
+// Storage should be a singleton to support multiple instances of the SDK. This should have
+// the same limitations as the browser sdk using the shared localStorage cache.
+let instance: ElectronStorage | undefined;
+
+export function getElectronStorage(logger?: LDLogger): ElectronStorage {
+  if (!instance) {
+    instance = new ElectronStorage(logger);
+  }
+  return instance;
+}
+
+/** @internal Visible for testing only. */
+export function resetElectronStorage(): void {
+  instance = undefined;
+}


### PR DESCRIPTION
This PR will fix the localstorage indexing by removing the previous nested structure:
```
ldcache-{credential}
```

To:
```
ldcache
```

The new structure is more consistent with other SDKs by calculating the storage index purely out of the context canonical keys.

This PR will also serialize the write to this cache so that multiple instances of this SDK could exist.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all Electron SDK instances persist flag data by moving to a shared `ldcache` file and introducing singleton/queued flush behavior; this can affect cache isolation and persistence correctness across clients. Risk is mitigated by added tests, but storage/indexing regressions would impact offline/bootstrapped evaluations.
> 
> **Overview**
> Switches Electron SDK persistent flag/context caching from per-credential files (e.g. `ldcache-{credentialHash}`) to a single shared `ldcache` file via a singleton `ElectronStorage`, aligning cache indexing purely with context-derived keys.
> 
> `ElectronStorage` now updates its in-memory cache first and **serializes disk flushes** through a queued atomic-write mechanism; initialization failures now surface as thrown errors (with cause) to the platform wrapper, which logs and swallows storage failures.
> 
> Updates contract tests to reset the storage singleton between clients and removes the `singleton` capability flag, and adds coverage for `maxCachedContexts` eviction/disabled caching plus new `ElectronPlatform` error-logging tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81826d717e121ec4dbb720e01dcac4e1908889e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
