### PR TITLE
fix: remove `rollup-plugin-dts` dependency

### DIFF
--- a/packages/sdk/cloudflare/package.json
+++ b/packages/sdk/cloudflare/package.json
@@ -17,12 +17,12 @@
   ],
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
+    "types": "./dist/esm/src/index.d.ts",
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js"
   },
   "main": "./dist/cjs/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/esm/src/index.d.ts",
   "files": [
     "dist"
   ],
@@ -69,8 +69,6 @@
     "prettier": "^3.0.0",
     "rimraf": "^5.0.1",
     "rollup": "^3.29.2",
-    "rollup-plugin-dts": "^6.0.2",
-    "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-generate-package-json": "^3.2.0",
     "ts-jest": "^29.1.0",

--- a/packages/sdk/cloudflare/rollup.config.ts
+++ b/packages/sdk/cloudflare/rollup.config.ts
@@ -2,16 +2,12 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import dts from 'rollup-plugin-dts';
-import esbuild from 'rollup-plugin-esbuild';
+import typescript from '@rollup/plugin-typescript';
 import filesize from 'rollup-plugin-filesize';
 
 const inputPath = 'src/index.ts';
 const cjsPath = 'dist/cjs/index.js';
 const esmPath = 'dist/esm/index.js';
-const typingsPath = 'dist/index.d.ts';
-
-const plugins = [resolve(), commonjs(), esbuild(), json(), terser(), filesize()];
 
 // the second array item is a function to include all js-core packages in the bundle so they
 // are not imported or required as separate npm packages
@@ -27,7 +23,14 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins,
+    plugins: [
+      resolve(),
+      commonjs(),
+      typescript({ declaration: false, declarationMap: false }),
+      json(),
+      terser(),
+      filesize(),
+    ],
     external,
   },
   {
@@ -39,15 +42,14 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins,
+    plugins: [
+      resolve(),
+      commonjs(),
+      typescript({ declaration: true, declarationDir: 'dist/esm' }),
+      json(),
+      terser(),
+      filesize(),
+    ],
     external,
-  },
-  {
-    input: inputPath,
-    plugins: [dts(), json()],
-    output: {
-      file: typingsPath,
-      format: 'esm',
-    },
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the build pipeline and TypeScript declaration output paths; risk is mainly around consumers resolving `.d.ts` correctly and the published package layout changing.
> 
> **Overview**
> Updates the Cloudflare SDK packaging to **stop using `rollup-plugin-dts`/`rollup-plugin-esbuild`** and instead generate type declarations during the ESM Rollup build via `@rollup/plugin-typescript`.
> 
> As part of this, the package’s `types` entrypoints are repointed from `dist/index.d.ts` to `dist/esm/src/index.d.ts`, and the Rollup config now emits declarations only for the ESM build while disabling them for CJS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de95959726fef7ca89d6919c7c87db78d8e123c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->