### PR TITLE
fix(node-server-sdk-dynamodb): remove unnecessary ioredis package

### DIFF
--- a/packages/store/node-server-sdk-dynamodb/package.json
+++ b/packages/store/node-server-sdk-dynamodb/package.json
@@ -26,9 +26,6 @@
     "lint": "npx eslint . --ext .ts",
     "lint:fix": "yarn run lint --fix"
   },
-  "dependencies": {
-    "ioredis": "^5.3.2"
-  },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.53.0",
     "@launchdarkly/node-server-sdk": ">=9.4.3"

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBBigSegmentStore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBBigSegmentStore.ts
@@ -56,7 +56,7 @@ export default class DynamoDBBigSegmentStore implements interfaces.BigSegmentSto
     if (data) {
       const attr = data[ATTR_SYNC_ON];
       if (attr && attr.N) {
-        return { lastUpToDate: parseInt(attr.N!, 10) };
+        return { lastUpToDate: parseInt(attr.N, 10) };
       }
     }
     return {};

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBClientState.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBClientState.ts
@@ -37,7 +37,7 @@ export default class DynamoDBClientState {
   private _owned: boolean;
 
   constructor(options?: LDDynamoDBOptions) {
-    this._prefix = options?.prefix ? `${options!.prefix}:` : DEFAULT_PREFIX;
+    this._prefix = options?.prefix ? `${options.prefix}:` : DEFAULT_PREFIX;
 
     // We track if we own the client so that we can destroy clients that we own.
     if (options?.dynamoDBClient) {
@@ -75,8 +75,8 @@ export default class DynamoDBClientState {
   async batchWrite(table: string, params: WriteRequest[]) {
     const batches: WriteRequest[][] = [];
     // Split into batches of at most 25 commands.
-    while (params.length) {
-      batches.push(params.splice(0, WRITE_BATCH_SIZE));
+    for (let i = 0; i < params.length; i += WRITE_BATCH_SIZE) {
+      batches.push(params.slice(i, i + WRITE_BATCH_SIZE));
     }
 
     // Execute all the batches and wait for them to complete.

--- a/packages/store/node-server-sdk-dynamodb/src/TtlFromOptions.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/TtlFromOptions.ts
@@ -17,5 +17,5 @@ export default function TtlFromOptions(options?: LDDynamoDBOptions): number {
   if (options?.cacheTTL === undefined || options.cacheTTL === null) {
     return DEFAULT_CACHE_TTL_S;
   }
-  return options!.cacheTTL;
+  return options.cacheTTL;
 }


### PR DESCRIPTION
This PR removes the unused ioredis dependency from dynamodb storage module.

Additionally, I removed some unnecessary non-null assertions.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused dependency and makes small, behavior-preserving TypeScript safety tweaks; only functional change is avoiding in-place mutation in `batchWrite` batching logic.
> 
> **Overview**
> Removes the unused `ioredis` dependency from `@launchdarkly/node-server-sdk-dynamodb`.
> 
> Cleans up several unnecessary non-null assertions in DynamoDB store code and updates `DynamoDBClientState.batchWrite` to build 25-item batches via `slice` (no longer mutating the input array).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6542c8e124071aadbe06db295e75ec26245e439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->