### PR TITLE
feat(react-native): no storage fallback to in-memory map

### DIFF
--- a/packages/sdk/react-native/__tests__/platform/ConditionalAsyncStorage.test.ts
+++ b/packages/sdk/react-native/__tests__/platform/ConditionalAsyncStorage.test.ts
@@ -1,0 +1,75 @@
+import type { LDLogger } from '@launchdarkly/js-client-sdk-common';
+
+import getAsyncStorage from '../../src/platform/ConditionalAsyncStorage';
+
+// Do NOT use the global jest setup mock for async-storage in this file.
+// We need to test what happens when the require fails.
+jest.mock('@react-native-async-storage/async-storage', () => {
+  throw new Error('Cannot find module @react-native-async-storage/async-storage');
+});
+
+describe('ConditionalAsyncStorage in-memory fallback', () => {
+  let logger: LDLogger;
+  let storage: any;
+
+  beforeEach(() => {
+    logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    storage = getAsyncStorage(logger);
+  });
+
+  it('logs a warning when AsyncStorage is unavailable', () => {
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AsyncStorage is not available'),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('in-memory storage as a fallback'),
+    );
+  });
+
+  it('returns null for keys that have not been set', async () => {
+    const value = await storage.getItem('nonexistent');
+    expect(value).toBeNull();
+  });
+
+  it('stores and retrieves values within the session', async () => {
+    await storage.setItem('flag-key', '{"flagA":true}');
+    const value = await storage.getItem('flag-key');
+    expect(value).toBe('{"flagA":true}');
+  });
+
+  it('overwrites existing values', async () => {
+    await storage.setItem('key', 'first');
+    await storage.setItem('key', 'second');
+    const value = await storage.getItem('key');
+    expect(value).toBe('second');
+  });
+
+  it('removes values', async () => {
+    await storage.setItem('key', 'value');
+    await storage.removeItem('key');
+    const value = await storage.getItem('key');
+    expect(value).toBeNull();
+  });
+
+  it('removing a nonexistent key does not throw', async () => {
+    await expect(storage.removeItem('nonexistent')).resolves.toBeUndefined();
+  });
+
+  it('isolates storage between separate fallback instances', async () => {
+    const otherLogger: LDLogger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    const otherStorage = getAsyncStorage(otherLogger);
+
+    await storage.setItem('key', 'from-first');
+    await expect(otherStorage.getItem('key')).resolves.toBeNull();
+  });
+});

--- a/packages/sdk/react-native/src/platform/ConditionalAsyncStorage.ts
+++ b/packages/sdk/react-native/src/platform/ConditionalAsyncStorage.ts
@@ -21,14 +21,23 @@ export default function getAsyncStorage(logger: LDLogger): any {
   try {
     return require('@react-native-async-storage/async-storage').default;
   } catch (e) {
-    // Use a mock if async-storage is unavailable
+    // Use an in-memory fallback if async-storage is unavailable.
+    // This preserves session-level persistence (flag caching, generated keys,
+    // context index) but data will not survive app restarts.
     logger.warn(
-      'AsyncStorage is not available, generated keys and context caches will not be persisted. Please see https://launchdarkly.github.io/js-core/packages/sdk/react-native/docs/interfaces/LDOptions.html#storage for more information.',
+      'AsyncStorage is not available. Using in-memory storage as a fallback - cached flags, generated keys, and context data will not persist across app restarts. Please see https://launchdarkly.github.io/js-core/packages/sdk/react-native/docs/interfaces/LDOptions.html#storage for more information.',
     );
+    const memoryStore = new Map<string, string>();
     return {
-      getItem: (_key: string) => Promise.resolve(null),
-      setItem: (_key: string, _value: string) => Promise.resolve(),
-      removeItem: (_key: string) => Promise.resolve(),
+      getItem: (key: string) => Promise.resolve(memoryStore.get(key) ?? null),
+      setItem: (key: string, value: string) => {
+        memoryStore.set(key, value);
+        return Promise.resolve();
+      },
+      removeItem: (key: string) => {
+        memoryStore.delete(key);
+        return Promise.resolve();
+      },
     };
   }
 }


### PR DESCRIPTION
This PR will change the no storage fallback from NOOP to in-memory storage.

SDK-1856

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the React Native SDK storage fallback behavior when `@react-native-async-storage/async-storage` cannot be required, which can affect flag/key/context caching behavior in environments missing the native dependency.
> 
> **Overview**
> When `@react-native-async-storage/async-storage` is unavailable, the React Native SDK now falls back to a per-instance in-memory `Map` implementation instead of a no-op storage, providing *session-only* persistence for cached flags, generated keys, and context data.
> 
> Adds a focused Jest test suite that forces the `require` to fail and verifies the warning log plus basic `getItem`/`setItem`/`removeItem` behavior and isolation between fallback instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77106ed8fa9f46d0498bb7ed76c31e60ec3592ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->