### PR TITLE
feat: common identify now reports identify status

### DIFF
--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -9,15 +9,18 @@ import {
   createFDv2DataManagerBase,
   FDv2ConnectionMode,
   FlagManager,
+  Hook,
   internal,
   LDIdentifyOptions as LDBaseIdentifyOptions,
   LDClientImpl,
   LDContext,
   LDEmitter,
   LDEmitterEventName,
+  LDFlagValue,
   LDHeaders,
   LDIdentifyResult,
   LDPluginEnvironmentMetadata,
+  LDWaitForInitializationOptions,
   MODE_TABLE,
   Platform,
   resolveForegroundMode,
@@ -30,7 +33,7 @@ import { BrowserIdentifyOptions as LDIdentifyOptions } from './BrowserIdentifyOp
 import { registerStateDetection } from './BrowserStateDetector';
 import GoalManager from './goals/GoalManager';
 import { Goal, isClick } from './goals/Goals';
-import { LDClient } from './LDClient';
+import { LDClient, LDStartOptions } from './LDClient';
 import { LDPlugin } from './LDPlugin';
 import validateBrowserOptions, { BrowserOptions, filterToBaseOptionsWithDefaults } from './options';
 import BrowserPlatform from './platform/BrowserPlatform';
@@ -290,7 +293,7 @@ export function makeClient(
   options: BrowserOptions = {},
   overridePlatform?: Platform,
 ): LDClient {
-  const client = new BrowserClientImpl(
+  const impl = new BrowserClientImpl(
     clientSideId,
     initialContext,
     autoEnvAttributes,
@@ -298,7 +301,46 @@ export function makeClient(
     overridePlatform,
   );
 
-  client.registerPlugins(client);
+  // Return a PIMPL style implementation. This decouples the interface from the interface of the implementation.
+  // In the future we should consider updating the common SDK code to not use inheritance and instead compose
+  // the leaf-implementation.
+  // Using an object with PIMPL here also allows us to completely hide the underlying implementation, where with a class
+  // it is trivial to access what should be protected (or even private) fields.
+  const client: LDClient = {
+    variation: (key: string, defaultValue?: LDFlagValue) => impl.variation(key, defaultValue),
+    variationDetail: (key: string, defaultValue?: LDFlagValue) =>
+      impl.variationDetail(key, defaultValue),
+    boolVariation: (key: string, defaultValue: boolean) => impl.boolVariation(key, defaultValue),
+    boolVariationDetail: (key: string, defaultValue: boolean) =>
+      impl.boolVariationDetail(key, defaultValue),
+    numberVariation: (key: string, defaultValue: number) => impl.numberVariation(key, defaultValue),
+    numberVariationDetail: (key: string, defaultValue: number) =>
+      impl.numberVariationDetail(key, defaultValue),
+    stringVariation: (key: string, defaultValue: string) => impl.stringVariation(key, defaultValue),
+    stringVariationDetail: (key: string, defaultValue: string) =>
+      impl.stringVariationDetail(key, defaultValue),
+    jsonVariation: (key: string, defaultValue: unknown) => impl.jsonVariation(key, defaultValue),
+    jsonVariationDetail: (key: string, defaultValue: unknown) =>
+      impl.jsonVariationDetail(key, defaultValue),
+    track: (key: string, data?: any, metricValue?: number) => impl.track(key, data, metricValue),
+    on: (key: LDEmitterEventName, callback: (...args: any[]) => void) => impl.on(key, callback),
+    off: (key: LDEmitterEventName, callback: (...args: any[]) => void) => impl.off(key, callback),
+    flush: () => impl.flush(),
+    setConnectionMode: (mode?: FDv2ConnectionMode) => impl.setConnectionMode(mode),
+    setStreaming: (streaming?: boolean) => impl.setStreaming(streaming),
+    identify: (pristineContext: LDContext, identifyOptions?: LDIdentifyOptions) =>
+      impl.identify(pristineContext, identifyOptions),
+    getContext: () => impl.getContext(),
+    close: () => impl.close(),
+    allFlags: () => impl.allFlags(),
+    addHook: (hook: Hook) => impl.addHook(hook),
+    waitForInitialization: (waitOptions?: LDWaitForInitializationOptions) =>
+      impl.waitForInitialization(waitOptions),
+    logger: impl.logger,
+    start: (startOptions?: LDStartOptions) => impl.start(startOptions),
+  };
+
+  impl.registerPlugins(client);
 
   return client;
 }

--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -230,11 +230,7 @@ class BrowserClientImpl extends LDClientImpl {
     }
   }
 
-  override async identify(context: LDContext, identifyOptions?: LDIdentifyOptions): Promise<void> {
-    return super.identify(context, identifyOptions);
-  }
-
-  override async identifyResult(
+  override async identify(
     context: LDContext,
     identifyOptions?: LDIdentifyOptions,
   ): Promise<LDIdentifyResult> {
@@ -242,7 +238,7 @@ class BrowserClientImpl extends LDClientImpl {
       identifyOptions?.sheddable === undefined
         ? { ...identifyOptions, sheddable: true }
         : identifyOptions;
-    const res = await super.identifyResult(context, options);
+    const res = await super.identify(context, options);
     // Ensure that we do not start the goal manager if start() is not called.
     if (this.startPromise) {
       this._goalManager?.startTracking();
@@ -308,7 +304,6 @@ export function makeClient(
   // Return a PIMPL style implementation. This decouples the interface from the interface of the implementation.
   // In the future we should consider updating the common SDK code to not use inheritance and instead compose
   // the leaf-implementation.
-  // The purpose for this in the short-term is to have a signature for identify that is different than the class implementation.
   // Using an object with PIMPL here also allows us to completely hide the underlying implementation, where with a class
   // it is trivial to access what should be protected (or even private) fields.
   const client: LDClient = {
@@ -334,7 +329,7 @@ export function makeClient(
     setConnectionMode: (mode?: FDv2ConnectionMode) => impl.setConnectionMode(mode),
     setStreaming: (streaming?: boolean) => impl.setStreaming(streaming),
     identify: (pristineContext: LDContext, identifyOptions?: LDIdentifyOptions) =>
-      impl.identifyResult(pristineContext, identifyOptions),
+      impl.identify(pristineContext, identifyOptions),
     getContext: () => impl.getContext(),
     close: () => impl.close(),
     allFlags: () => impl.allFlags(),

--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -9,18 +9,15 @@ import {
   createFDv2DataManagerBase,
   FDv2ConnectionMode,
   FlagManager,
-  Hook,
   internal,
   LDIdentifyOptions as LDBaseIdentifyOptions,
   LDClientImpl,
   LDContext,
   LDEmitter,
   LDEmitterEventName,
-  LDFlagValue,
   LDHeaders,
   LDIdentifyResult,
   LDPluginEnvironmentMetadata,
-  LDWaitForInitializationOptions,
   MODE_TABLE,
   Platform,
   resolveForegroundMode,
@@ -33,7 +30,7 @@ import { BrowserIdentifyOptions as LDIdentifyOptions } from './BrowserIdentifyOp
 import { registerStateDetection } from './BrowserStateDetector';
 import GoalManager from './goals/GoalManager';
 import { Goal, isClick } from './goals/Goals';
-import { LDClient, LDStartOptions } from './LDClient';
+import { LDClient } from './LDClient';
 import { LDPlugin } from './LDPlugin';
 import validateBrowserOptions, { BrowserOptions, filterToBaseOptionsWithDefaults } from './options';
 import BrowserPlatform from './platform/BrowserPlatform';
@@ -293,7 +290,7 @@ export function makeClient(
   options: BrowserOptions = {},
   overridePlatform?: Platform,
 ): LDClient {
-  const impl = new BrowserClientImpl(
+  const client = new BrowserClientImpl(
     clientSideId,
     initialContext,
     autoEnvAttributes,
@@ -301,46 +298,7 @@ export function makeClient(
     overridePlatform,
   );
 
-  // Return a PIMPL style implementation. This decouples the interface from the interface of the implementation.
-  // In the future we should consider updating the common SDK code to not use inheritance and instead compose
-  // the leaf-implementation.
-  // Using an object with PIMPL here also allows us to completely hide the underlying implementation, where with a class
-  // it is trivial to access what should be protected (or even private) fields.
-  const client: LDClient = {
-    variation: (key: string, defaultValue?: LDFlagValue) => impl.variation(key, defaultValue),
-    variationDetail: (key: string, defaultValue?: LDFlagValue) =>
-      impl.variationDetail(key, defaultValue),
-    boolVariation: (key: string, defaultValue: boolean) => impl.boolVariation(key, defaultValue),
-    boolVariationDetail: (key: string, defaultValue: boolean) =>
-      impl.boolVariationDetail(key, defaultValue),
-    numberVariation: (key: string, defaultValue: number) => impl.numberVariation(key, defaultValue),
-    numberVariationDetail: (key: string, defaultValue: number) =>
-      impl.numberVariationDetail(key, defaultValue),
-    stringVariation: (key: string, defaultValue: string) => impl.stringVariation(key, defaultValue),
-    stringVariationDetail: (key: string, defaultValue: string) =>
-      impl.stringVariationDetail(key, defaultValue),
-    jsonVariation: (key: string, defaultValue: unknown) => impl.jsonVariation(key, defaultValue),
-    jsonVariationDetail: (key: string, defaultValue: unknown) =>
-      impl.jsonVariationDetail(key, defaultValue),
-    track: (key: string, data?: any, metricValue?: number) => impl.track(key, data, metricValue),
-    on: (key: LDEmitterEventName, callback: (...args: any[]) => void) => impl.on(key, callback),
-    off: (key: LDEmitterEventName, callback: (...args: any[]) => void) => impl.off(key, callback),
-    flush: () => impl.flush(),
-    setConnectionMode: (mode?: FDv2ConnectionMode) => impl.setConnectionMode(mode),
-    setStreaming: (streaming?: boolean) => impl.setStreaming(streaming),
-    identify: (pristineContext: LDContext, identifyOptions?: LDIdentifyOptions) =>
-      impl.identify(pristineContext, identifyOptions),
-    getContext: () => impl.getContext(),
-    close: () => impl.close(),
-    allFlags: () => impl.allFlags(),
-    addHook: (hook: Hook) => impl.addHook(hook),
-    waitForInitialization: (waitOptions?: LDWaitForInitializationOptions) =>
-      impl.waitForInitialization(waitOptions),
-    logger: impl.logger,
-    start: (startOptions?: LDStartOptions) => impl.start(startOptions),
-  };
-
-  impl.registerPlugins(client);
+  client.registerPlugins(client);
 
   return client;
 }

--- a/packages/sdk/electron/__tests__/ElectronClient.ipcMain.test.ts
+++ b/packages/sdk/electron/__tests__/ElectronClient.ipcMain.test.ts
@@ -152,7 +152,7 @@ describe('given an initialized ElectronClient', () => {
     const context: LDContext = { kind: 'user', key: 'test-user-id' };
     const options: LDIdentifyOptions = { waitForNetworkResults: true };
 
-    const spy = jest.spyOn(client, 'identifyResult');
+    const spy = jest.spyOn(client, 'identify');
     spy.mockResolvedValueOnce({ status: 'completed' });
 
     const result = await mockIpcMain.getHandler(getEventName('identify'))?.({}, context, options);

--- a/packages/sdk/electron/src/ElectronClient.ts
+++ b/packages/sdk/electron/src/ElectronClient.ts
@@ -14,7 +14,6 @@ import {
   LDContext,
   LDEmitter,
   LDEmitterEventName,
-  LDFlagValue,
   LDHeaders,
   LDIdentifyOptions,
   LDIdentifyResult,
@@ -35,7 +34,7 @@ import {
   IpcEventSubscription,
 } from './ElectronIPC';
 import type { ElectronOptions } from './ElectronOptions';
-import type { LDClient, LDStartOptions } from './LDClient';
+import type { LDClient } from './LDClient';
 import type { LDPlugin } from './LDPlugin';
 import validateOptions, { filterToBaseOptions } from './options';
 import ElectronPlatform from './platform/ElectronPlatform';
@@ -133,8 +132,7 @@ export class ElectronClient extends LDClientImpl {
   }
 
   /**
-   * Registers plugins with the given client. Called from makeClient with the facade
-   * so plugins receive the public API (single identify that returns LDIdentifyResult).
+   * Registers plugins with the given client.
    */
   registerPluginsWith(client: LDClient): void {
     internal.safeRegisterPlugins(this.logger, this.environmentMetadata, client, this._plugins);
@@ -399,57 +397,14 @@ export class ElectronClient extends LDClientImpl {
   }
 }
 
-/**
- * Builds the LaunchDarkly client facade (PIMPL). Exposes a single identify method that returns
- * identify results. Plugins are registered with the facade.
- */
 export function makeClient(
   credential: string,
   initialContext: LDContext,
   options: ElectronOptions = {},
 ): LDClient {
-  const impl = new ElectronClient(credential, initialContext, options);
+  const client = new ElectronClient(credential, initialContext, options);
 
-  const client: LDClient = {
-    variation: (key: string, defaultValue?: LDFlagValue) => impl.variation(key, defaultValue),
-    variationDetail: (key: string, defaultValue?: LDFlagValue) =>
-      impl.variationDetail(key, defaultValue),
-    boolVariation: (key: string, defaultValue: boolean) => impl.boolVariation(key, defaultValue),
-    boolVariationDetail: (key: string, defaultValue: boolean) =>
-      impl.boolVariationDetail(key, defaultValue),
-    numberVariation: (key: string, defaultValue: number) => impl.numberVariation(key, defaultValue),
-    numberVariationDetail: (key: string, defaultValue: number) =>
-      impl.numberVariationDetail(key, defaultValue),
-    stringVariation: (key: string, defaultValue: string) => impl.stringVariation(key, defaultValue),
-    stringVariationDetail: (key: string, defaultValue: string) =>
-      impl.stringVariationDetail(key, defaultValue),
-    jsonVariation: (key: string, defaultValue: unknown) => impl.jsonVariation(key, defaultValue),
-    jsonVariationDetail: (key: string, defaultValue: unknown) =>
-      impl.jsonVariationDetail(key, defaultValue),
-    track: (key: string, data?: unknown, metricValue?: number) =>
-      impl.track(key, data, metricValue),
-    on: (key: string, callback: (...args: unknown[]) => void) =>
-      impl.on(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
-    off: (key: string, callback: (...args: unknown[]) => void) =>
-      impl.off(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
-    flush: () => impl.flush(),
-    identify: (ctx: LDContext, identifyOptions?: LDIdentifyOptions) =>
-      impl.identify(ctx, identifyOptions),
-    getContext: () => impl.getContext(),
-    close: () => impl.close(),
-    allFlags: () => impl.allFlags(),
-    addHook: (hook: Parameters<LDClient['addHook']>[0]) => impl.addHook(hook),
-    waitForInitialization: (waitOptions?: Parameters<LDClient['waitForInitialization']>[0]) =>
-      impl.waitForInitialization(waitOptions),
-    logger: impl.logger,
-    start: (startOptions?: LDStartOptions) => impl.start(startOptions),
-    setConnectionMode: (mode: Parameters<LDClient['setConnectionMode']>[0]) =>
-      impl.setConnectionMode(mode),
-    getConnectionMode: () => impl.getConnectionMode(),
-    isOffline: () => impl.isOffline(),
-  };
-
-  impl.registerPluginsWith(client);
+  client.registerPluginsWith(client);
 
   return client;
 }

--- a/packages/sdk/electron/src/ElectronClient.ts
+++ b/packages/sdk/electron/src/ElectronClient.ts
@@ -14,6 +14,7 @@ import {
   LDContext,
   LDEmitter,
   LDEmitterEventName,
+  LDFlagValue,
   LDHeaders,
   LDIdentifyOptions,
   LDIdentifyResult,
@@ -34,7 +35,7 @@ import {
   IpcEventSubscription,
 } from './ElectronIPC';
 import type { ElectronOptions } from './ElectronOptions';
-import type { LDClient } from './LDClient';
+import type { LDClient, LDStartOptions } from './LDClient';
 import type { LDPlugin } from './LDPlugin';
 import validateOptions, { filterToBaseOptions } from './options';
 import ElectronPlatform from './platform/ElectronPlatform';
@@ -132,7 +133,8 @@ export class ElectronClient extends LDClientImpl {
   }
 
   /**
-   * Registers plugins with the given client.
+   * Registers plugins with the given client. Called from makeClient with the facade
+   * so plugins receive the public API (single identify that returns LDIdentifyResult).
    */
   registerPluginsWith(client: LDClient): void {
     internal.safeRegisterPlugins(this.logger, this.environmentMetadata, client, this._plugins);
@@ -397,14 +399,57 @@ export class ElectronClient extends LDClientImpl {
   }
 }
 
+/**
+ * Builds the LaunchDarkly client facade (PIMPL). Exposes a single identify method that returns
+ * identify results. Plugins are registered with the facade.
+ */
 export function makeClient(
   credential: string,
   initialContext: LDContext,
   options: ElectronOptions = {},
 ): LDClient {
-  const client = new ElectronClient(credential, initialContext, options);
+  const impl = new ElectronClient(credential, initialContext, options);
 
-  client.registerPluginsWith(client);
+  const client: LDClient = {
+    variation: (key: string, defaultValue?: LDFlagValue) => impl.variation(key, defaultValue),
+    variationDetail: (key: string, defaultValue?: LDFlagValue) =>
+      impl.variationDetail(key, defaultValue),
+    boolVariation: (key: string, defaultValue: boolean) => impl.boolVariation(key, defaultValue),
+    boolVariationDetail: (key: string, defaultValue: boolean) =>
+      impl.boolVariationDetail(key, defaultValue),
+    numberVariation: (key: string, defaultValue: number) => impl.numberVariation(key, defaultValue),
+    numberVariationDetail: (key: string, defaultValue: number) =>
+      impl.numberVariationDetail(key, defaultValue),
+    stringVariation: (key: string, defaultValue: string) => impl.stringVariation(key, defaultValue),
+    stringVariationDetail: (key: string, defaultValue: string) =>
+      impl.stringVariationDetail(key, defaultValue),
+    jsonVariation: (key: string, defaultValue: unknown) => impl.jsonVariation(key, defaultValue),
+    jsonVariationDetail: (key: string, defaultValue: unknown) =>
+      impl.jsonVariationDetail(key, defaultValue),
+    track: (key: string, data?: unknown, metricValue?: number) =>
+      impl.track(key, data, metricValue),
+    on: (key: string, callback: (...args: unknown[]) => void) =>
+      impl.on(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
+    off: (key: string, callback: (...args: unknown[]) => void) =>
+      impl.off(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
+    flush: () => impl.flush(),
+    identify: (ctx: LDContext, identifyOptions?: LDIdentifyOptions) =>
+      impl.identify(ctx, identifyOptions),
+    getContext: () => impl.getContext(),
+    close: () => impl.close(),
+    allFlags: () => impl.allFlags(),
+    addHook: (hook: Parameters<LDClient['addHook']>[0]) => impl.addHook(hook),
+    waitForInitialization: (waitOptions?: Parameters<LDClient['waitForInitialization']>[0]) =>
+      impl.waitForInitialization(waitOptions),
+    logger: impl.logger,
+    start: (startOptions?: LDStartOptions) => impl.start(startOptions),
+    setConnectionMode: (mode: Parameters<LDClient['setConnectionMode']>[0]) =>
+      impl.setConnectionMode(mode),
+    getConnectionMode: () => impl.getConnectionMode(),
+    isOffline: () => impl.isOffline(),
+  };
+
+  impl.registerPluginsWith(client);
 
   return client;
 }

--- a/packages/sdk/electron/src/ElectronClient.ts
+++ b/packages/sdk/electron/src/ElectronClient.ts
@@ -140,7 +140,7 @@ export class ElectronClient extends LDClientImpl {
     internal.safeRegisterPlugins(this.logger, this.environmentMetadata, client, this._plugins);
   }
 
-  override async identifyResult(
+  override async identify(
     context: LDContext,
     identifyOptions?: LDIdentifyOptions,
   ): Promise<LDIdentifyResult> {
@@ -148,7 +148,7 @@ export class ElectronClient extends LDClientImpl {
       identifyOptions?.sheddable === undefined
         ? { ...identifyOptions, sheddable: true }
         : identifyOptions;
-    return super.identifyResult(context, options);
+    return super.identify(context, options);
   }
 
   async setConnectionMode(mode: ConnectionMode): Promise<void> {
@@ -223,7 +223,7 @@ export class ElectronClient extends LDClientImpl {
     });
 
     ipcMain.handle(getIPCChannelName(namespace, 'identify'), (_event, context, identifyOptions) =>
-      this.identifyResult(context, identifyOptions),
+      this.identify(context, identifyOptions),
     );
 
     ipcMain.on(getIPCChannelName(namespace, 'log'), (_event, level: string, message: string) => {
@@ -434,7 +434,7 @@ export function makeClient(
       impl.off(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
     flush: () => impl.flush(),
     identify: (ctx: LDContext, identifyOptions?: LDIdentifyOptions) =>
-      impl.identifyResult(ctx, identifyOptions),
+      impl.identify(ctx, identifyOptions),
     getContext: () => impl.getContext(),
     close: () => impl.close(),
     allFlags: () => impl.allFlags(),

--- a/packages/sdk/react-native/src/LDClient.ts
+++ b/packages/sdk/react-native/src/LDClient.ts
@@ -5,8 +5,8 @@ import {
 } from '@launchdarkly/js-client-sdk-common';
 
 /**
- * React Native-specific LDClient type that preserves backward compatibility
- * by declaring `identify()` as returning `Promise<void>` (throws on error/timeout).
+ * React Native LDClient type. Overrides `identify()` to return `Promise<void>` and throw on
+ * error/timeout to maintain backward compatibility with existing React Native consumers.
  */
 export type LDClient = Omit<CommonClient, 'identify'> & {
   /**

--- a/packages/sdk/react-native/src/LDClient.ts
+++ b/packages/sdk/react-native/src/LDClient.ts
@@ -1,0 +1,38 @@
+import {
+  LDClient as CommonClient,
+  LDContext,
+  LDIdentifyOptions,
+} from '@launchdarkly/js-client-sdk-common';
+
+/**
+ * React Native-specific LDClient type that preserves backward compatibility
+ * by declaring `identify()` as returning `Promise<void>` (throws on error/timeout).
+ */
+export type LDClient = Omit<CommonClient, 'identify'> & {
+  /**
+   * Identifies a context to LaunchDarkly.
+   *
+   * Unlike the server-side SDKs, the client-side JavaScript SDKs maintain a current context state,
+   * which is set when you call `identify()`.
+   *
+   * Changing the current context also causes all feature flag values to be reloaded. Until that has
+   * finished, calls to {@link variation} will still return flag values for the previous context. You can
+   * await the Promise to determine when the new flag values are available.
+   *
+   * @param context
+   *    The LDContext object.
+   * @param identifyOptions
+   *    Optional configuration. Please see {@link LDIdentifyOptions}.
+   * @returns
+   *    A Promise which resolves when the flag values for the specified
+   * context are available. It rejects when:
+   *
+   * 1. The context is unspecified or has no key.
+   *
+   * 2. The identify timeout is exceeded. In client SDKs this defaults to 5s.
+   * You can customize this timeout with {@link LDIdentifyOptions | identifyOptions}.
+   *
+   * 3. A network error is encountered during initialization.
+   */
+  identify(context: LDContext, identifyOptions?: LDIdentifyOptions): Promise<void>;
+};

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -231,15 +231,6 @@ export default class ReactNativeLDClient extends LDClientImpl {
     );
   }
 
-  /**
-   * Identifies a context to LaunchDarkly.
-   *
-   * This override preserves backward compatibility by throwing on error or timeout,
-   * matching the behavior consumers expect from the React Native SDK.
-   *
-   * @param context The LDContext object.
-   * @param identifyOptions Optional configuration. See {@link LDIdentifyOptions}.
-   */
   override async identify(
     context: LDContext,
     identifyOptions?: LDIdentifyOptions,

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -20,6 +20,7 @@ import {
   type LDIdentifyResult,
   LDPluginEnvironmentMetadata,
   LDTimeoutError,
+  type LDWaitForInitializationResult,
   MOBILE_DATA_SYSTEM_DEFAULTS,
   MOBILE_TRANSITION_TABLE,
   mobileFdv1Endpoints,
@@ -246,6 +247,16 @@ export default class ReactNativeLDClient extends LDClientImpl {
       throw timeoutError;
     }
     return result;
+  }
+
+  /**
+   * Protect against trying to use start() in RN.
+   *
+   * @internal
+   **/
+
+  override start(): Promise<LDWaitForInitializationResult> {
+    throw new Error('start() is not supported in the React Native SDK. Use identify() directly.');
   }
 
   override async close(): Promise<void> {

--- a/packages/sdk/react-native/src/ReactNativeLDClient.ts
+++ b/packages/sdk/react-native/src/ReactNativeLDClient.ts
@@ -13,9 +13,13 @@ import {
   type LDClientDataSystemOptions,
   LDClientImpl,
   LDClientInternalOptions,
+  type LDContext,
   LDEmitter,
   LDHeaders,
+  type LDIdentifyOptions,
+  type LDIdentifyResult,
   LDPluginEnvironmentMetadata,
+  LDTimeoutError,
   MOBILE_DATA_SYSTEM_DEFAULTS,
   MOBILE_TRANSITION_TABLE,
   mobileFdv1Endpoints,
@@ -225,6 +229,32 @@ export default class ReactNativeLDClient extends LDClientImpl {
       this,
       validatedRnOptions.plugins,
     );
+  }
+
+  /**
+   * Identifies a context to LaunchDarkly.
+   *
+   * This override preserves backward compatibility by throwing on error or timeout,
+   * matching the behavior consumers expect from the React Native SDK.
+   *
+   * @param context The LDContext object.
+   * @param identifyOptions Optional configuration. See {@link LDIdentifyOptions}.
+   */
+  override async identify(
+    context: LDContext,
+    identifyOptions?: LDIdentifyOptions,
+  ): Promise<LDIdentifyResult> {
+    const result = await super.identify(context, identifyOptions);
+    if (result.status === 'error') {
+      throw result.error;
+    } else if (result.status === 'timeout') {
+      const timeoutError = new LDTimeoutError(
+        `identify timed out after ${result.timeout} seconds.`,
+      );
+      this.logger.error(timeoutError.message);
+      throw timeoutError;
+    }
+    return result;
   }
 
   override async close(): Promise<void> {

--- a/packages/sdk/react-native/src/index.ts
+++ b/packages/sdk/react-native/src/index.ts
@@ -10,6 +10,10 @@ import RNOptions, { RNDataSystemOptions, RNStorage } from './RNOptions';
 
 export * from '@launchdarkly/js-client-sdk-common';
 
+// Override the common LDClient type with a React Native-specific one that
+// preserves backward-compatible identify() returning Promise<void>.
+export type { LDClient } from './LDClient';
+
 export * from './hooks';
 export * from './provider';
 export * from './LDPlugin';

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.start.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.start.test.ts
@@ -246,7 +246,7 @@ describe('LDClientImpl.start()', () => {
         initialContext: context,
       });
 
-      const result = await ldc.identifyResult({ kind: 'user', key: 'other-user' });
+      const result = await ldc.identify({ kind: 'user', key: 'other-user' });
 
       expect(result.status).toBe('error');
       if (result.status === 'error') {
@@ -263,7 +263,7 @@ describe('LDClientImpl.start()', () => {
 
       await ldc.start();
 
-      const result = await ldc.identifyResult({ kind: 'user', key: 'other-user' });
+      const result = await ldc.identify({ kind: 'user', key: 'other-user' });
       expect(result.status).toBe('completed');
     });
 
@@ -271,7 +271,7 @@ describe('LDClientImpl.start()', () => {
       const mockPlatform = setupStreamingPlatform();
       const { ldc } = setupClient(mockPlatform, { requiresStart: false });
 
-      const result = await ldc.identifyResult(context);
+      const result = await ldc.identify(context);
       expect(result.status).toBe('completed');
     });
 
@@ -280,9 +280,9 @@ describe('LDClientImpl.start()', () => {
       const { ldc } = setupClient(mockPlatform, { requiresStart: true, initialContext: context });
 
       const startPromise = ldc.start();
-      const promise1 = ldc.identifyResult({ kind: 'user', key: 'user-1' });
-      const promise2 = ldc.identifyResult({ kind: 'user', key: 'user-2' });
-      const promise3 = ldc.identifyResult({ kind: 'user', key: 'user-3' });
+      const promise1 = ldc.identify({ kind: 'user', key: 'user-1' });
+      const promise2 = ldc.identify({ kind: 'user', key: 'user-2' });
+      const promise3 = ldc.identify({ kind: 'user', key: 'user-3' });
 
       const [startResult, result1, result2, result3] = await Promise.all([
         startPromise,

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
@@ -286,7 +286,6 @@ describe('sdk-client object', () => {
 
     // @ts-expect-error - invalid context
     const result = await ldc.identify(carContext);
-    expect(result.status).toBe('error');
     expect(result).toEqual(expect.objectContaining({ status: 'error', error: expect.any(Error) }));
     expect(ldc.getContext()).toBeUndefined();
   });
@@ -296,7 +295,6 @@ describe('sdk-client object', () => {
 
     // @ts-ignore - invalid context
     const result = await ldc.identify(carContext);
-    expect(result.status).toBe('error');
     expect(result).toEqual(expect.objectContaining({ status: 'error', error: expect.any(Error) }));
     expect(ldc.getContext()).toBeUndefined();
   });
@@ -313,7 +311,7 @@ describe('sdk-client object', () => {
     const carContext: LDContext = { kind: 'car', key: 'test-car' };
 
     const result = await ldc.identify(carContext);
-    expect(result.status).toBe('error');
+    expect(result).toEqual(expect.objectContaining({ status: 'error' }));
     expect(logger.error).toHaveBeenCalledTimes(2);
     expect(logger.error).toHaveBeenNthCalledWith(1, expect.stringMatching(/^error:.*test-error/));
     expect(logger.error).toHaveBeenNthCalledWith(2, expect.stringContaining('Received error 404'));
@@ -434,7 +432,7 @@ describe('sdk-client object', () => {
     ldc.on('dataSourceStatus', spyListener);
     const changePromise = onDataSourceChangePromise(2);
     const identifyResult = await ldc.identify(carContext);
-    expect(identifyResult.status).toBe('error');
+    expect(identifyResult).toEqual(expect.objectContaining({ status: 'error' }));
     await changePromise;
 
     expect(spyListener).toHaveBeenCalledTimes(2);

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
@@ -285,8 +285,9 @@ describe('sdk-client object', () => {
     const carContext = { kind: 'car' };
 
     // @ts-expect-error - invalid context
-    await expect(ldc.identify(carContext)).rejects.toThrow(/no key/);
-    expect(logger.error).toHaveBeenCalledTimes(1);
+    const result = await ldc.identify(carContext);
+    expect(result.status).toBe('error');
+    expect(result).toEqual(expect.objectContaining({ status: 'error', error: expect.any(Error) }));
     expect(ldc.getContext()).toBeUndefined();
   });
 
@@ -294,8 +295,9 @@ describe('sdk-client object', () => {
     const carContext = { kind: 'multi', user: { name: 'test' } };
 
     // @ts-ignore - invalid context
-    await expect(ldc.identify(carContext)).rejects.toThrow(/no key/);
-    expect(logger.error).toHaveBeenCalledTimes(1);
+    const result = await ldc.identify(carContext);
+    expect(result.status).toBe('error');
+    expect(result).toEqual(expect.objectContaining({ status: 'error', error: expect.any(Error) }));
     expect(ldc.getContext()).toBeUndefined();
   });
 
@@ -310,7 +312,8 @@ describe('sdk-client object', () => {
 
     const carContext: LDContext = { kind: 'car', key: 'test-car' };
 
-    await expect(ldc.identify(carContext)).rejects.toThrow('test-error');
+    const result = await ldc.identify(carContext);
+    expect(result.status).toBe('error');
     expect(logger.error).toHaveBeenCalledTimes(2);
     expect(logger.error).toHaveBeenNthCalledWith(1, expect.stringMatching(/^error:.*test-error/));
     expect(logger.error).toHaveBeenNthCalledWith(2, expect.stringContaining('Received error 404'));
@@ -430,7 +433,8 @@ describe('sdk-client object', () => {
     const spyListener = jest.fn();
     ldc.on('dataSourceStatus', spyListener);
     const changePromise = onDataSourceChangePromise(2);
-    await expect(ldc.identify(carContext)).rejects.toThrow('test-error');
+    const identifyResult = await ldc.identify(carContext);
+    expect(identifyResult.status).toBe('error');
     await changePromise;
 
     expect(spyListener).toHaveBeenCalledTimes(2);

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
@@ -213,7 +213,7 @@ describe('sdk-client waitForInitialization', () => {
     simulatedEvents = [{ data: JSON.stringify(defaultPutResponse) }];
 
     const waitPromise = ldc.waitForInitialization({ timeout: 10 });
-    const identifyPromise = ldc.identifyResult(carContext);
+    const identifyPromise = ldc.identify(carContext);
 
     jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT).then();
 
@@ -227,7 +227,7 @@ describe('sdk-client waitForInitialization', () => {
     simulatedEvents = [{ data: JSON.stringify(defaultPutResponse) }];
 
     const waitPromise = ldc.waitForInitialization({ timeout: 10 });
-    const identifyPromise = ldc.identifyResult(carContext);
+    const identifyPromise = ldc.identify(carContext);
 
     jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT).then();
 
@@ -245,7 +245,7 @@ describe('sdk-client waitForInitialization', () => {
     simulatedEvents = [];
 
     const waitPromise = ldc.waitForInitialization({ timeout: 10 });
-    const identifyPromise = ldc.identifyResult(carContext);
+    const identifyPromise = ldc.identify(carContext);
 
     jest.advanceTimersByTimeAsync(10 * 1000 + 1).then();
 
@@ -279,7 +279,7 @@ describe('sdk-client waitForInitialization', () => {
     );
 
     const waitPromise = errorLdc.waitForInitialization({ timeout: 10 });
-    const identifyPromise = errorLdc.identifyResult(carContext);
+    const identifyPromise = errorLdc.identify(carContext);
 
     // Advance timers to allow error handler to be set up and error to propagate
     await jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT);

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
@@ -63,25 +63,30 @@ describe('sdk-client identify timeout', () => {
     jest.resetAllMocks();
   });
 
-  test('rejects with default timeout of 5s', async () => {
+  test('returns timeout result with default timeout of 5s', async () => {
     jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT * 1000).then();
-    await expect(ldc.identify(carContext)).rejects.toThrow(/identify timed out/);
-    expect(logger.error).toHaveBeenCalledWith(expect.stringMatching(/identify timed out/));
+    await expect(ldc.identify(carContext)).resolves.toEqual({
+      status: 'timeout',
+      timeout: DEFAULT_IDENTIFY_TIMEOUT,
+    });
   });
 
-  test('rejects with custom timeout', async () => {
+  test('returns timeout result with custom timeout', async () => {
     const timeout = 15;
     jest.advanceTimersByTimeAsync(timeout * 1000).then();
-    await expect(ldc.identify(carContext, { timeout })).rejects.toThrow(/identify timed out/);
+    await expect(ldc.identify(carContext, { timeout })).resolves.toEqual({
+      status: 'timeout',
+      timeout,
+    });
   });
 
-  test('resolves with default timeout', async () => {
+  test('resolves with completed status on default timeout', async () => {
     // set simulated events to be default response
     simulatedEvents = [{ data: JSON.stringify(defaultPutResponse) }];
 
     jest.advanceTimersByTimeAsync(DEFAULT_IDENTIFY_TIMEOUT * 1000).then();
 
-    await expect(ldc.identify(carContext)).resolves.toBeUndefined();
+    await expect(ldc.identify(carContext)).resolves.toEqual({ status: 'completed' });
 
     expect(ldc.getContext()).toEqual(expect.objectContaining(toMulti(carContext)));
     expect(ldc.allFlags()).toEqual({
@@ -106,7 +111,7 @@ describe('sdk-client identify timeout', () => {
 
     jest.advanceTimersByTimeAsync(timeout).then();
 
-    await expect(ldc.identify(carContext, { timeout })).resolves.toBeUndefined();
+    await expect(ldc.identify(carContext, { timeout })).resolves.toEqual({ status: 'completed' });
 
     expect(ldc.getContext()).toEqual(expect.objectContaining(toMulti(carContext)));
     expect(ldc.allFlags()).toEqual({

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
@@ -77,7 +77,7 @@ describe('sdk-client object', () => {
     const p = ldc.identify(context);
     const flagValue = ldc.variation('does-not-exist', 'not-found');
 
-    await expect(p).resolves.toBeUndefined();
+    await expect(p).resolves.toEqual({ status: 'completed' });
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unknown feature'));
     expect(flagValue).toBe('not-found');

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -11,7 +11,6 @@ import {
   LDHeaders,
   LDLogger,
   LDPluginEnvironmentMetadata,
-  LDTimeoutError,
   Platform,
   TypeValidators,
 } from '@launchdarkly/js-sdk-common';
@@ -337,7 +336,7 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
       'start',
     );
 
-    this.identifyResult(this.initialContext!, identifyOptions);
+    this.identify(this.initialContext!, identifyOptions);
     return this.startPromise;
   }
 
@@ -348,38 +347,12 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
    * multiple identify operations are done, without waiting for the previous one to complete, then intermediate
    * operations may be discarded.
    *
-   * It is recommended to use the `identifyResult` method instead when the operation is sheddable. In a future release,
-   * all identify operations will default to being sheddable.
-   *
    * @param pristineContext The LDContext object to be identified.
    * @param identifyOptions Optional configuration. See {@link LDIdentifyOptions}.
-   * @returns A Promise which resolves when the flag values for the specified
-   * context are available. It rejects when:
-   *
-   * 1. The context is unspecified or has no key.
-   *
-   * 2. The identify timeout is exceeded. In client SDKs this defaults to 5s.
-   * You can customize this timeout with {@link LDIdentifyOptions | identifyOptions}.
-   *
-   * 3. A network error is encountered during initialization.
+   * @returns A promise which resolves to an object containing the result of the identify operation.
+   *    The promise returned from this method will not be rejected.
    */
-  async identify(pristineContext: LDContext, identifyOptions?: LDIdentifyOptions): Promise<void> {
-    // In order to manage customization in the derived classes it is important that `identify` MUST be implemented in
-    // terms of `identifyResult`. So that the logic of the identification process can be extended in one place.
-    const result = await this.identifyResult(pristineContext, identifyOptions);
-    if (result.status === 'error') {
-      throw result.error;
-    } else if (result.status === 'timeout') {
-      const timeoutError = new LDTimeoutError(
-        `identify timed out after ${result.timeout} seconds.`,
-      );
-      this.logger.error(timeoutError.message);
-      throw timeoutError;
-    }
-    // If completed or shed, then we are done.
-  }
-
-  async identifyResult(
+  async identify(
     pristineContext: LDContext,
     identifyOptions?: LDIdentifyOptions,
   ): Promise<LDIdentifyResult> {
@@ -489,6 +462,16 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
       }, identifyTimeout * 1000);
     });
     return Promise.race([callSitePromise, timeoutPromise]);
+  }
+
+  /**
+   * @deprecated Use {@link identify} instead, which now returns `Promise<LDIdentifyResult>`.
+   */
+  async identifyResult(
+    pristineContext: LDContext,
+    identifyOptions?: LDIdentifyOptions,
+  ): Promise<LDIdentifyResult> {
+    return this.identify(pristineContext, identifyOptions);
   }
 
   /**

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -18,7 +18,6 @@ import {
 import {
   Hook,
   LDClient,
-  LDClientIdentifyResult,
   LDContext,
   LDContextStrict,
   LDIdentifyError,
@@ -67,7 +66,7 @@ const { ClientMessages, ErrorKinds } = internal;
 
 const DEFAULT_IDENTIFY_TIMEOUT_SECONDS = 5;
 
-export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
+export default class LDClientImpl implements LDClient {
   private readonly _config: Configuration;
   private readonly _diagnosticsManager?: internal.DiagnosticsManager;
   private _eventProcessor?: internal.EventProcessor;
@@ -462,16 +461,6 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
       }, identifyTimeout * 1000);
     });
     return Promise.race([callSitePromise, timeoutPromise]);
-  }
-
-  /**
-   * @deprecated Use {@link identify} instead, which now returns `Promise<LDIdentifyResult>`.
-   */
-  async identifyResult(
-    pristineContext: LDContext,
-    identifyOptions?: LDIdentifyOptions,
-  ): Promise<LDIdentifyResult> {
-    return this.identify(pristineContext, identifyOptions);
   }
 
   /**

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -369,8 +369,6 @@ export interface LDClient {
 }
 
 /**
- * Interface that extends the LDClient interface to include the identifyResult method.
- *
  * @deprecated Use {@link LDClient.identify} instead, which now returns `Promise<LDIdentifyResult>`.
  */
 export interface LDClientIdentifyResult {

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -107,17 +107,10 @@ export interface LDClient {
    * @param identifyOptions
    *    Optional configuration. Please see {@link LDIdentifyOptions}.
    * @returns
-   *    A Promise which resolves when the flag values for the specified
-   * context are available. It rejects when:
-   *
-   * 1. The context is unspecified or has no key.
-   *
-   * 2. The identify timeout is exceeded. In client SDKs this defaults to 5s.
-   * You can customize this timeout with {@link LDIdentifyOptions | identifyOptions}.
-   *
-   * 3. A network error is encountered during initialization.
+   *    A promise which resolves to an object containing the result of the identify operation.
+   *    The promise returned from this method will not be rejected.
    */
-  identify(context: LDContext, identifyOptions?: LDIdentifyOptions): Promise<void>;
+  identify(context: LDContext, identifyOptions?: LDIdentifyOptions): Promise<LDIdentifyResult>;
 
   /**
    * Determines the json variation of a feature flag.
@@ -378,8 +371,7 @@ export interface LDClient {
 /**
  * Interface that extends the LDClient interface to include the identifyResult method.
  *
- * This is an independent interface for backwards compatibility. Adding this to the LDClient interface would require
- * a breaking change.
+ * @deprecated Use {@link LDClient.identify} instead, which now returns `Promise<LDIdentifyResult>`.
  */
 export interface LDClientIdentifyResult {
   /**

--- a/packages/shared/sdk-client/src/api/LDClient.ts
+++ b/packages/shared/sdk-client/src/api/LDClient.ts
@@ -367,36 +367,3 @@ export interface LDClient {
     options?: LDWaitForInitializationOptions,
   ): Promise<LDWaitForInitializationResult>;
 }
-
-/**
- * @deprecated Use {@link LDClient.identify} instead, which now returns `Promise<LDIdentifyResult>`.
- */
-export interface LDClientIdentifyResult {
-  /**
-   * Identifies a context to LaunchDarkly and returns a promise which resolves to an object containing the result of
-   * the identify operation.
-   *
-   * Unlike the server-side SDKs, the client-side JavaScript SDKs maintain a current context state,
-   * which is set when you call `identify()`.
-   *
-   * Changing the current context also causes all feature flag values to be reloaded. Until that has
-   * finished, calls to {@link variation} will still return flag values for the previous context. You can
-   * await the Promise to determine when the new flag values are available.
-   *
-   * If used with the `sheddable` option set to true, then the identify operation will be sheddable. This means that if
-   * multiple identify operations are done, without waiting for the previous one to complete, then intermediate
-   * operations may be discarded.
-   *
-   * @param context
-   *    The LDContext object.
-   * @param identifyOptions
-   *    Optional configuration. Please see {@link LDIdentifyOptions}.
-   * @returns
-   *    A promise which resolves to an object containing the result of the identify operation.
-   *    The promise returned from this method will not be rejected.
-   */
-  identifyResult(
-    context: LDContext,
-    identifyOptions?: LDIdentifyOptions,
-  ): Promise<LDIdentifyResult>;
-}

--- a/packages/shared/sdk-client/src/index.ts
+++ b/packages/shared/sdk-client/src/index.ts
@@ -35,7 +35,6 @@ export type {
   LDIdentifyError,
   LDIdentifyTimeout,
   LDIdentifyShed,
-  LDClientIdentifyResult,
   LDPluginBase,
   LDWaitForInitializationOptions,
   LDWaitForInitializationResult,


### PR DESCRIPTION
This PR will consolidate the identify implementation in the sdk common level.

sdk-2078
sdk-2081
sdk-2082

The change here is that identify will always return a promise that resolves to a result. This pattern allows for better identify status tracking.

A few caveats:
- we will continue having react native conform to the old identify function signiture
- we have another work item to assess removing the proxy implementation that browser and electron sdk uses to compat the identify function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `identify()` contract across the shared client and browser/electron SDKs from throwing/void to returning `LDIdentifyResult`, requiring downstream callers to handle `{status}` outcomes; behavior differences (timeouts/errors no longer reject) could break assumptions.
> 
> **Overview**
> **Unifies `identify()` to always return an `LDIdentifyResult`** (completed/error/timeout/shed) and guarantees the Promise does not reject, removing the separate `identifyResult()` API and updating the shared `LDClient` type accordingly.
> 
> Browser and Electron clients are updated to call/forward the new `identify()` (including IPC handlers and PIMPL facades) while still defaulting `sheddable: true` in their overrides; related tests are rewritten to assert returned status objects instead of promise rejections.
> 
> React Native preserves backward compatibility by exporting an RN-specific `LDClient` type with `identify(): Promise<void>` semantics and overriding `ReactNativeLDClient.identify()` to throw on error/timeout (and explicitly disallowing `start()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b88b80557cdf91dbe82570ece663a3bcc18d3f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->