### PR TITLE
fix(electron): correcting package.json versions

### DIFF
--- a/packages/sdk/electron/contract-tests/entity/package.json
+++ b/packages/sdk/electron/contract-tests/entity/package.json
@@ -31,6 +31,9 @@
     "typescript": "~4.5.4",
     "vite": "^5.4.21"
   },
+  "peerDependencies": {
+    "electron": "^40.2.1"
+  },
   "dependencies": {
     "@launchdarkly/js-contract-test-utils": "workspace:^",
     "body-parser": "^2.2.2",

--- a/packages/sdk/electron/example/package.json
+++ b/packages/sdk/electron/example/package.json
@@ -34,6 +34,9 @@
     "typescript": "~4.5.4",
     "vite": "^5.4.21"
   },
+  "peerDependencies": {
+    "electron": "^40.4.1"
+  },
   "dependencies": {
     "@launchdarkly/electron-client-sdk": "0.0.1",
     "electron-squirrel-startup": "^1.0.1"

--- a/packages/sdk/electron/package.json
+++ b/packages/sdk/electron/package.json
@@ -49,7 +49,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "electron": "*"
+    "electron": ">=34.5.6"
   },
   "dependencies": {
     "@launchdarkly/js-client-sdk-common": "workspace:^",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts `peerDependencies` for Electron packages, which can change install-time compatibility for consumers using older Electron versions. No runtime logic changes, but dependency resolution/build pipelines may be affected.
> 
> **Overview**
> Updates Electron package manifests to better reflect supported Electron versions.
> 
> `@launchdarkly/electron-client-sdk` now declares an Electron peer requirement of `>=34.5.6` (instead of `*`), and the `example` and `contract-tests` packages add explicit `peerDependencies` matching their Electron devDependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1f307d5c9462bce656006ab52f4a9f9dab9cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->