### PR TITLE
ci: remove electron and svelte from release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -263,27 +263,6 @@
       "release-as": "1.0.0"
     },
     "packages/telemetry/browser-telemetry": {},
-    "packages/sdk/electron": {
-      "bump-minor-pre-major": true,
-      "extra-files": [
-        "src/platform/ElectronInfo.ts",
-        {
-          "type": "json",
-          "path": "example/package.json",
-          "jsonpath": "$.dependencies['@launchdarkly/electron-client-sdk']"
-        }
-      ]
-    },
-    "packages/sdk/svelte": {
-      "bump-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "example/package.json",
-          "jsonpath": "$.dependencies['@launchdarkly/svelte-client-sdk']"
-        }
-      ]
-    },
     "packages/sdk/combined-browser": {
       "bump-minor-pre-major": true
     },


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates release automation config to exclude two packages; no runtime or library code changes.
> 
> **Overview**
> **Release automation update:** `release-please-config.json` no longer includes `packages/sdk/electron` or `packages/sdk/svelte`, removing their `bump-minor-pre-major` and `extra-files` tracking so Release Please stops managing releases/updates for those packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85c50567ff58555a3ade9f58b765a4a076f37d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->