### PR TITLE
feat: Add Strands Provider for AI SDK

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,6 +58,7 @@ on:
           - packages/ai-providers/server-ai-openai
           - packages/ai-providers/server-ai-vercel
           - packages/ai-providers/server-ai-langchain
+          - packages/ai-providers/server-ai-strands
           - packages/telemetry/browser-telemetry
           - packages/sdk/combined-browser
           - packages/sdk/shopify-oxygen
@@ -102,6 +103,7 @@ jobs:
       package-server-ai-langchain-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-langchain--release_created'] }}
       package-server-ai-openai-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-openai--release_created'] }}
       package-server-ai-vercel-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-vercel--release_created'] }}
+      package-server-ai-strands-released: ${{ steps.release.outputs['packages/ai-providers/server-ai-strands--release_created'] }}
       package-browser-telemetry-released: ${{ steps.release.outputs['packages/telemetry/browser-telemetry--release_created'] }}
       package-combined-browser-released: ${{ steps.release.outputs['packages/sdk/combined-browser--release_created'] }}
       package-sdk-shopify-oxygen-released: ${{ steps.release.outputs['packages/sdk/shopify-oxygen--release_created'] }}
@@ -485,6 +487,22 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/ai-providers/server-ai-vercel
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-server-ai-strands:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-server-ai']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-server-ai-strands-released == 'true'}}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: release-server-ai-strands
+        name: Full release of packages/ai-providers/server-ai-strands
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/ai-providers/server-ai-strands
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   release-shopify-oxygen:

--- a/.github/workflows/server-ai-strands.yml
+++ b/.github/workflows/server-ai-strands.yml
@@ -1,0 +1,27 @@
+name: ai-providers/server-ai-strands
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-strands-provider:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/server-sdk-ai-strands'
+          workspace_path: packages/ai-providers/server-ai-strands

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/ai-providers/server-ai-strands": "0.0.0",
   "packages/ai-providers/server-ai-langchain": "0.5.3",
   "packages/ai-providers/server-ai-openai": "0.5.3",
   "packages/ai-providers/server-ai-vercel": "0.5.3",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 
 | AI Providers                                                                              | npm                                                           | issues                                      | tests                                                               |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------- |
+| [@launchdarkly/server-sdk-ai-strands](packages/ai-providers/server-ai-strands/README.md) | [![NPM][server-ai-strands-npm-badge]][server-ai-strands-npm-link] | [server-ai-strands][package-ai-providers-server-ai-strands-issues] | [![Actions Status][server-ai-strands-ci-badge]][server-ai-strands-ci] |
 | [@launchdarkly/server-sdk-ai-langchain](packages/ai-providers/server-ai-langchain/README.md) | [![NPM][server-ai-langchain-npm-badge]][server-ai-langchain-npm-link] | [server-ai-langchain][package-ai-providers-server-ai-langchain-issues] | [![Actions Status][server-ai-langchain-ci-badge]][server-ai-langchain-ci] |
 | [@launchdarkly/server-sdk-ai-openai](packages/ai-providers/server-ai-openai/README.md) | [![NPM][server-ai-openai-npm-badge]][server-ai-openai-npm-link] | [server-ai-openai][package-ai-providers-server-ai-openai-issues] | [![Actions Status][server-ai-openai-ci-badge]][server-ai-openai-ci] |
 | [@launchdarkly/server-sdk-ai-vercel](packages/ai-providers/server-ai-vercel/README.md) | [![NPM][server-ai-vercel-npm-badge]][server-ai-vercel-npm-link] | [server-ai-vercel][package-ai-providers-server-ai-vercel-issues] | [![Actions Status][server-ai-vercel-ci-badge]][server-ai-vercel-ci] |
