### PR TITLE
refactor: reenabling `no-this-alias` and `no-non-null-asserted-option-chain` rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { ignoreRestSiblings: true, argsIgnorePattern: '^_', varsIgnorePattern: '^__' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,6 @@ module.exports = {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
-    '@typescript-eslint/no-this-alias': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { ignoreRestSiblings: true, argsIgnorePattern: '^_', varsIgnorePattern: '^__' },

--- a/packages/shared/sdk-server/__tests__/evaluation/Evaluator.prerequisite.test.ts
+++ b/packages/shared/sdk-server/__tests__/evaluation/Evaluator.prerequisite.test.ts
@@ -131,7 +131,7 @@ describe('given a flag payload with prerequisites', () => {
 
   it('can track prerequisites for a basic prereq', async () => {
     const res = await evaluator.evaluate(
-      testPayload?.flags['has-prereq-depth-1']!,
+      testPayload.flags['has-prereq-depth-1']!,
       Context.fromLDContext({ kind: 'user', key: 'bob' }),
       new EventFactory(true),
     );
@@ -143,7 +143,7 @@ describe('given a flag payload with prerequisites', () => {
 
   it('can track prerequisites for a prereq of a prereq', async () => {
     const res = await evaluator.evaluate(
-      testPayload?.flags['has-prereq-depth-2']!,
+      testPayload.flags['has-prereq-depth-2']!,
       Context.fromLDContext({ kind: 'user', key: 'bob' }),
       new EventFactory(true),
     );
@@ -155,7 +155,7 @@ describe('given a flag payload with prerequisites', () => {
 
   it('can track prerequisites for a flag with multiple prereqs with and without additional prereqs', async () => {
     const res = await evaluator.evaluate(
-      testPayload?.flags['has-prereq-depth-3']!,
+      testPayload.flags['has-prereq-depth-3']!,
       Context.fromLDContext({ kind: 'user', key: 'bob' }),
       new EventFactory(true),
     );
@@ -168,7 +168,7 @@ describe('given a flag payload with prerequisites', () => {
   it('has can handle a prerequisite failure', async () => {
     testPayload.flags['is-prereq'].on = false;
     const res = await evaluator.evaluate(
-      testPayload?.flags['has-prereq-depth-3']!,
+      testPayload.flags['has-prereq-depth-3']!,
       Context.fromLDContext({ kind: 'user', key: 'bob' }),
       new EventFactory(true),
     );

--- a/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
+++ b/packages/telemetry/browser-telemetry/src/BrowserTelemetryImpl.ts
@@ -170,9 +170,8 @@ export default class BrowserTelemetryImpl implements BrowserTelemetry {
       collector.register(this as BrowserTelemetry, this._sessionId),
     );
 
-    const impl = this;
     const inspectors: BrowserTelemetryInspector[] = [];
-    makeInspectors(_options, inspectors, impl);
+    makeInspectors(_options, inspectors, this);
     this._inspectorInstances.push(...inspectors);
   }
 


### PR DESCRIPTION
- **refactor: reenable no this alias rule**
- **refactor(test): enabling no-non-null-asserted-option-chain**

SDK-2233
SDK-2232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lint-driven refactor: behavior is unchanged aside from passing `this` directly and tightening test typing assumptions.
> 
> **Overview**
> Re-enables the TypeScript ESLint rules `@typescript-eslint/no-this-alias` and `@typescript-eslint/no-non-null-asserted-optional-chain` by removing their disables from `.eslintrc.js`.
> 
> Updates affected code to comply: `BrowserTelemetryImpl` no longer aliases `this` before calling `makeInspectors`, and the prerequisite evaluator tests remove `?.` + `!` optional-chain assertions when accessing `testPayload.flags`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd60b80c880282dbe55e24e5136c89f15de96993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->