### PR TITLE
fix(react-native): `package.json` should declare esm format

### DIFF
--- a/packages/sdk/react-native/babel.config.js
+++ b/packages/sdk/react-native/babel.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   presets: ['module:metro-react-native-babel-preset'],
 };

--- a/packages/sdk/react-native/package.json
+++ b/packages/sdk/react-native/package.json
@@ -13,7 +13,7 @@
     "launchdarkly",
     "react-native"
   ],
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
This PR should address https://github.com/launchdarkly/js-core/issues/1321

The change should be safe as, per the issue, downstream consumers should not be able to use `reqire` due to everything being in `esm` syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because changing `package.json` `type` and Babel config module syntax can affect how tooling and downstream bundlers/loaders resolve and execute the package.
> 
> **Overview**
> Makes the React Native SDK explicitly ESM by switching `package.json` `type` from `commonjs` to `module`.
> 
> Updates `babel.config.js` to use ESM syntax (`export default`) to align with the package’s module format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b263443c674d8e9e3686e232e1c4354c64634b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->