### PR TITLE
fix(js-client-sdk): better `undefined` handling

### DIFF
--- a/packages/sdk/browser/src/BrowserApi.ts
+++ b/packages/sdk/browser/src/BrowserApi.ts
@@ -50,13 +50,13 @@ export function addWindowEventListener(
   listener: (this: Document, ev: Event) => any,
   options?: boolean | AddEventListenerOptions,
 ): () => void {
-  if (isDocument()) {
+  if (isWindow()) {
     window.addEventListener(type, listener, options);
     return () => {
       window.removeEventListener(type, listener, options);
     };
   }
-  // No document, so no need to unregister anything.
+  // No window, so no need to unregister anything.
   return () => {};
 }
 

--- a/packages/sdk/browser/src/platform/randomUuidV4.ts
+++ b/packages/sdk/browser/src/platform/randomUuidV4.ts
@@ -36,7 +36,7 @@ const nodes = {
 };
 
 function getRandom128bit(): number[] {
-  if (crypto && crypto.getRandomValues) {
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
     const typedArray = new Uint8Array(16);
     crypto.getRandomValues(typedArray);
     return [...typedArray.values()];

--- a/packages/telemetry/browser-telemetry/src/randomUuidV4.ts
+++ b/packages/telemetry/browser-telemetry/src/randomUuidV4.ts
@@ -39,7 +39,7 @@ const nodes = {
 };
 
 function getRandom128bit(): number[] {
-  if (crypto && crypto.getRandomValues) {
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
     const typedArray = new Uint8Array(16);
     crypto.getRandomValues(typedArray);
     return [...typedArray.values()];


### PR DESCRIPTION
This PR addresses

SDK-2235
SDK-2236

changes:
- changing `isDocument` to `isWindow` because that is more semanitcally correct (we are using `window` in the conditional block)
- changing bare check to type check (`crypto` -> `typeof crypto !== 'undefined'`) so that the code doesn't throw due to `crypto` not existing (this should never happen unless running on some bad obscure browser)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small guard-condition fixes around `window` and `crypto` presence to avoid runtime errors in non-browser/limited environments. Behavior changes only when these globals are missing, where the previous code could throw or incorrectly skip listener registration.
> 
> **Overview**
> Fixes environment detection in the browser SDK by gating `addWindowEventListener` on `isWindow()` (matching the actual `window` usage) and updating the no-op comment accordingly.
> 
> Hardens UUID v4 generation in both the SDK and browser-telemetry packages by replacing the unsafe `crypto` truthiness check with `typeof crypto !== 'undefined'` before calling `crypto.getRandomValues`, preventing ReferenceErrors when `crypto` is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cee04198282a1ec59a035c58716597c06dff5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->