### PR TITLE
chore: update provider examples to use createTracker() factory

### DIFF
--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -92,7 +92,8 @@ const userMessage = new HumanMessage('What is the capital of France?');
 const allMessages = [...LangChainProvider.convertMessagesToLangChain(configMessages), userMessage];
 
 // Track the model call with LaunchDarkly tracking
-const response = await aiConfig.tracker.trackMetricsOf(
+const tracker = aiConfig.createTracker();
+const response = await tracker.trackMetricsOf(
   LangChainProvider.getAIMetricsFromResponse,
   () => llm.invoke(allMessages)
 );

--- a/packages/ai-providers/server-ai-openai/README.md
+++ b/packages/ai-providers/server-ai-openai/README.md
@@ -76,7 +76,8 @@ const userMessage = { role: 'user', content: 'What is the capital of France?' };
 const allMessages = [...configMessages, userMessage];
 
 // Track the model call with LaunchDarkly tracking
-const response = await aiConfig.tracker.trackMetricsOf(
+const tracker = aiConfig.createTracker();
+const response = await tracker.trackMetricsOf(
   OpenAIProvider.getAIMetricsFromResponse,
   () => client.chat.completions.create({
     model: 'gpt-4',

--- a/packages/ai-providers/server-ai-openai/src/OpenAIProvider.ts
+++ b/packages/ai-providers/server-ai-openai/src/OpenAIProvider.ts
@@ -210,7 +210,8 @@ export class OpenAIProvider extends AIProvider {
    * @returns LDAIMetrics with success status and token usage
    *
    * @example
-   * const response = await aiConfig.tracker.trackMetricsOf(
+   * const tracker = aiConfig.createTracker();
+   * const response = await tracker.trackMetricsOf(
    *   OpenAIProvider.getAIMetricsFromResponse,
    *   () => client.chat.completions.create(config)
    * );

--- a/packages/ai-providers/server-ai-vercel/README.md
+++ b/packages/ai-providers/server-ai-vercel/README.md
@@ -92,7 +92,8 @@ const userMessage = { role: 'user', content: 'What is the capital of France?' };
 const allMessages = [...configMessages, userMessage];
 
 // Track the model call with LaunchDarkly tracking
-const response = await aiConfig.tracker.trackMetricsOf(
+const tracker = aiConfig.createTracker();
+const response = await tracker.trackMetricsOf(
   VercelProvider.getAIMetricsFromResponse,
   () => generateText({ model, messages: allMessages })
 );

--- a/packages/ai-providers/server-ai-vercel/src/VercelProvider.ts
+++ b/packages/ai-providers/server-ai-vercel/src/VercelProvider.ts
@@ -181,7 +181,8 @@ export class VercelProvider extends AIProvider {
    * @returns LDAIMetrics with success status and token usage
    *
    * @example
-   * const response = await aiConfig.tracker.trackMetricsOf(
+   * const tracker = aiConfig.createTracker();
+   * const response = await tracker.trackMetricsOf(
    *   VercelProvider.getAIMetricsFromResponse,
    *   () => generateText(vercelConfig)
    * );
@@ -229,7 +230,8 @@ export class VercelProvider extends AIProvider {
    * @returns A Promise that resolves to LDAIMetrics
    *
    * @example
-   * const stream = aiConfig.tracker.trackStreamMetricsOf(
+   * const tracker = aiConfig.createTracker();
+   * const stream = tracker.trackStreamMetricsOf(
    *   () => streamText(vercelConfig),
    *   VercelProvider.getAIMetricsFromStream
    * );


### PR DESCRIPTION
## Summary

- Updates JSDoc `@example` blocks and README code snippets in the LangChain, OpenAI, and Vercel AI provider packages to use the new `config.createTracker()` factory pattern introduced in `@launchdarkly/server-sdk-ai` v0.17.0
- Removes references to the removed `config.tracker` property across 3 READMEs and 2 source files

## Test plan

- [ ] Verify no remaining `aiConfig.tracker` or `config.tracker` property accesses in the provider packages
- [ ] Confirm JSDoc examples compile and reflect the current API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is documentation/JSDoc example updates only, aligning sample code with the newer tracking API without changing runtime provider behavior.
> 
> **Overview**
> Updates LangChain, OpenAI, and Vercel provider READMEs and JSDoc examples to use the `aiConfig.createTracker()` factory, replacing direct `aiConfig.tracker` property access.
> 
> This keeps the sample tracking calls (`trackMetricsOf`/`trackStreamMetricsOf`) the same but ensures examples match `@launchdarkly/server-sdk-ai` v0.17.0’s API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1321cd9346763513853e0c54a32a4d87a28d934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->