### PR TITLE
chore: update deprecated API usage in server-ai examples

### DIFF
--- a/packages/sdk/server-ai/examples/bedrock/src/index.ts
+++ b/packages/sdk/server-ai/examples/bedrock/src/index.ts
@@ -48,7 +48,7 @@ async function main() {
 
   const aiClient = initAi(ldClient);
 
-  const aiConfig = await aiClient.config(
+  const aiConfig = await aiClient.completionConfig(
     aiConfigKey!,
     context,
     {

--- a/packages/sdk/server-ai/examples/openai-observability/src/index.ts
+++ b/packages/sdk/server-ai/examples/openai-observability/src/index.ts
@@ -77,15 +77,13 @@ async function main() {
   try {
     // ── 4. Call OpenAI and track metrics with the provider's extractor ──
     const tracker = aiConfig.createTracker!();
-    const completion = await tracker.trackMetricsOf(
-      OpenAIProvider.getAIMetricsFromResponse,
-      () =>
-        openai.chat.completions.create({
-          messages: aiConfig.messages || [],
-          model: aiConfig.model?.name || 'gpt-4',
-          temperature: (aiConfig.model?.parameters?.temperature as number) ?? 0.5,
-          max_tokens: (aiConfig.model?.parameters?.maxTokens as number) ?? 4096,
-        }),
+    const completion = await tracker.trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, () =>
+      openai.chat.completions.create({
+        messages: aiConfig.messages || [],
+        model: aiConfig.model?.name || 'gpt-4',
+        temperature: (aiConfig.model?.parameters?.temperature as number) ?? 0.5,
+        max_tokens: (aiConfig.model?.parameters?.maxTokens as number) ?? 4096,
+      }),
     );
 
     console.log('AI Response:', completion.choices[0]?.message.content);

--- a/packages/sdk/server-ai/examples/openai-observability/src/index.ts
+++ b/packages/sdk/server-ai/examples/openai-observability/src/index.ts
@@ -68,7 +68,7 @@ async function main() {
     { example_type: 'provider_observability_demo' },
   );
 
-  if (!aiConfig.enabled || !aiConfig.tracker) {
+  if (!aiConfig.enabled) {
     console.log('*** AI configuration is not enabled');
     ldClient.close();
     process.exit(0);
@@ -76,7 +76,8 @@ async function main() {
 
   try {
     // ── 4. Call OpenAI and track metrics with the provider's extractor ──
-    const completion = await aiConfig.tracker.trackMetricsOf(
+    const tracker = aiConfig.createTracker!();
+    const completion = await tracker.trackMetricsOf(
       OpenAIProvider.getAIMetricsFromResponse,
       () =>
         openai.chat.completions.create({

--- a/packages/sdk/server-ai/examples/openai/src/index.ts
+++ b/packages/sdk/server-ai/examples/openai/src/index.ts
@@ -66,7 +66,7 @@ async function main() {
   }
 
   const tracker = aiConfig.createTracker!();
-  const completion = await tracker.trackMetricsOf(OpenAIProvider.createAIMetrics, async () =>
+  const completion = await tracker.trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, async () =>
     client.chat.completions.create({
       messages: aiConfig.messages || [],
       model: aiConfig.model?.name || 'gpt-4',

--- a/packages/sdk/server-ai/examples/openai/src/index.ts
+++ b/packages/sdk/server-ai/examples/openai/src/index.ts
@@ -66,13 +66,15 @@ async function main() {
   }
 
   const tracker = aiConfig.createTracker!();
-  const completion = await tracker.trackMetricsOf(OpenAIProvider.getAIMetricsFromResponse, async () =>
-    client.chat.completions.create({
-      messages: aiConfig.messages || [],
-      model: aiConfig.model?.name || 'gpt-4',
-      temperature: (aiConfig.model?.parameters?.temperature as number) ?? 0.5,
-      max_tokens: (aiConfig.model?.parameters?.maxTokens as number) ?? 4096,
-    }),
+  const completion = await tracker.trackMetricsOf(
+    OpenAIProvider.getAIMetricsFromResponse,
+    async () =>
+      client.chat.completions.create({
+        messages: aiConfig.messages || [],
+        model: aiConfig.model?.name || 'gpt-4',
+        temperature: (aiConfig.model?.parameters?.temperature as number) ?? 0.5,
+        max_tokens: (aiConfig.model?.parameters?.maxTokens as number) ?? 4096,
+      }),
   );
 
   console.log('AI Response:', completion.choices[0]?.message.content);


### PR DESCRIPTION
## Summary

Updates three example apps under `packages/sdk/server-ai/examples/` to use the current SDK API, replacing deprecated/removed calls.

**Changes:**

- `examples/openai/src/index.ts` — `OpenAIProvider.createAIMetrics` → `OpenAIProvider.getAIMetricsFromResponse`
- `examples/bedrock/src/index.ts` — `aiClient.config(...)` → `aiClient.completionConfig(...)`
- `examples/openai-observability/src/index.ts` — migrated from the removed `aiConfig.tracker` property to the `const tracker = aiConfig.createTracker!();` pattern used by the other examples on this branch

No behavioral changes; functional parity with the existing examples.

## Test plan

- [ ] Build the affected examples and confirm they type-check against the current `feat/ai-sdk-next-release` SDK
- [ ] Spot-run `openai` and `openai-observability` examples end-to-end to confirm they still emit metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to example apps and primarily swap deprecated SDK APIs for current ones without altering core logic or data handling.
> 
> **Overview**
> Updates the `server-ai` examples to match the current SDK surface by switching Bedrock from `aiClient.config` to `aiClient.completionConfig`.
> 
> Adjusts OpenAI examples to use the newer tracking flow (`aiConfig.createTracker()`) and the provider metrics extractor `OpenAIProvider.getAIMetricsFromResponse`, removing reliance on the deprecated/removed `aiConfig.tracker` and `createAIMetrics` APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a733ceac09a6ab04cf080f6f7a4f1338c47d835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->