### PR TITLE
chore: remove _agentConfigInternal and use _agentConfig directly

### DIFF
--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -446,7 +446,7 @@ export class LDAIClientImpl implements LDAIClient {
     const agentConfigs: Record<string, LDAIAgentConfig> = {};
     const fetchResults = await Promise.all(
       [...allKeys].map(async (key) => {
-        const config = await this._agentConfigInternal(key, context, graphKey, variables);
+        const config = await this._agentConfig(key, context, disabledAIConfig, variables, graphKey);
         return { key, config };
       }),
     );
@@ -468,26 +468,6 @@ export class LDAIClientImpl implements LDAIClient {
 
   createGraphTracker(token: string, context: LDContext): LDGraphTracker {
     return LDGraphTrackerImpl.fromResumptionToken(token, this._ldClient, context);
-  }
-
-  /**
-   * Fetches a single agent config without tracking usage (used internally by agentGraph).
-   */
-  private async _agentConfigInternal(
-    key: string,
-    context: LDContext,
-    graphKey?: string,
-    variables?: Record<string, unknown>,
-  ): Promise<LDAIAgentConfig> {
-    const config = await this._evaluate(
-      key,
-      context,
-      disabledAIConfig,
-      'agent',
-      variables,
-      graphKey,
-    );
-    return config as LDAIAgentConfig;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Removes the duplicate `_agentConfigInternal` private method from `LDAIClientImpl`
- Replaces its single call site with `_agentConfig(key, context, disabledAIConfig, variables, graphKey)`, correcting the parameter order (`graphKey, variables` → `variables, graphKey`)

## Test plan
- [ ] `yarn workspace @launchdarkly/server-sdk-ai lint` passes
- [ ] `yarn workspace @launchdarkly/server-sdk-ai test` passes (181 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes a duplicate private helper and updates a single call site; behavior should remain the same aside from passing `graphKey`/`variables` in the correct order.
> 
> **Overview**
> Simplifies `LDAIClientImpl` by deleting the redundant private `_agentConfigInternal` helper and having `agentGraph` call `_agentConfig` directly.
> 
> This also fixes the argument ordering for the internal agent-config fetch in `agentGraph` (passing `variables` before `graphKey`) so configs are evaluated with the intended interpolation variables and graph tracking context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0670ad5355df426c4e53578183ba385c25e04ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->