### PR TITLE
feat: support waitForNetworkResults in FDv2 data manager

### DIFF
--- a/packages/shared/sdk-client/src/datasource/FDv2DataManagerBase.ts
+++ b/packages/shared/sdk-client/src/datasource/FDv2DataManagerBase.ts
@@ -157,6 +157,14 @@ export function createFDv2DataManagerBase(
   let closed = false;
   let flushCallback: (() => void) | undefined;
 
+  /**
+   * The minimum data availability required before the identify promise
+   * resolves. Maps from the public `waitForNetworkResults` option:
+   * - `'cached'` -- resolve as soon as any data (e.g. from cache) is delivered
+   * - `'fresh'`  -- wait for network data with a selector (REFRESHED state)
+   */
+  let minimumDataAvailability: 'cached' | 'fresh' = 'fresh';
+
   // Explicit connection mode override — bypasses transition table entirely.
   let connectionModeOverride: FDv2ConnectionMode | undefined;
 
@@ -329,11 +337,22 @@ export function createFDv2DataManagerBase(
 
     const descriptors = flagEvalPayloadToItemDescriptors(payload.updates ?? []);
     // Flag updates and change events happen synchronously inside applyChanges.
-    // The returned promise is only for async cache persistence — we intentionally
+    // The returned promise is only for async cache persistence -- we intentionally
     // do not await it so the data source pipeline is not blocked by storage I/O.
     flagManager.applyChanges(context, descriptors, payload.type).catch((e) => {
       logger.warn(`${logTag} Failed to persist flag cache: ${e}`);
     });
+
+    // When the minimum data availability is 'cached', resolve the identify
+    // promise as soon as any data (e.g. from cache) has been delivered. The
+    // data source continues its initialization pipeline normally --
+    // subsequent changesets update flags and fire change events.
+    if (minimumDataAvailability === 'cached' && !initialized && pendingIdentifyResolve) {
+      initialized = true;
+      pendingIdentifyResolve();
+      pendingIdentifyResolve = undefined;
+      pendingIdentifyReject = undefined;
+    }
   }
 
   /**
@@ -470,6 +489,7 @@ export function createFDv2DataManagerBase(
       selector = undefined;
       initialized = false;
       bootstrapped = false;
+      minimumDataAvailability = identifyOptions?.waitForNetworkResults ? 'fresh' : 'cached';
       identifiedContext = context;
       pendingIdentifyResolve = identifyResolve;
       pendingIdentifyReject = identifyReject;


### PR DESCRIPTION
The FDv2 data manager now respects the waitForNetworkResults identify option. When false (the default for mobile), identify resolves as soon as cached data is delivered rather than waiting for network.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the `identify` promise resolves (cached-first vs network-fresh), which can alter initialization timing and app control flow across platforms.
> 
> **Overview**
> `FDv2DataManagerBase` now respects `LDIdentifyOptions.waitForNetworkResults` by tracking a `minimumDataAvailability` threshold for `identify` completion.
> 
> When configured to not wait for network results, `identify` can resolve as soon as any initial data (e.g. cache) is delivered via `dataCallback`, while the data source continues initializing and applying subsequent updates as they arrive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2244e654558568c99d006d5ea88400cdf441083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->