### PR TITLE
ci: fixing flaky CI

### DIFF
--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -32,6 +32,8 @@ jobs:
           workspace_name: '@launchdarkly/node-server-sdk'
           workspace_path: packages/sdk/server-node
       - name: Install contract test service dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: yarn workspace @launchdarkly/node-server-sdk-contract-tests install --no-immutable
       - name: Build shared contract test utils (server)
         run: yarn workspace @launchdarkly/js-contract-test-utils build:server

--- a/.github/workflows/shopify-oxygen.yml
+++ b/.github/workflows/shopify-oxygen.yml
@@ -27,6 +27,8 @@ jobs:
           workspace_name: '@launchdarkly/shopify-oxygen-sdk'
           workspace_path: packages/sdk/shopify-oxygen
       - name: Install contract test service dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: yarn workspace @launchdarkly/shopify-oxygen-contract-tests install --no-immutable
       - name: Build shared contract test utils
         run: yarn workspace @launchdarkly/js-contract-test-utils build:server


### PR DESCRIPTION
This PR will apply the same fix as we did for `.github/workflows/react.yml` to stablize the CI jobs.

The underlying issue is that electron binary installation is expensive and would some times flake out. The fix here is to skip the binary setup for workflows that do not need it.

The reason this is a problem is that we need to do a `workspace ... install` on contract test installations (as `workspaces focus` does some funny things to non-prod dependencies that may interfere with building the contract tests). Unfortunately, in `yarn`, `workspace... install` does the same thing as `yarn install` (installs all deps).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters dependency install environment for contract-test services; main risk is an unexpected package needing Electron in these jobs.
> 
> **Overview**
> Reduces flakiness in the `server-node` and `shopify-oxygen` GitHub Actions workflows by setting `ELECTRON_SKIP_BINARY_DOWNLOAD=1` for the contract-test service `yarn workspace ... install` step.
> 
> This avoids unnecessary Electron binary downloads during CI installs while keeping the rest of the contract-test build and execution flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c320ff714919938c974e88bcda4bb882e6c2b9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->