### PR TITLE
fix(shopify): standardizing the pre-release banner

### DIFF
--- a/packages/sdk/shopify-oxygen/README.md
+++ b/packages/sdk/shopify-oxygen/README.md
@@ -10,7 +10,10 @@ LaunchDarkly Server SDK for Shopify Oxygen Runtimes
 # ⛔️⛔️⛔️⛔️
 
 > [!CAUTION]
-> *This version of the SDK is a **beta** version and should not be considered ready for production use while this message is visible.*
+> This SDK is in pre-release and not subject to backwards compatibility 
+> guarantees. The API may change based on feedback.
+>
+> Pin to a specific minor version and review the [changelog](./CHANGELOG.md) before upgrading.
 
 # ☝️☝️☝️☝️☝️☝️
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change limited to the README pre-release notice; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the `shopify-oxygen` SDK README pre-release banner to standardize the warning: removes the beta/production-language and replaces it with a *pre-release/no backwards-compatibility* notice, plus explicit guidance to pin minor versions and review `CHANGELOG.md` before upgrading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b68cddea0ab4965d2924124600a5921e733c72fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->