### PR TITLE
chore: bump tracked-chat example to LangChain 1.x

### DIFF
--- a/packages/sdk/server-ai/examples/chat-judge/package.json
+++ b/packages/sdk/server-ai/examples/chat-judge/package.json
@@ -10,9 +10,11 @@
     "start": "yarn build && node ./dist/index.js"
   },
   "dependencies": {
+    "@langchain/core": "^1.0.0",
     "@launchdarkly/node-server-sdk": "9.10.12",
     "@launchdarkly/server-sdk-ai": "0.17.1",
     "@launchdarkly/server-sdk-ai-langchain": "0.5.6",
+    "langchain": "^1.0.0",
     "@launchdarkly/server-sdk-ai-openai": "0.5.6",
     "@launchdarkly/server-sdk-ai-vercel": "0.5.6",
     "dotenv": "^16.0.0"

--- a/packages/sdk/server-ai/examples/direct-judge/package.json
+++ b/packages/sdk/server-ai/examples/direct-judge/package.json
@@ -10,9 +10,11 @@
     "start": "yarn build && node ./dist/index.js"
   },
   "dependencies": {
+    "@langchain/core": "^1.0.0",
     "@launchdarkly/node-server-sdk": "9.10.12",
     "@launchdarkly/server-sdk-ai": "0.17.1",
     "@launchdarkly/server-sdk-ai-langchain": "0.5.6",
+    "langchain": "^1.0.0",
     "@launchdarkly/server-sdk-ai-openai": "0.5.6",
     "@launchdarkly/server-sdk-ai-vercel": "0.5.6",
     "dotenv": "^16.0.0"

--- a/packages/sdk/server-ai/examples/tracked-chat/package.json
+++ b/packages/sdk/server-ai/examples/tracked-chat/package.json
@@ -10,15 +10,15 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^2.0.20",
-    "@langchain/core": "^0.3.78",
-    "@langchain/google-genai": "^0.2.18",
+    "@langchain/core": "^1.1.42",
+    "@langchain/google-genai": "^1.0.3",
     "@launchdarkly/node-server-sdk": "9.10.12",
     "@launchdarkly/server-sdk-ai": "0.17.1",
     "@launchdarkly/server-sdk-ai-langchain": "0.5.6",
     "@launchdarkly/server-sdk-ai-openai": "0.5.6",
     "@launchdarkly/server-sdk-ai-vercel": "0.5.6",
     "dotenv": "^16.0.0",
-    "langchain": "^0.1.0"
+    "langchain": "^1.3.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary

- Bumps `@langchain/core` from `^0.3.78` to `^1.1.42`
- Bumps `@langchain/google-genai` from `^0.2.18` to `^1.0.3`
- Bumps `langchain` from `^0.1.0` to `^1.3.5`

Follow-up to #1311 which updated `@launchdarkly/server-sdk-ai-langchain` to require LangChain 1.x peer deps. The `tracked-chat` example was still pinned to pre-1.x versions.

## Test plan

- [x] Ran `yarn start` in `tracked-chat` example — SDK initialized and completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only changes limited to example `package.json` files; main risk is install/build breakage if peer-dep expectations differ.
> 
> **Overview**
> Updates server AI SDK examples to use LangChain 1.x dependencies.
> 
> `tracked-chat` bumps `@langchain/core`, `@langchain/google-genai`, and `langchain` to 1.x versions, and `chat-judge`/`direct-judge` add explicit `@langchain/core` and `langchain` 1.x deps to satisfy the `@launchdarkly/server-sdk-ai-langchain` peer requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2e5d7b3c08e7eba4dce0ee76f669686d8f21ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->