### PR TITLE
chore: Enable automatic peer dependency while we are pre 1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -305,7 +305,7 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "updatePeerDependencies": false
+      "updatePeerDependencies": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Sets `updatePeerDependencies: true` in the `node-workspace` release-please plugin
- Ensures provider packages (`server-sdk-ai-langchain`, `server-sdk-ai-openai`, `server-sdk-ai-vercel`) have their peer dep ranges bumped automatically whenever `server-sdk-ai` releases
- Fixes the incompatibility flagged by Cursor Bugbot on #1323: in 0.x semver, `^0.17.0` means `>=0.17.0 <0.18.0`, so a minor bump to the SDK immediately breaks the peer dep constraint

## Post-1.0

Once `server-sdk-ai` reaches 1.0, flip `updatePeerDependencies` back to `false`. At that point `^1.0.0` covers all `1.x.x` releases and provider packages won't need a peer dep bump with every SDK minor/patch release.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the open release-please PR (#1323) is updated/regenerated with peer dep bumps included automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects release automation by updating peer dependency ranges during workspace version bumps.
> 
> **Overview**
> Enables `updatePeerDependencies` for the `node-workspace` `release-please` plugin so release PRs automatically bump workspace package peer dependency ranges when related packages are released (notably helpful for 0.x versions where `^` ranges are narrow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c1bcbfc210d1313ea2d9275a9d110f82bc638b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->