### PR TITLE
chore: rename trackLatency to trackDuration on LDGraphTracker

### DIFF
--- a/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
@@ -165,25 +165,25 @@ it('drops trackInvocationFailure after trackInvocationSuccess and warns', () => 
 });
 
 // ---------------------------------------------------------------------------
-// trackLatency – at-most-once
+// trackDuration – at-most-once
 // ---------------------------------------------------------------------------
 
-it('trackLatency sets durationMs and emits event', () => {
+it('trackDuration sets durationMs and emits event', () => {
   const tracker = makeTracker('r');
-  tracker.trackLatency(1234);
+  tracker.trackDuration(1234);
   expect(tracker.getSummary().durationMs).toBe(1234);
   expect(mockTrack).toHaveBeenCalledWith(
-    '$ld:ai:graph:latency',
+    '$ld:ai:duration:total',
     testContext,
     tracker.getTrackData(),
     1234,
   );
 });
 
-it('drops second trackLatency call and warns', () => {
+it('drops second trackDuration call and warns', () => {
   const tracker = makeTracker('r');
-  tracker.trackLatency(100);
-  tracker.trackLatency(200);
+  tracker.trackDuration(100);
+  tracker.trackDuration(200);
   expect(mockTrack).toHaveBeenCalledTimes(1);
   expect(tracker.getSummary().durationMs).toBe(100);
   expect(mockWarn).toHaveBeenCalled();

--- a/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
@@ -173,7 +173,7 @@ it('trackDuration sets durationMs and emits event', () => {
   tracker.trackDuration(1234);
   expect(tracker.getSummary().durationMs).toBe(1234);
   expect(mockTrack).toHaveBeenCalledWith(
-    '$ld:ai:duration:total',
+    '$ld:ai:graph:duration:total',
     testContext,
     tracker.getTrackData(),
     1234,

--- a/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
@@ -112,7 +112,12 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
       return;
     }
     this._summary.durationMs = durationMs;
-    this._ldClient.track('$ld:ai:duration:total', this._context, this.getTrackData(), durationMs);
+    this._ldClient.track(
+      '$ld:ai:graph:duration:total',
+      this._context,
+      this.getTrackData(),
+      durationMs,
+    );
   }
 
   trackTotalTokens(tokens: LDTokenUsage): void {

--- a/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
@@ -104,15 +104,15 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
     this._ldClient.track('$ld:ai:graph:invocation_failure', this._context, this.getTrackData(), 1);
   }
 
-  trackLatency(durationMs: number): void {
+  trackDuration(durationMs: number): void {
     if (this._summary.durationMs !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: trackLatency already called for this run — dropping duplicate call.',
+        'LDGraphTracker: trackDuration already called for this run — dropping duplicate call.',
       );
       return;
     }
     this._summary.durationMs = durationMs;
-    this._ldClient.track('$ld:ai:graph:latency', this._context, this.getTrackData(), durationMs);
+    this._ldClient.track('$ld:ai:duration:total', this._context, this.getTrackData(), durationMs);
   }
 
   trackTotalTokens(tokens: LDTokenUsage): void {

--- a/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
+++ b/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
@@ -63,7 +63,7 @@ export interface LDGraphTracker {
 
   /**
    * Tracks the total duration of the graph execution in milliseconds.
-   * Emits event `$ld:ai:duration:total` with the duration as the metric value.
+   * Emits event `$ld:ai:graph:duration:total` with the duration as the metric value.
    * At-most-once: subsequent calls are dropped with a warning.
    *
    * @param durationMs Duration in milliseconds.

--- a/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
+++ b/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
@@ -15,7 +15,7 @@ import type { LDGraphMetricSummary, LDGraphTrackData } from './types';
  * try {
  *   // ... execute graph ...
  *   tracker.trackInvocationSuccess();
- *   tracker.trackLatency(durationMs);
+ *   tracker.trackDuration(durationMs);
  * } catch {
  *   tracker.trackInvocationFailure();
  * }
@@ -62,13 +62,13 @@ export interface LDGraphTracker {
   trackInvocationFailure(): void;
 
   /**
-   * Tracks the total latency of the graph execution in milliseconds.
-   * Emits event `$ld:ai:graph:latency` with the duration as the metric value.
+   * Tracks the total duration of the graph execution in milliseconds.
+   * Emits event `$ld:ai:duration:total` with the duration as the metric value.
    * At-most-once: subsequent calls are dropped with a warning.
    *
    * @param durationMs Duration in milliseconds.
    */
-  trackLatency(durationMs: number): void;
+  trackDuration(durationMs: number): void;
 
   /**
    * Tracks aggregate token usage across the entire graph invocation.


### PR DESCRIPTION
## Summary
- Renames `trackLatency()` → `trackDuration()` on the `LDGraphTracker` interface and `LDGraphTrackerImpl` class to align with the existing `trackDuration` naming on `LDAIConfigTracker`
- Updates the event key from `$ld:ai:graph:latency` to `$ld:ai:graph:duration:total` per the updated AIGRAPHTRACK spec
- Updates all tests to match the new method name and event key

## Test plan
- [x] All 144 unit tests pass (`yarn workspace @launchdarkly/server-sdk-ai test`)
- [x] Lint passes clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API rename plus a telemetry event-key change may break downstream callers and dashboards if they aren’t updated, but the implementation change is small and localized.
> 
> **Overview**
> Renames the graph timing API from `trackLatency(durationMs)` to `trackDuration(durationMs)` on `LDGraphTracker` and `LDGraphTrackerImpl`, including updated warnings and docs.
> 
> Switches the emitted metric event from `$ld:ai:graph:latency` to `$ld:ai:graph:duration:total`, and updates unit tests to assert the new method name and event key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cc6cb6006efa02281e897d1374510880011e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->