### PR TITLE
fix: correct typeof comparisons in browser SDK

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     'eqeqeq': ['error', 'always', { null: 'ignore' }],
     'prefer-const': ['error', { ignoreReadBeforeAssign: true }],
     'no-var': 'error',
-    'valid-typeof': 'off',
+    'valid-typeof': 'error',
     'no-restricted-syntax': [
       'error',
       { selector: 'ForInStatement', message: 'Use Object.{keys,values,entries} instead.' },

--- a/packages/sdk/browser/__tests__/BrowserApi.test.ts
+++ b/packages/sdk/browser/__tests__/BrowserApi.test.ts
@@ -4,6 +4,26 @@ it('isDocument returns true when document is defined', () => {
   expect(isDocument()).toBe(true);
 });
 
+it('isDocument returns false when document is not defined', () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'document');
+  Object.defineProperty(globalThis, 'document', { value: undefined, configurable: true });
+  try {
+    expect(isDocument()).toBe(false);
+  } finally {
+    Object.defineProperty(globalThis, 'document', original!);
+  }
+});
+
 it('isWindow returns true when window is defined', () => {
   expect(isWindow()).toBe(true);
+});
+
+it('isWindow returns false when window is not defined', () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });
+  try {
+    expect(isWindow()).toBe(false);
+  } finally {
+    Object.defineProperty(globalThis, 'window', original!);
+  }
 });

--- a/packages/sdk/browser/__tests__/BrowserApi.test.ts
+++ b/packages/sdk/browser/__tests__/BrowserApi.test.ts
@@ -1,0 +1,9 @@
+import { isDocument, isWindow } from '../src/BrowserApi';
+
+it('isDocument returns true when document is defined', () => {
+  expect(isDocument()).toBe(true);
+});
+
+it('isWindow returns true when window is defined', () => {
+  expect(isWindow()).toBe(true);
+});

--- a/packages/sdk/browser/__tests__/platform/randomUuidV4.test.ts
+++ b/packages/sdk/browser/__tests__/platform/randomUuidV4.test.ts
@@ -1,4 +1,4 @@
-import { fallbackUuidV4, formatDataAsUuidV4 } from '../../src/platform/randomUuidV4';
+import randomUuidV4, { fallbackUuidV4, formatDataAsUuidV4 } from '../../src/platform/randomUuidV4';
 
 it('formats conformant UUID', () => {
   // For this test we remove the random component and just inspect the variant and version.
@@ -25,4 +25,20 @@ it('formats conformant UUID', () => {
   expect(specifierA).toEqual(0x8);
   expect(specifierB).toEqual(0x8);
   expect(specifierC).toEqual(0x8);
+});
+
+it('falls back when crypto.randomUUID is unavailable', () => {
+  const original = globalThis.crypto;
+  Object.defineProperty(globalThis, 'crypto', {
+    value: { getRandomValues: original.getRandomValues.bind(original) },
+    configurable: true,
+  });
+
+  try {
+    const uuid = randomUuidV4();
+    expect(uuid).toHaveLength(36);
+    expect(uuid[14]).toEqual('4');
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', { value: original, configurable: true });
+  }
 });

--- a/packages/sdk/browser/src/BrowserApi.ts
+++ b/packages/sdk/browser/src/BrowserApi.ts
@@ -5,11 +5,11 @@
  */
 
 export function isDocument() {
-  return typeof document !== undefined;
+  return typeof document !== 'undefined';
 }
 
 export function isWindow() {
-  return typeof window !== undefined;
+  return typeof window !== 'undefined';
 }
 
 /**
@@ -91,7 +91,7 @@ export function getLocationHash(): string {
 }
 
 export function getCrypto(): Crypto {
-  if (typeof crypto !== undefined) {
+  if (typeof crypto !== 'undefined') {
     return crypto;
   }
   // This would indicate running in an environment that doesn't have window.crypto or self.crypto.

--- a/packages/sdk/browser/src/platform/randomUuidV4.ts
+++ b/packages/sdk/browser/src/platform/randomUuidV4.ts
@@ -91,7 +91,7 @@ export function fallbackUuidV4(): string {
 }
 
 export default function randomUuidV4(): string {
-  if (typeof crypto !== undefined && typeof crypto.randomUUID === 'function') {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
 

--- a/packages/telemetry/browser-telemetry/src/randomUuidV4.ts
+++ b/packages/telemetry/browser-telemetry/src/randomUuidV4.ts
@@ -94,7 +94,7 @@ export function fallbackUuidV4(): string {
 }
 
 export default function randomUuidV4(): string {
-  if (typeof crypto !== undefined && typeof crypto.randomUUID === 'function') {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
 


### PR DESCRIPTION
## Summary
- Fix `typeof x !== undefined` (always true) to `typeof x !== 'undefined'` (correct) in 5 locations
- `isDocument()` and `isWindow()` now correctly return `false` in service worker contexts
- `getCrypto()` now correctly throws when crypto API is unavailable
- `randomUuidV4()` now correctly falls back when `crypto.randomUUID` is missing
- Re-enables the `valid-typeof` ESLint rule to prevent this class of bug

## Context
These bugs were introduced in Sept-Oct 2024. Since `typeof` always returns a string, comparing against the value `undefined` (not the string `'undefined'`) made these checks always truthy. The bug was masked because the previous ESLint config did not flag this pattern.

## Affected files
- `packages/sdk/browser/src/BrowserApi.ts` (3 locations)
- `packages/sdk/browser/src/platform/randomUuidV4.ts` (1 location)
- `packages/telemetry/browser-telemetry/src/randomUuidV4.ts` (1 location)

## Test plan
- [ ] `yarn workspaces foreach -p run lint` passes with 0 errors
- [ ] `yarn workspace @launchdarkly/js-client-sdk test` passes
- [ ] `yarn workspace @launchdarkly/browser-telemetry test` passes

Depends on #1299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes environment/crypto detection and UUID generation fallback logic in browser-facing SDK code; while small, it can change behavior in non-browser contexts (service workers/SSR) and affects ID generation paths.
> 
> **Overview**
> Corrects several invalid `typeof x !== undefined` checks to `typeof x !== 'undefined'` in the browser SDK and browser telemetry UUID helper, so non-browser contexts no longer incorrectly treat `document`, `window`, or `crypto` as available.
> 
> Re-enables ESLint `valid-typeof` to prevent regressions, and adds Jest coverage to ensure `isDocument`/`isWindow` return `false` when globals are missing and `randomUuidV4` properly falls back when `crypto.randomUUID` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074d3f332cde43b1bd533774c135a02e21f957ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->