### PR TITLE
ci: fixing release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -264,6 +264,7 @@
     },
     "packages/telemetry/browser-telemetry": {},
     "packages/sdk/electron": {
+      "bump-minor-pre-major": true,
       "extra-files": [
         "src/platform/ElectronInfo.ts",
         {
@@ -274,6 +275,7 @@
       ]
     },
     "packages/sdk/svelte": {
+      "bump-minor-pre-major": true,
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects automated version bump behavior for `packages/sdk/electron` and `packages/sdk/svelte`. No runtime code paths are modified.
> 
> **Overview**
> Updates `release-please-config.json` to set `bump-minor-pre-major: true` for `packages/sdk/electron` and `packages/sdk/svelte`, aligning their release-please behavior so *minor* changes can bump the minor version even while the packages are still pre-`1.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b5bab6ea2fc32ed8fd11f605285015545a0074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
