### PR TITLE
fix: enabling eslint `ban-types` rule and fixed string typing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,6 @@ module.exports = {
     ],
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',

--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -279,12 +279,12 @@ class BrowserClientImpl extends LDClientImpl {
     this.dataManager.setAutomaticStreamingState?.(hasListeners);
   }
 
-  override on(eventName: LDEmitterEventName, listener: Function): void {
+  override on(eventName: LDEmitterEventName, listener: (...args: any[]) => void): void {
     super.on(eventName, listener);
     this._updateAutomaticStreamingState();
   }
 
-  override off(eventName: LDEmitterEventName, listener: Function): void {
+  override off(eventName: LDEmitterEventName, listener: (...args: any[]) => void): void {
     super.off(eventName, listener);
     this._updateAutomaticStreamingState();
   }

--- a/packages/sdk/electron/__tests__/ElectronClient.ipcMain.test.ts
+++ b/packages/sdk/electron/__tests__/ElectronClient.ipcMain.test.ts
@@ -16,19 +16,21 @@ import ElectronInfo from '../src/platform/ElectronInfo';
 import { createMockLogger } from './testHelpers';
 
 type MockIpcMain = IpcMain & {
-  getHandler: (eventName: string) => Function | undefined;
+  getHandler: (eventName: string) => ((...args: any[]) => void) | undefined;
   removeAllListeners: (channel: string) => void;
   removeHandler: (channel: string) => void;
 };
-type MockPort = { postMessage: Function; close: Function };
+type MockPort = { postMessage: (...args: any[]) => void; close: (...args: any[]) => void };
 type MockIpcEvent = { returnValue?: any; ports?: MockPort[] };
 
 jest.mock('electron', () => {
-  const handlers = new Map<string, Function>();
+  const handlers = new Map<string, (...args: any[]) => void>();
   return {
     ipcMain: {
-      on: (eventName: string, handler: Function) => handlers.set(eventName, handler),
-      handle: (eventName: string, handler: Function) => handlers.set(eventName, handler),
+      on: (eventName: string, handler: (...args: any[]) => void) =>
+        handlers.set(eventName, handler),
+      handle: (eventName: string, handler: (...args: any[]) => void) =>
+        handlers.set(eventName, handler),
       getHandler: (eventName: string) => handlers.get(eventName),
       removeAllListeners: (channel: string) => handlers.delete(channel),
       removeHandler: (channel: string) => handlers.delete(channel),

--- a/packages/sdk/electron/__tests__/ElectronClient.mainProcess.test.ts
+++ b/packages/sdk/electron/__tests__/ElectronClient.mainProcess.test.ts
@@ -56,18 +56,19 @@ function createMockEventSourceThatDeliversPut(putData: object) {
   });
 }
 
-const handlers = new Map<string, Function>();
-const mockOn = jest.fn((eventName: string, handler: Function) => {
+const handlers = new Map<string, (...args: any[]) => void>();
+const mockOn = jest.fn((eventName: string, handler: (...args: any[]) => void) => {
   handlers.set(eventName, handler);
 });
-const mockHandle = jest.fn((eventName: string, handler: Function) => {
+const mockHandle = jest.fn((eventName: string, handler: (...args: any[]) => void) => {
   handlers.set(eventName, handler);
 });
 
 jest.mock('electron', () => ({
   ipcMain: {
-    on: (eventName: string, handler: Function) => mockOn(eventName, handler),
-    handle: (eventName: string, handler: Function) => mockHandle(eventName, handler),
+    on: (eventName: string, handler: (...args: any[]) => void) => mockOn(eventName, handler),
+    handle: (eventName: string, handler: (...args: any[]) => void) =>
+      mockHandle(eventName, handler),
     getHandler: (eventName: string) => handlers.get(eventName),
     removeAllListeners: (channel: string) => handlers.delete(channel),
     removeHandler: (channel: string) => handlers.delete(channel),

--- a/packages/sdk/electron/__tests__/renderer/ElectronRendererClient.test.ts
+++ b/packages/sdk/electron/__tests__/renderer/ElectronRendererClient.test.ts
@@ -217,7 +217,7 @@ describe('given an instance of ElectronRendererClient', () => {
     const clientForSyncClose = new ElectronRendererClient(clientSideId);
     const syncCloseId = 'sync-close-id';
     (ldClientBridge.addEventHandler as jest.Mock).mockImplementation(
-      (_eventName: string, _cb: Function, onClose?: () => void) => {
+      (_eventName: string, _cb: (...args: any[]) => void, onClose?: () => void) => {
         onClose?.();
         return syncCloseId;
       },

--- a/packages/sdk/electron/src/platform/ElectronRequests.ts
+++ b/packages/sdk/electron/src/platform/ElectronRequests.ts
@@ -122,7 +122,7 @@ export default class ElectronRequests implements platform.Requests {
     const impl = isSecure ? https : http;
 
     const headers = { ...options.headers };
-    let bodyData: String | Buffer | undefined = options.body;
+    let bodyData: string | Buffer | undefined = options.body;
 
     // For get requests we are going to automatically support compressed responses.
     // Note this does not affect SSE as the event source is not using this fetch implementation.

--- a/packages/sdk/server-node/src/Emits.ts
+++ b/packages/sdk/server-node/src/Emits.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 export type EventableConstructor<T = {}> = new (...args: any[]) => T;
 export type Eventable = EventableConstructor<{ emitter: EventEmitter }>;
 
@@ -50,10 +51,12 @@ export function Emits<TBase extends Eventable>(Base: TBase) {
       return this.emitter.getMaxListeners();
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-types
     listeners(eventName: string | symbol): Function[] {
       return this.emitter.listeners(eventName);
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-types
     rawListeners(eventName: string | symbol): Function[] {
       return this.emitter.rawListeners(eventName);
     }

--- a/packages/sdk/server-node/src/LDClientNode.ts
+++ b/packages/sdk/server-node/src/LDClientNode.ts
@@ -133,10 +133,12 @@ class LDClientNode extends LDClientImpl implements LDClient {
     return this.emitter.getMaxListeners();
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-types
   listeners(eventName: string | symbol): Function[] {
     return this.emitter.listeners(eventName);
   }
 
+  // eslint-disable-next-line @typescript-eslint/ban-types
   rawListeners(eventName: string | symbol): Function[] {
     return this.emitter.rawListeners(eventName);
   }

--- a/packages/sdk/server-node/src/platform/NodeRequests.ts
+++ b/packages/sdk/server-node/src/platform/NodeRequests.ts
@@ -126,7 +126,7 @@ export default class NodeRequests implements platform.Requests {
     const impl = isSecure ? https : http;
 
     const headers = { ...options.headers };
-    let bodyData: String | Buffer | undefined = options.body;
+    let bodyData: string | Buffer | undefined = options.body;
 
     // For get requests we are going to automatically support compressed responses.
     // Note this does not affect SSE as the event source is not using this fetch implementation.

--- a/packages/sdk/shopify-oxygen/contract-tests/src/index.ts
+++ b/packages/sdk/shopify-oxygen/contract-tests/src/index.ts
@@ -19,7 +19,7 @@ const port = 8000;
 const clientPool = new ClientPool();
 
 if (debugging) {
-  app.use((req: Request, res: Response, next: Function) => {
+  app.use((req: Request, res: Response, next: (...args: any[]) => void) => {
     console.debug('request', req.method, req.url);
     if (req.body) {
       console.debug('request', JSON.stringify(req.body, null, 2));

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/utils/validateOptions.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/utils/validateOptions.test.ts
@@ -35,7 +35,7 @@ const mockOptions = ({
   } as LDOptionsInternal;
 };
 
-const expectError = (callback: Function, expectedError: Error) => {
+const expectError = (callback: (...args: any[]) => void, expectedError: Error) => {
   expect.assertions(1);
   try {
     callback();

--- a/packages/shared/common/src/utils/deepCompact.ts
+++ b/packages/shared/common/src/utils/deepCompact.ts
@@ -8,7 +8,7 @@ import isEmptyObject from './isEmptyObject';
  * @param obj
  * @param ignoreKeys
  */
-const deepCompact = <T extends Object>(obj?: T, ignoreKeys?: string[]) => {
+const deepCompact = <T extends object>(obj?: T, ignoreKeys?: string[]) => {
   if (!obj) {
     return obj;
   }

--- a/packages/shared/sdk-client/src/LDClientImpl.ts
+++ b/packages/shared/sdk-client/src/LDClientImpl.ts
@@ -568,11 +568,11 @@ export default class LDClientImpl implements LDClient, LDClientIdentifyResult {
     });
   }
 
-  on(eventName: EventName, listener: Function): void {
+  on(eventName: EventName, listener: (...args: any[]) => void): void {
     this.emitter.on(eventName, listener);
   }
 
-  off(eventName: EventName, listener: Function): void {
+  off(eventName: EventName, listener: (...args: any[]) => void): void {
     this.emitter.off(eventName, listener);
   }
 

--- a/packages/shared/sdk-client/src/LDEmitter.ts
+++ b/packages/shared/sdk-client/src/LDEmitter.ts
@@ -21,11 +21,11 @@ export type EventName =
  * a system to allow listeners which have counts independent of the primary listener counts.
  */
 export default class LDEmitter {
-  private _listeners: Map<EventName, Function[]> = new Map();
+  private _listeners: Map<EventName, ((...args: any[]) => void)[]> = new Map();
 
   constructor(private _logger?: LDLogger) {}
 
-  on(name: EventName, listener: Function) {
+  on(name: EventName, listener: (...args: any[]) => void) {
     if (typeof name !== 'string') {
       this._logger?.warn('Only string event names are supported.');
       return;
@@ -43,7 +43,7 @@ export default class LDEmitter {
    * @param name
    * @param listener Optional. If unspecified, all listeners for the event will be removed.
    */
-  off(name: EventName, listener?: Function) {
+  off(name: EventName, listener?: (...args: any[]) => void) {
     const existingListeners = this._listeners.get(name);
     if (!existingListeners) {
       return;
@@ -64,7 +64,7 @@ export default class LDEmitter {
     this._listeners.delete(name);
   }
 
-  private _invokeListener(listener: Function, name: EventName, ...detail: any[]) {
+  private _invokeListener(listener: (...args: any[]) => void, name: EventName, ...detail: any[]) {
     try {
       listener(...detail);
     } catch (err) {

--- a/packages/shared/sdk-server/__tests__/LDClientImpl.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClientImpl.test.ts
@@ -14,7 +14,7 @@ function getUpdateProcessorFactory(shouldError: boolean = false, initTimeoutMs: 
   return (
     _clientContext: LDClientContext,
     featureStore: LDFeatureStore,
-    initSuccessHandler: Function,
+    initSuccessHandler: (...args: any[]) => void,
     errorHandler?: (e: Error) => void,
   ) => ({
     start: jest.fn(async () => {

--- a/packages/shared/sdk-server/src/api/subsystems/LDTransactionalDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDTransactionalDataSourceUpdates.ts
@@ -23,6 +23,6 @@ export interface LDTransactionalDataSourceUpdates extends LDDataSourceUpdates {
     data: LDFeatureStoreDataStorage,
     callback: () => void,
     initMetadata?: internal.InitMetadata,
-    selector?: String,
+    selector?: string,
   ): void;
 }

--- a/packages/shared/sdk-server/src/api/subsystems/LDTransactionalFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDTransactionalFeatureStore.ts
@@ -32,7 +32,7 @@ export interface LDTransactionalFeatureStore extends LDFeatureStore {
     data: LDFeatureStoreDataStorage,
     callback: () => void,
     initMetadata?: internal.InitMetadata,
-    selector?: String,
+    selector?: string,
   ): void;
 
   /**

--- a/packages/shared/sdk-server/src/data_sources/TransactionalDataSourceUpdates.ts
+++ b/packages/shared/sdk-server/src/data_sources/TransactionalDataSourceUpdates.ts
@@ -50,7 +50,7 @@ export default class TransactionalDataSourceUpdates implements LDTransactionalDa
     data: LDFeatureStoreDataStorage,
     callback: () => void,
     initMetadata?: internal.InitMetadata,
-    selector?: String,
+    selector?: string,
   ): void {
     const checkForChanges = this._hasEventListeners();
     const doApplyChanges = (oldData: LDFeatureStoreDataStorage) => {

--- a/packages/shared/sdk-server/src/store/AsyncTransactionalStoreFacade.ts
+++ b/packages/shared/sdk-server/src/store/AsyncTransactionalStoreFacade.ts
@@ -66,7 +66,7 @@ export default class AsyncTransactionalStoreFacade {
     basis: boolean,
     data: LDFeatureStoreDataStorage,
     initMetadata?: internal.InitMetadata,
-    selector?: String,
+    selector?: string,
   ): Promise<void> {
     return promisify((cb) => {
       this._store.applyChanges(basis, data, cb, initMetadata, selector);


### PR DESCRIPTION
This PR reenables the ban-type eslint rule. This results in:
- a fix to a pre-existing typing bug where `String` type should be `string`
- a more defined `Function` typing

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly TypeScript typing/lint-only changes (replacing `Function`/`String` with safer types) with minimal runtime impact; risk is limited to potential downstream type incompatibilities in event listener signatures.
> 
> **Overview**
> Re-enables stricter TypeScript linting around banned types by removing the global `@typescript-eslint/ban-types` opt-out and adding targeted suppressions where `Function` return types are required (e.g. `listeners()`/`rawListeners()`).
> 
> Tightens public and test-facing callback typings across clients/emitter APIs by replacing `Function` with `(...args: any[]) => void`, and fixes boxed `String` usages to primitive `string` in request bodies and transactional store `selector` parameters (plus `deepCompact` now constrains `T` to `object`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ceb8c02e36060d19ee70677ab5511e62f4022e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->