### PR TITLE
fix(cloudflare): bundle tslib with esm module

### DIFF
--- a/packages/sdk/cloudflare/rollup.config.ts
+++ b/packages/sdk/cloudflare/rollup.config.ts
@@ -12,7 +12,7 @@ const esmPath = 'dist/esm/index.js';
 // the second array item is a function to include all js-core packages in the bundle so they
 // are not imported or required as separate npm packages
 const external = [
-  // @rollup/plugin-typescript needs explicit externalization of tslib.
+  // @rollup/plugin-typescript needs tslib bundled, so exclude it from the node_modules external pattern.
   /node_modules(?!.*tslib)/,
   (id: string) => !id.includes('js-core'),
 ];

--- a/packages/sdk/cloudflare/rollup.config.ts
+++ b/packages/sdk/cloudflare/rollup.config.ts
@@ -11,7 +11,11 @@ const esmPath = 'dist/esm/index.js';
 
 // the second array item is a function to include all js-core packages in the bundle so they
 // are not imported or required as separate npm packages
-const external = [/node_modules/, (id: string) => !id.includes('js-core')];
+const external = [
+  // @rollup/plugin-typescript needs explicit externalization of tslib.
+  /node_modules(?!.*tslib)/,
+  (id: string) => !id.includes('js-core'),
+];
 
 export default [
   {


### PR DESCRIPTION
**Related issues**
https://github.com/launchdarkly/js-core/issues/1291

**Describe the solution you've provided**

Ensure that tslib is excluded from the bundling exclusion list.

**Additional context**

I've recreated and ensured that this fix is working when done against a module tgz generated by `npm pack`. This _should_ prove efficacy, but wouldn't know for sure until we publish the fix.

I also checked to see if any other modules are referenced in this way and tslib is the only once, which makes sense because it was probably hoisted to root node_modules.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build configuration-only change limited to Rollup externals; risk is mainly altered bundle contents/size or unexpected dependency inclusion.
> 
> **Overview**
> Updates the Cloudflare SDK Rollup config to **bundle `tslib`** by excluding it from the generic `/node_modules/` externalization rule, while still keeping other `node_modules` packages external and continuing to inline `js-core` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c9f87a81a4a48d18457bcfea4163f1c53ccba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->