### PR TITLE
ci: fix dependency-scan SBOM workflow to scan released packages

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -43,6 +43,7 @@ jobs:
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
         with:
           types: 'nodejs'
+          omit-optional: 'true'
 
   evaluate-policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -34,16 +34,16 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
-      - name: Install dependencies
+      - name: Install dependencies (skip platform-specific optionals)
         run: yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+          YARN_SUPPORTED_ARCHITECTURES: '{"os":[],"cpu":[],"libc":[]}'
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
         with:
           types: 'nodejs'
-          omit-optional: 'true'
 
   evaluate-policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -35,10 +35,13 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies (skip platform-specific optionals)
-        run: yarn install
+        run: |
+          yarn config set supportedArchitectures.os --json '[]'
+          yarn config set supportedArchitectures.cpu --json '[]'
+          yarn config set supportedArchitectures.libc --json '[]'
+          yarn install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
-          YARN_SUPPORTED_ARCHITECTURES: '{"os":[],"cpu":[],"libc":[]}'
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,3 +1,12 @@
+# Dependency Scan — License Compliance
+#
+# Generates a CycloneDX SBOM via cdxgen and evaluates it against an OPA/Rego
+# license policy. This checks for disallowed licenses (e.g. GPL in a
+# proprietary SDK) — it does NOT check for CVEs or security vulnerabilities.
+# Vulnerability scanning is handled separately by dependency-review-action.
+#
+# See: SDK-2170, SEC-7263
+
 name: Dependency Scan
 
 on:
@@ -11,6 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # The shared generate-sbom action runs cdxgen, which internally invokes
+      # `yarn install` to resolve the dependency tree. This repo uses Yarn 3.x
+      # via corepack (packageManager field in package.json), so corepack must
+      # be enabled before cdxgen runs. Without this, cdxgen falls back to
+      # system yarn (1.x), fails silently, and produces a 0-component BOM.
+      - name: Setup Node with corepack
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20.x
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
@@ -28,3 +53,15 @@ jobs:
         uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
         with:
           artifacts-pattern: bom-*
+
+      # Guard against silent regression: if cdxgen fails to resolve
+      # dependencies (e.g. corepack not enabled), the BOM will contain
+      # 0 components and the policy evaluation vacuously passes.
+      - name: Verify SBOM contains components
+        run: |
+          COMPONENT_COUNT=$(jq '.components | length' bom.json)
+          echo "SBOM contains $COMPONENT_COUNT components"
+          if [ "$COMPONENT_COUNT" -eq 0 ]; then
+            echo "::error::SBOM contains 0 components — the scan produced nothing. Check that corepack is enabled and dependencies are installed."
+            exit 1
+          fi

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,12 +1,3 @@
-# Dependency Scan — License Compliance
-#
-# Generates a CycloneDX SBOM via cdxgen and evaluates it against an OPA/Rego
-# license policy. This checks for disallowed licenses (e.g. GPL in a
-# proprietary SDK) — it does NOT check for CVEs or security vulnerabilities.
-# Vulnerability scanning is handled separately by dependency-review-action.
-#
-# See: SDK-2170, SEC-7263
-
 name: Dependency Scan
 
 on:
@@ -21,32 +12,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # The shared generate-sbom action runs cdxgen, which internally invokes
-      # `yarn install` to resolve the dependency tree. This repo uses Yarn 3.x
-      # via corepack (packageManager field in package.json), so corepack must
-      # be enabled before cdxgen runs. Without this, cdxgen falls back to
-      # system yarn (1.x), fails silently, and produces a 0-component BOM.
-      - name: Setup Node with corepack
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20.x
 
       - name: Enable corepack
         run: corepack enable
 
-      - name: Install dependencies (skip platform-specific optionals)
-        run: |
-          yarn config set supportedArchitectures.os --json '[]'
-          yarn config set supportedArchitectures.cpu --json '[]'
-          yarn config set supportedArchitectures.libc --json '[]'
-          yarn install
+      - name: Install released package dependencies
+        run: yarn workspaces focus $(node scripts/released-packages.js)
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+          YARN_ENABLE_SCRIPTS: 'false'
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
 
       - name: Generate SBOM
         uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
         with:
           types: 'nodejs'
+          ensure-non-empty: 'true'
 
   evaluate-policy:
     runs-on: ubuntu-latest
@@ -59,15 +43,3 @@ jobs:
         uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@0a54234f88a428df4163234dbb23ddb7fee8b8ec # main
         with:
           artifacts-pattern: bom-*
-
-      # Guard against silent regression: if cdxgen fails to resolve
-      # dependencies (e.g. corepack not enabled), the BOM will contain
-      # 0 components and the policy evaluation vacuously passes.
-      - name: Verify SBOM contains components
-        run: |
-          COMPONENT_COUNT=$(jq '.components | length' bom.json)
-          echo "SBOM contains $COMPONENT_COUNT components"
-          if [ "$COMPONENT_COUNT" -eq 0 ]; then
-            echo "::error::SBOM contains 0 components — the scan produced nothing. Check that corepack is enabled and dependencies are installed."
-            exit 1
-          fi

--- a/scripts/released-packages.js
+++ b/scripts/released-packages.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * Prints the workspace names of all released packages, one per line.
+ * Released packages are those listed in .release-please-manifest.json.
+ */
+
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const manifest = require(path.join(repoRoot, '.release-please-manifest.json'));
+
+for (const pkgPath of Object.keys(manifest)) {
+  const { name } = require(path.join(repoRoot, pkgPath, 'package.json'));
+  console.log(name);
+}


### PR DESCRIPTION
## Summary

The `dependency-scan.yml` workflow has been silently broken since it was added (SEC-7263, Nov 2025). Every run produces a 0-component SBOM and vacuously passes the license policy check.

- **Root cause:** cdxgen internally runs `yarn install` but corepack was never enabled, so it fell back to system yarn 1.x, failed silently, and produced an empty BOM
- Enable corepack and install only released package dependencies (via `yarn workspaces focus`) before cdxgen runs
- Scopes the scan to published packages only, excluding example apps and contract tests that bring in LGPL-licensed dev tooling (e.g. `@img/sharp-libvips` via Next.js)

## Changes

- `.github/workflows/dependency-scan.yml` -- add node setup, corepack, and scoped dependency install before SBOM generation
- `scripts/released-packages.js` -- new script that reads `.release-please-manifest.json` and prints workspace names of all released packages

## Test plan

- [x] Verified locally: clean checkout (no yarn.lock, no node_modules) produces 970 packages with zero LGPL violations
- [ ] Verify the `Dependency Scan` workflow runs green on this PR

Fixes SDK-2170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only changes CI dependency-scanning behavior, but it could cause the `Dependency Scan` workflow to fail if Yarn workspace focusing or the released-packages list is incorrect.
> 
> **Overview**
> Fixes the `Dependency Scan` GitHub Action so SBOM generation runs with the intended Node/Yarn toolchain and produces a **non-empty** BOM.
> 
> The workflow now sets up Node 20, enables `corepack`, installs dependencies for *released* workspaces via `yarn workspaces focus $(node scripts/released-packages.js)`, and passes `ensure-non-empty: 'true'` to the SBOM generator.
> 
> Adds `scripts/released-packages.js`, which reads `.release-please-manifest.json` and prints the corresponding workspace package names to drive the focused install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73db9594c74a4b8da7502630fc8314971e3f012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->