@@ -228,6 +229,12 @@ We encourage pull requests and other contributions from the community. Check out
 [sdk-combined-browser-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/browser.svg?style=flat-square
 [sdk-combined-browser-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/browser.svg?style=flat-square
 [package-sdk-browser-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fcombined-browser%22+
+[//]: # 'ai-providers/server-ai-strands'
+[server-ai-strands-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-strands.yml/badge.svg
+[server-ai-strands-ci]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-strands.yml
+[server-ai-strands-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/server-sdk-ai-strands.svg?style=flat-square
+[server-ai-strands-npm-link]: https://www.npmjs.com/package/@launchdarkly/server-sdk-ai-strands
+[package-ai-providers-server-ai-strands-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+ai-providers%2Fserver-ai-strands%22+
 [//]: # 'ai-providers/server-ai-langchain'
 [server-ai-langchain-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-langchain.yml/badge.svg
 [server-ai-langchain-ci]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-langchain.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@launchdarkly/js-core",
   "workspaces": [
+    "packages/ai-providers/server-ai-strands",
     "packages/ai-providers/server-ai-langchain",
     "packages/ai-providers/server-ai-openai",
     "packages/ai-providers/server-ai-vercel",

--- a/packages/ai-providers/server-ai-strands/README.md
+++ b/packages/ai-providers/server-ai-strands/README.md
@@ -1,0 +1,57 @@
+# LaunchDarkly AI SDK Strands provider for Server-Side JavaScript
+
+[![NPM][server-ai-strands-npm-badge]][server-ai-strands-npm-link]
+[![Actions Status][server-ai-strands-ci-badge]][server-ai-strands-ci]
+[![Documentation][server-ai-strands-ghp-badge]][server-ai-strands-ghp-link]
+[![NPM][server-ai-strands-dm-badge]][server-ai-strands-npm-link]
+[![NPM][server-ai-strands-dt-badge]][server-ai-strands-npm-link]
+
+> [!CAUTION]
+> This SDK is in pre-release and not subject to backwards compatibility
+> guarantees. The API may change based on feedback.
+>
+> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
+
+## LaunchDarkly overview
+
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
+
+## Overview
+
+This package provides Strands-oriented building blocks for use with the [LaunchDarkly AI SDK](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai). Install it alongside `@launchdarkly/server-sdk-ai` when building or consuming Strands agents on Amazon Bedrock.
+
+```shell
+npm install @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-strands --save
+```
+
+For more information about using the LaunchDarkly AI SDK, see the [LaunchDarkly AI SDK documentation](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-ai/README.md).
+
+## Contributing
+
+We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this SDK.
+
+## About LaunchDarkly
+
+- LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard. With LaunchDarkly, you can:
+  - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+  - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+  - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan).
+  - Disable parts of your application to facilitate maintenance, without taking everything offline.
+- LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+- Explore LaunchDarkly
+  - [launchdarkly.com](https://www.launchdarkly.com/ 'LaunchDarkly Main Website') for more information
+  - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
+  - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
+  - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+[server-ai-strands-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-strands.yml/badge.svg
+[server-ai-strands-ci]: https://github.com/launchdarkly/js-core/actions/workflows/server-ai-strands.yml
+[server-ai-strands-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/server-sdk-ai-strands.svg?style=flat-square
+[server-ai-strands-npm-link]: https://www.npmjs.com/package/@launchdarkly/server-sdk-ai-strands
+[server-ai-strands-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[server-ai-strands-ghp-link]: https://launchdarkly.github.io/js-core/packages/ai-providers/server-ai-strands/docs/
+[server-ai-strands-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/server-sdk-ai-strands.svg?style=flat-square
+[server-ai-strands-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/server-sdk-ai-strands.svg?style=flat-square

--- a/packages/ai-providers/server-ai-strands/__tests__/StrandsProvider.test.ts
+++ b/packages/ai-providers/server-ai-strands/__tests__/StrandsProvider.test.ts
@@ -1,0 +1,436 @@
+import { Agent, type AgentResult } from '@strands-agents/sdk';
+
+import type { LDAIConfig } from '@launchdarkly/server-sdk-ai';
+
+import { StrandsProvider } from '../src/StrandsProvider';
+
+const mockLogger = {
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+type MockStrandsAgent = {
+  messages: unknown[];
+  systemPrompt?: string;
+  invoke: jest.Mock;
+};
+
+// Mock @strands-agents/sdk (ESM-only; Jest loads this instead of node_modules)
+jest.mock('@strands-agents/sdk', () => ({
+  Agent: jest.fn().mockImplementation(() => ({
+    messages: [],
+    systemPrompt: undefined,
+    invoke: jest.fn(),
+  })),
+  BedrockModel: jest.fn().mockImplementation(() => ({})),
+  Message: jest
+    .fn()
+    .mockImplementation((data: { role: 'user' | 'assistant'; content: unknown[] }) => ({
+      role: data.role,
+      content: data.content,
+    })),
+  TextBlock: jest.fn().mockImplementation((text: string) => ({
+    text,
+  })),
+}));
+
+describe('StrandsProvider', () => {
+  it('create returns a StrandsProvider instance', async () => {
+    const config = {
+      key: 'test-config',
+      enabled: true,
+    } as LDAIConfig;
+
+    const provider = await StrandsProvider.create(config);
+
+    expect(provider).toBeInstanceOf(StrandsProvider);
+  });
+
+  describe('invokeModel', () => {
+    let mockAgent: MockStrandsAgent;
+    let provider: StrandsProvider;
+
+    const defaultInvokeResult = {
+      toString: () => 'Hello! How can I help you today?',
+      stopReason: 'endTurn',
+      metrics: {
+        accumulatedUsage: {
+          inputTokens: 10,
+          outputTokens: 15,
+          totalTokens: 25,
+        },
+      },
+    };
+
+    beforeEach(() => {
+      mockAgent = new Agent({}) as unknown as MockStrandsAgent;
+      mockAgent.invoke.mockClear();
+      mockAgent.invoke.mockResolvedValue(defaultInvokeResult);
+      provider = new StrandsProvider(mockAgent as unknown as Agent, mockLogger);
+      jest.clearAllMocks();
+    });
+
+    it('invokes Strands agent and returns response', async () => {
+      const messages = [{ role: 'user' as const, content: 'Hello!' }];
+
+      const result = await provider.invokeModel(messages);
+
+      expect(mockAgent.invoke).toHaveBeenCalledTimes(1);
+      const strandsMessages = mockAgent.invoke.mock.calls[0][0] as {
+        role: string;
+        content: { text: string }[];
+      }[];
+      expect(strandsMessages).toHaveLength(1);
+      expect(strandsMessages[0].role).toBe('user');
+      expect(strandsMessages[0].content[0].text).toBe('Hello!');
+      expect(mockAgent.invoke.mock.calls[0][1]).toBeUndefined();
+
+      expect(result).toEqual({
+        message: {
+          role: 'assistant',
+          content: 'Hello! How can I help you today?',
+        },
+        metrics: {
+          success: true,
+          usage: {
+            total: 25,
+            input: 10,
+            output: 15,
+          },
+        },
+      });
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('invokes agent with system and user messages', async () => {
+      const messages = [
+        { role: 'system' as const, content: 'You are helpful.' },
+        { role: 'user' as const, content: 'Hello!' },
+      ];
+
+      const result = await provider.invokeModel(messages);
+
+      expect(mockAgent.invoke).toHaveBeenCalledTimes(1);
+      const strandsMessages = mockAgent.invoke.mock.calls[0][0] as { role: string }[];
+      expect(strandsMessages).toHaveLength(1);
+      expect(strandsMessages[0].role).toBe('user');
+      expect(result.message.content).toBe('Hello! How can I help you today?');
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns unsuccessful response when no content in response', async () => {
+      mockAgent.invoke.mockResolvedValue({
+        toString: () => '',
+        stopReason: 'endTurn',
+        metrics: undefined,
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Hello!' }];
+
+      const result = await provider.invokeModel(messages);
+
+      expect(result).toEqual({
+        message: {
+          role: 'assistant',
+          content: '',
+        },
+        metrics: {
+          success: false,
+          usage: undefined,
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith('Strands agent response has no text content');
+    });
+
+    it('returns unsuccessful response when agent invoke throws', async () => {
+      const error = new Error('Bedrock error');
+      mockAgent.invoke.mockRejectedValue(error);
+
+      const messages = [{ role: 'user' as const, content: 'Hello!' }];
+
+      const result = await provider.invokeModel(messages);
+
+      expect(result).toEqual({
+        message: {
+          role: 'assistant',
+          content: '',
+        },
+        metrics: {
+          success: false,
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith('Strands agent invocation failed:', error);
+    });
+
+    it('returns unsuccessful response when only system messages are provided', async () => {
+      const messages = [{ role: 'system' as const, content: 'You are a bot.' }];
+
+      const result = await provider.invokeModel(messages);
+
+      expect(mockAgent.invoke).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        message: {
+          role: 'assistant',
+          content: '',
+        },
+        metrics: {
+          success: false,
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Strands agent invocation failed:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('invokeStructuredModel', () => {
+    let mockAgent: MockStrandsAgent;
+    let provider: StrandsProvider;
+
+    const structuredPerson = { name: 'John', age: 30, city: 'New York' };
+
+    const defaultStructuredInvokeResult = {
+      structuredOutput: structuredPerson,
+      stopReason: 'endTurn',
+      metrics: {
+        accumulatedUsage: {
+          inputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 30,
+        },
+      },
+    };
+
+    beforeEach(() => {
+      mockAgent = new Agent({}) as unknown as MockStrandsAgent;
+      mockAgent.invoke.mockClear();
+      mockAgent.invoke.mockResolvedValue(defaultStructuredInvokeResult);
+      provider = new StrandsProvider(mockAgent as unknown as Agent, mockLogger);
+      jest.clearAllMocks();
+    });
+
+    it('invokes Strands agent with structured output and returns parsed response', async () => {
+      const messages = [{ role: 'user' as const, content: 'Tell me about a person' }];
+      const responseStructure = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'number' },
+          city: { type: 'string' },
+        },
+        required: ['name', 'age', 'city'],
+      };
+
+      const result = await provider.invokeStructuredModel(messages, responseStructure);
+
+      expect(mockAgent.invoke).toHaveBeenCalledTimes(1);
+      const strandsMessages = mockAgent.invoke.mock.calls[0][0] as {
+        role: string;
+        content: { text: string }[];
+      }[];
+      expect(strandsMessages[0].content[0].text).toBe('Tell me about a person');
+      expect(mockAgent.invoke.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          structuredOutputSchema: expect.anything(),
+        }),
+      );
+
+      expect(result).toEqual({
+        data: {
+          name: 'John',
+          age: 30,
+          city: 'New York',
+        },
+        rawResponse: JSON.stringify(structuredPerson),
+        metrics: {
+          success: true,
+          usage: {
+            total: 30,
+            input: 20,
+            output: 10,
+          },
+        },
+      });
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('wraps non-object structured output in data.value', async () => {
+      mockAgent.invoke.mockResolvedValue({
+        structuredOutput: 42,
+        stopReason: 'endTurn',
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Pick a number' }];
+      const result = await provider.invokeStructuredModel(messages, { type: 'number' });
+
+      expect(result.data).toEqual({ value: 42 });
+      expect(result.rawResponse).toBe('42');
+      expect(result.metrics.success).toBe(true);
+    });
+
+    it('returns unsuccessful response when structured output is missing', async () => {
+      mockAgent.invoke.mockResolvedValue({
+        structuredOutput: undefined,
+        stopReason: 'endTurn',
+        metrics: undefined,
+      });
+
+      const messages = [{ role: 'user' as const, content: 'Tell me about a person' }];
+      const responseStructure = { type: 'object' };
+
+      const result = await provider.invokeStructuredModel(messages, responseStructure);
+
+      expect(result).toEqual({
+        data: {},
+        rawResponse: '',
+        metrics: {
+          success: false,
+          usage: undefined,
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Strands agent structured response has no structured output',
+      );
+    });
+
+    it('returns success=false when structured invocation throws an error', async () => {
+      const error = new Error('Structured invocation failed');
+      mockAgent.invoke.mockRejectedValue(error);
+
+      const messages = [{ role: 'user' as const, content: 'Hello' }];
+      const responseStructure = { type: 'object', properties: {} };
+
+      const result = await provider.invokeStructuredModel(messages, responseStructure);
+
+      expect(result.metrics.success).toBe(false);
+      expect(result.data).toEqual({});
+      expect(result.rawResponse).toBe('');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Strands agent structured invocation failed:',
+        error,
+      );
+    });
+
+    it('returns unsuccessful response when only system messages are provided', async () => {
+      const messages = [{ role: 'system' as const, content: 'You are a bot.' }];
+      const responseStructure = { type: 'object', properties: {} };
+
+      const result = await provider.invokeStructuredModel(messages, responseStructure);
+
+      expect(mockAgent.invoke).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        data: {},
+        rawResponse: '',
+        metrics: {
+          success: false,
+        },
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Strands agent structured invocation failed:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('getAIMetricsFromAgentResult', () => {
+    it('creates metrics with success=true and token usage', () => {
+      const mockResult = {
+        stopReason: 'endTurn',
+        metrics: {
+          accumulatedUsage: {
+            inputTokens: 50,
+            outputTokens: 50,
+            totalTokens: 100,
+          },
+        },
+      } as unknown as AgentResult;
+
+      const result = StrandsProvider.getAIMetricsFromAgentResult(mockResult);
+
+      expect(result).toEqual({
+        success: true,
+        usage: {
+          total: 100,
+          input: 50,
+          output: 50,
+        },
+      });
+    });
+
+    it('creates metrics with success=true and no usage when usage is missing', () => {
+      const mockResult = {
+        stopReason: 'endTurn',
+      } as unknown as AgentResult;
+
+      const result = StrandsProvider.getAIMetricsFromAgentResult(mockResult);
+
+      expect(result).toEqual({
+        success: true,
+        usage: undefined,
+      });
+    });
+
+    it('handles partial usage data', () => {
+      const mockResult = {
+        stopReason: 'endTurn',
+        metrics: {
+          accumulatedUsage: {
+            inputTokens: 30,
+            // outputTokens and totalTokens missing
+          },
+        },
+      } as unknown as AgentResult;
+
+      const result = StrandsProvider.getAIMetricsFromAgentResult(mockResult);
+
+      expect(result).toEqual({
+        success: true,
+        usage: {
+          total: 0,
+          input: 30,
+          output: 0,
+        },
+      });
+    });
+
+    it('sets success=false when stopReason is cancelled', () => {
+      const mockResult = {
+        stopReason: 'cancelled',
+        metrics: {
+          accumulatedUsage: {
+            inputTokens: 10,
+            outputTokens: 0,
+            totalTokens: 10,
+          },
+        },
+      } as unknown as AgentResult;
+
+      const result = StrandsProvider.getAIMetricsFromAgentResult(mockResult);
+
+      expect(result).toEqual({
+        success: false,
+        usage: {
+          total: 10,
+          input: 10,
+          output: 0,
+        },
+      });
+    });
+
+    it('sets success=false when stopReason is modelContextWindowExceeded', () => {
+      const mockResult = {
+        stopReason: 'modelContextWindowExceeded',
+      } as unknown as AgentResult;
+
+      const result = StrandsProvider.getAIMetricsFromAgentResult(mockResult);
+
+      expect(result).toEqual({
+        success: false,
+        usage: undefined,
+      });
+    });
+  });
+});

--- a/packages/ai-providers/server-ai-strands/jest.config.cjs
+++ b/packages/ai-providers/server-ai-strands/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  transform: { '^.+\\.ts?$': 'ts-jest' },
+  testMatch: ['**/__tests__/**/*test.ts?(x)'],
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  collectCoverageFrom: ['src/**/*.ts'],
+};

--- a/packages/ai-providers/server-ai-strands/package.json
+++ b/packages/ai-providers/server-ai-strands/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@launchdarkly/server-sdk-ai-strands",
+  "version": "0.1.0",
+  "description": "LaunchDarkly AI SDK Strands provider for Server-Side JavaScript",
+  "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/ai-providers/server-ai-strands",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/js-core.git"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup-node",
+    "lint": "npx eslint . --ext .ts",
+    "prettier": "prettier --write '**/*.@(js|ts|tsx|json|css)' --ignore-path ../../../.prettierignore",
+    "lint:fix": "yarn run lint --fix",
+    "check": "yarn prettier && yarn lint && yarn build && yarn test",
+    "test": "jest"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "launchdarkly",
+    "ai",
+    "llm",
+    "strands",
+    "agent"
+  ],
+  "author": "LaunchDarkly",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@launchdarkly/server-sdk-ai": "^0.16.7",
+    "@strands-agents/sdk": "^1.0.0-rc.3",
+    "@trivago/prettier-plugin-sort-imports": "^4.1.1",
+    "@types/jest": "^29.5.3",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "eslint": "^8.45.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.6.3",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.6.1",
+    "prettier": "^3.0.0",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.5.1",
+    "typescript": "5.1.6",
+    "zod": "^4.1.0"
+  },
+  "peerDependencies": {
+    "@launchdarkly/server-sdk-ai": "^0.15.0 || ^0.16.0",
+    "@strands-agents/sdk": "^1.0.0-rc.3",
+    "zod": "^4.1.0"
+  }
+}

--- a/packages/ai-providers/server-ai-strands/src/StrandsProvider.ts
+++ b/packages/ai-providers/server-ai-strands/src/StrandsProvider.ts
@@ -1,0 +1,275 @@
+import { Agent, BedrockModel, Message, TextBlock } from '@strands-agents/sdk';
+import type { AgentResult, BedrockModelOptions } from '@strands-agents/sdk';
+import { fromJSONSchema, z, type ZodType } from 'zod';
+
+import {
+  AIProvider,
+  ChatResponse,
+  type LDAIConfig,
+  type LDAIMetrics,
+  type LDLogger,
+  LDMessage,
+  type LDTokenUsage,
+  StructuredResponse,
+} from '@launchdarkly/server-sdk-ai';
+
+/**
+ * LaunchDarkly AI provider for Strands agents on Amazon Bedrock.
+ * Extend with model invocation; {@link StrandsProvider.create} wires configuration from LDAI config.
+ */
+export class StrandsProvider extends AIProvider {
+  private _agent: Agent;
+
+  constructor(agent: Agent, logger?: LDLogger) {
+    super(logger);
+    this._agent = agent;
+  }
+
+  /**
+   * Invoke the Strands agent with an array of messages.
+   */
+  async invokeModel(messages: LDMessage[]): Promise<ChatResponse> {
+    const previousSystemPrompt = this._agent.systemPrompt;
+    try {
+      const systemTexts = messages.filter((m) => m.role === 'system').map((m) => m.content);
+      if (systemTexts.length > 0) {
+        this._agent.systemPrompt = systemTexts.join('\n\n');
+      }
+
+      const conversationMessages = messages.filter((m) => m.role !== 'system');
+      if (conversationMessages.length === 0) {
+        throw new Error('Strands agent invocation requires at least one user or assistant message');
+      }
+
+      this._agent.messages.splice(0, this._agent.messages.length);
+
+      const strandsMessages = StrandsProvider.convertMessagesToStrands(conversationMessages);
+      const result = await this._agent.invoke(strandsMessages);
+
+      const content = result.toString();
+      const metrics = StrandsProvider.getAIMetricsFromAgentResult(result);
+
+      if (!content) {
+        this.logger?.warn('Strands agent response has no text content');
+        metrics.success = false;
+      }
+
+      return {
+        message: {
+          role: 'assistant',
+          content,
+        },
+        metrics,
+      };
+    } catch (error) {
+      this.logger?.warn('Strands agent invocation failed:', error);
+      return {
+        message: {
+          role: 'assistant',
+          content: '',
+        },
+        metrics: {
+          success: false,
+        },
+      };
+    } finally {
+      this._agent.systemPrompt = previousSystemPrompt;
+    }
+  }
+  /**
+   * Invoke the Strands agent with structured output (Zod schema derived from JSON Schema).
+   * Uses per-invocation {@link Agent.invoke} options `structuredOutputSchema`, matching Strands
+   * structured-output flows.
+   */
+  async invokeStructuredModel(
+    messages: LDMessage[],
+    responseStructure: Record<string, unknown>,
+  ): Promise<StructuredResponse> {
+    const previousSystemPrompt = this._agent.systemPrompt;
+    try {
+      const systemTexts = messages.filter((m) => m.role === 'system').map((m) => m.content);
+      if (systemTexts.length > 0) {
+        this._agent.systemPrompt = systemTexts.join('\n\n');
+      }
+
+      const conversationMessages = messages.filter((m) => m.role !== 'system');
+      if (conversationMessages.length === 0) {
+        throw new Error('Strands agent invocation requires at least one user or assistant message');
+      }
+
+      this._agent.messages.splice(0, this._agent.messages.length);
+
+      const strandsMessages = StrandsProvider.convertMessagesToStrands(conversationMessages);
+      const zodSchema = StrandsProvider.responseStructureToZodSchema(responseStructure);
+
+      const result = await this._agent.invoke(strandsMessages, {
+        structuredOutputSchema: zodSchema,
+      });
+
+      const metrics = StrandsProvider.getAIMetricsFromAgentResult(result);
+      const { structuredOutput } = result;
+
+      if (structuredOutput === undefined) {
+        this.logger?.warn('Strands agent structured response has no structured output');
+        metrics.success = false;
+        return {
+          data: {},
+          rawResponse: '',
+          metrics,
+        };
+      }
+
+      const data: Record<string, unknown> =
+        structuredOutput !== null &&
+        typeof structuredOutput === 'object' &&
+        !Array.isArray(structuredOutput)
+          ? (structuredOutput as Record<string, unknown>)
+          : { value: structuredOutput as unknown };
+
+      return {
+        data,
+        rawResponse: JSON.stringify(structuredOutput),
+        metrics,
+      };
+    } catch (error) {
+      this.logger?.warn('Strands agent structured invocation failed:', error);
+      return {
+        data: {},
+        rawResponse: '',
+        metrics: {
+          success: false,
+        },
+      };
+    } finally {
+      this._agent.systemPrompt = previousSystemPrompt;
+    }
+  }
+
+  /**
+   * Build a Zod schema from LaunchDarkly's JSON Schema–style `responseStructure` for use with
+   * Strands {@link Agent.invoke} (`structuredOutputSchema`). Uses Zod's `fromJSONSchema`.
+   *
+   * @param responseStructure JSON Schema object (e.g. from AI Config or judge evaluation schema)
+   */
+  static responseStructureToZodSchema(responseStructure: Record<string, unknown>): ZodType {
+    if (!responseStructure || Object.keys(responseStructure).length === 0) {
+      return z.record(z.string(), z.unknown());
+    }
+    return fromJSONSchema(responseStructure as Parameters<typeof fromJSONSchema>[0]);
+  }
+
+  /**
+   * Static factory method to create a StrandsProvider from an AI configuration.
+   */
+  static async create(aiConfig: LDAIConfig, logger?: LDLogger): Promise<StrandsProvider> {
+    const bedrockOptions = StrandsProvider.createBedrockModelOptions(aiConfig);
+    const model = new BedrockModel(bedrockOptions);
+    const agent = new Agent({ model, printer: false });
+    return new StrandsProvider(agent, logger);
+  }
+
+  /**
+   * Create Bedrock model options from a LaunchDarkly AI configuration.
+   * This public helper method enables developers to initialize their own {@link BedrockModel}
+   * using LaunchDarkly AI configurations.
+   *
+   * @param aiConfig The LaunchDarkly AI configuration
+   * @returns Options suitable for `new BedrockModel(options)`
+   */
+  static createBedrockModelOptions(aiConfig: LDAIConfig): BedrockModelOptions {
+    const modelId = aiConfig.model?.name || '';
+    const parameters = aiConfig.model?.parameters || {};
+    return StrandsProvider.mapParametersToBedrockOptions(parameters, modelId);
+  }
+
+  /**
+   * Map LaunchDarkly model parameters to {@link BedrockModelOptions}.
+   * Aligns with common LDAI parameter names (e.g. max_tokens, top_p) used across AI providers.
+   *
+   * @param parameters The LaunchDarkly model parameters object
+   * @param modelId The Bedrock model identifier
+   */
+  static mapParametersToBedrockOptions(
+    parameters: Record<string, unknown>,
+    modelId: string,
+  ): BedrockModelOptions {
+    const options: BedrockModelOptions = { modelId };
+
+    if (parameters.max_completion_tokens !== undefined) {
+      options.maxTokens = parameters.max_completion_tokens as number;
+    } else if (parameters.max_tokens !== undefined) {
+      options.maxTokens = parameters.max_tokens as number;
+    }
+    if (parameters.temperature !== undefined) {
+      options.temperature = parameters.temperature as number;
+    }
+    if (parameters.top_p !== undefined) {
+      options.topP = parameters.top_p as number;
+    }
+    if (parameters.stop !== undefined) {
+      options.stopSequences = parameters.stop as string[];
+    }
+    if (typeof parameters.region === 'string') {
+      options.region = parameters.region;
+    }
+    if (typeof parameters.stream === 'boolean') {
+      options.stream = parameters.stream;
+    }
+
+    return options;
+  }
+
+  /**
+   * Convert LaunchDarkly messages to Strands {@link Message} instances.
+   * This helper method enables developers to work directly with Strands message types
+   * while maintaining compatibility with LaunchDarkly's standardized message format.
+   * System messages should be supplied via {@link Agent.systemPrompt}, not in this array.
+   *
+   * @param messages User and assistant messages (typically excluding system role)
+   */
+  static convertMessagesToStrands(messages: LDMessage[]): Message[] {
+    return messages.map((msg) => {
+      const role = msg.role === 'user' ? 'user' : 'assistant';
+      return new Message({
+        role,
+        content: [new TextBlock(msg.content)],
+      });
+    });
+  }
+
+  /**
+   * Get AI metrics from a Strands {@link AgentResult}.
+   * This method extracts token usage and success status from Strands agent results
+   * and returns a LaunchDarkly {@link LDAIMetrics} object.
+   *
+   * @param result The result from {@link Agent.invoke}
+   * @returns LDAIMetrics with success status and token usage
+   *
+   * @example
+   * const result = await aiConfig.tracker.trackMetricsOf(
+   *   StrandsProvider.getAIMetricsFromAgentResult,
+   *   () => agent.invoke(messages)
+   * );
+   */
+  static getAIMetricsFromAgentResult(result: AgentResult): LDAIMetrics {
+    let usage: LDTokenUsage | undefined;
+    const accumulated = result.metrics?.accumulatedUsage;
+    if (accumulated) {
+      usage = {
+        total: accumulated.totalTokens ?? 0,
+        input: accumulated.inputTokens ?? 0,
+        output: accumulated.outputTokens ?? 0,
+      };
+    }
+
+    let success = true;
+    if (result.stopReason === 'cancelled' || result.stopReason === 'modelContextWindowExceeded') {
+      success = false;
+    }
+
+    return {
+      success,
+      usage,
+    };
+  }
+}

--- a/packages/ai-providers/server-ai-strands/src/index.ts
+++ b/packages/ai-providers/server-ai-strands/src/index.ts
@@ -1,0 +1,1 @@
+export { StrandsProvider } from './StrandsProvider';

--- a/packages/ai-providers/server-ai-strands/tsconfig.eslint.json
+++ b/packages/ai-providers/server-ai-strands/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/packages/ai-providers/server-ai-strands/tsconfig.json
+++ b/packages/ai-providers/server-ai-strands/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/ai-providers/server-ai-strands/tsconfig.ref.json
+++ b/packages/ai-providers/server-ai-strands/tsconfig.ref.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/ai-providers/server-ai-strands/tsup.config.ts
+++ b/packages/ai-providers/server-ai-strands/tsup.config.ts
@@ -1,0 +1,14 @@
+// It is a dev dependency and the linter doesn't understand.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+});

--- a/packages/ai-providers/server-ai-strands/typedoc.json
+++ b/packages/ai-providers/server-ai-strands/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,6 +47,10 @@
         }
       ]
     },
+    "packages/ai-providers/server-ai-strands": {
+      "bump-minor-pre-major": true,
+      "prerelease": true
+    },
     "packages/ai-providers/server-ai-openai": {
       "bump-minor-pre-major": true,
       "prerelease": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,9 @@
       "path": "./packages/sdk/combined-browser/tsconfig.ref.json"
     },
     {
+      "path": "./packages/ai-providers/server-ai-strands/tsconfig.ref.json"
+    },
+    {
       "path": "./packages/ai-providers/server-ai-langchain/tsconfig.ref.json"
     },
     {


### PR DESCRIPTION
## Summary

- Adds a new `@launchdarkly/server-ai-strands` package that implements a LaunchDarkly AI provider for the [AWS Strands Agents SDK](https://strandsagents.com/)
- Implements `StrandsProvider` integrating with the LaunchDarkly AI SDK (`LDAIClient`) to track token usage, latency, errors, and feedback for Strands-based AI calls
- Includes CI workflow (`server-ai-strands.yml`) and release-please configuration for the new package

## Test plan

- [ ] Unit tests pass: `yarn workspace @launchdarkly/server-ai-strands test`
- [ ] Lint passes: `yarn workspace @launchdarkly/server-ai-strands lint`
- [ ] Build passes: `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/server-ai-strands' run build`
- [ ] Verify `StrandsProvider` correctly reports token usage, latency, and errors to LaunchDarkly

🤖 Generated with [Claude Code](https://claude.com/claude-code)