### PR TITLE
chore: init shared openfeature server provider

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -14,6 +14,7 @@
   "packages/sdk/vercel": "1.3.45",
   "packages/shared/akamai-edgeworker-sdk": "2.0.20",
   "packages/shared/common": "2.24.3",
+  "packages/shared/openfeature-server-common": "0.1.0",
   "packages/shared/sdk-client": "1.26.2",
   "packages/shared/sdk-server": "2.18.6",
   "packages/shared/sdk-server-edge": "2.6.19",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "packages/shared/sdk-server",
     "packages/shared/sdk-server-edge",
     "packages/shared/akamai-edgeworker-sdk",
+    "packages/shared/openfeature-server-common",
     "packages/sdk/server-node",
     "packages/sdk/server-node/contract-tests",
     "packages/sdk/cloudflare",

--- a/packages/shared/openfeature-server-common/LICENSE
+++ b/packages/shared/openfeature-server-common/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2025 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/shared/openfeature-server-common/README.md
+++ b/packages/shared/openfeature-server-common/README.md
@@ -1,0 +1,46 @@
+# LaunchDarkly OpenFeature Common Server Provider
+
+<!--
+[![NPM][openfeature-server-common-npm-badge]][openfeature-server-common-npm-link]
+[![Actions Status][openfeature-server-common-ci-badge]][openfeature-server-common-ci]
+-->
+
+> [!CAUTION]
+> This SDK is in pre-release and not subject to backwards compatibility
+> guarantees. The API may change based on feedback.
+>
+> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
+
+This package contains the shared OpenFeature provider implementation for LaunchDarkly server-side JavaScript SDKs. It provides a base provider class and translation utilities that convert between OpenFeature and LaunchDarkly concepts.
+
+This package is not intended to be used directly.
+
+## Contributing
+
+See [Contributing](../CONTRIBUTING.md).
+
+## Verifying SDK build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
+## About LaunchDarkly
+
+- LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard. With LaunchDarkly, you can:
+  - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+  - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+  - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan).
+  - Disable parts of your application to facilitate maintenance, without taking everything offline.
+- LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+- Explore LaunchDarkly
+  - [launchdarkly.com](https://www.launchdarkly.com/ 'LaunchDarkly Main Website') for more information
+  - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
+  - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
+  - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+<!--
+[openfeature-server-common-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-js-server-common.svg?style=flat-square
+[openfeature-server-common-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-js-server-common
+[openfeature-server-common-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml/badge.svg
+[openfeature-server-common-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml
+-->

--- a/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
@@ -232,6 +232,20 @@ it('track passes undefined data when only the value is provided', () => {
   );
 });
 
+it('track with no event details passes undefined data and undefined metricValue', () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  provider.track('event', { targetingKey: 'u' });
+
+  expect(client.track).toHaveBeenCalledWith(
+    'event',
+    { kind: 'user', key: 'u' },
+    undefined,
+    undefined,
+  );
+});
+
 it('track with empty event details passes undefined data and undefined metricValue', () => {
   const client = new MockLDClient();
   const provider = new TestProvider(baseConfig(new TestLogger()), client);
@@ -316,3 +330,4 @@ it('wraps a host logger that throws so flag evaluation does not crash', async ()
     }),
   ).resolves.toEqual({ value: true, variant: '0', reason: 'OFF' });
 });
+

--- a/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
@@ -158,6 +158,24 @@ it.each([
   },
 );
 
+it('resolveObjectEvaluation returns wrong-type fallback when the SDK value is null', async () => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: null,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveObjectEvaluation('flag', { a: 1 }, { targetingKey: 'u' });
+
+  expect(result).toEqual({
+    value: { a: 1 },
+    reason: StandardResolutionReasons.ERROR,
+    errorCode: ErrorCode.TYPE_MISMATCH,
+  });
+});
+
 it.each([
   ['CLIENT_NOT_READY', ErrorCode.PROVIDER_NOT_READY],
   ['MALFORMED_FLAG', ErrorCode.PARSE_ERROR],

--- a/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
@@ -1,0 +1,300 @@
+import { ErrorCode, ProviderEvents, StandardResolutionReasons } from '@openfeature/server-sdk';
+
+import { BaseOpenFeatureProvider, type BaseProviderConfig } from '../src/BaseOpenFeatureProvider';
+import type { OpenFeatureLDClientContract } from '../src/OpenFeatureLDClientContract';
+import TestLogger from './TestLogger';
+
+class MockLDClient implements OpenFeatureLDClientContract {
+  variationDetail = jest.fn();
+  waitForInitialization = jest.fn().mockResolvedValue(undefined);
+  flush = jest.fn().mockResolvedValue(undefined);
+  close = jest.fn();
+  track = jest.fn();
+}
+
+class TestProvider extends BaseOpenFeatureProvider {
+  constructor(config: BaseProviderConfig, client?: OpenFeatureLDClientContract, error?: unknown) {
+    super(config);
+    if (error !== undefined) {
+      this.setClientError(error);
+    } else if (client) {
+      this.setClient(client);
+    }
+  }
+
+  emitChange(flagKey: string) {
+    this.emitConfigurationChanged(flagKey);
+  }
+}
+
+const baseConfig = (logger: TestLogger): BaseProviderConfig => ({
+  logger,
+  providerName: 'test-provider',
+});
+
+it('exposes provider metadata and runsOn', () => {
+  const provider = new TestProvider(baseConfig(new TestLogger()), new MockLDClient());
+  expect(provider.metadata).toEqual({ name: 'test-provider' });
+  expect(provider.runsOn).toEqual('server');
+  expect(provider.hooks).toEqual([]);
+});
+
+it('initialize forwards the configured timeout to waitForInitialization', async () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(
+    { logger: new TestLogger(), providerName: 'p', initTimeoutSeconds: 5 },
+    client,
+  );
+  await provider.initialize();
+  expect(client.waitForInitialization).toHaveBeenCalledWith({ timeout: 5 });
+});
+
+it('initialize defaults the timeout to 10 seconds', async () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+  await provider.initialize();
+  expect(client.waitForInitialization).toHaveBeenCalledWith({ timeout: 10 });
+});
+
+it('initialize rethrows the construction error when setClientError was called', async () => {
+  const error = new Error('boom');
+  const provider = new TestProvider(baseConfig(new TestLogger()), undefined, error);
+  await expect(provider.initialize()).rejects.toBe(error);
+});
+
+it('initialize throws a generic error when no client and no error were registered', async () => {
+  const provider = new TestProvider(baseConfig(new TestLogger()));
+  await expect(provider.initialize()).rejects.toThrow('Unknown problem encountered during initialization');
+});
+
+it('resolveBooleanEvaluation returns the translated result for boolean flags', async () => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: true,
+    variationIndex: 1,
+    reason: { kind: 'OFF' },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveBooleanEvaluation('flag', false, { targetingKey: 'u' });
+
+  expect(client.variationDetail).toHaveBeenCalledWith(
+    'flag',
+    { kind: 'user', key: 'u' },
+    false,
+  );
+  expect(result).toEqual({ value: true, variant: '1', reason: 'OFF' });
+});
+
+it('resolveStringEvaluation returns the translated result for string flags', async () => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: 'green',
+    variationIndex: 0,
+    reason: { kind: 'FALLTHROUGH' },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveStringEvaluation('flag', 'red', { targetingKey: 'u' });
+
+  expect(result).toEqual({ value: 'green', variant: '0', reason: 'FALLTHROUGH' });
+});
+
+it('resolveNumberEvaluation returns the translated result for number flags', async () => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: 42,
+    variationIndex: 2,
+    reason: { kind: 'TARGET_MATCH' },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveNumberEvaluation('flag', 0, { targetingKey: 'u' });
+
+  expect(result).toEqual({ value: 42, variant: '2', reason: 'TARGET_MATCH' });
+});
+
+it('resolveObjectEvaluation returns the translated result for object flags', async () => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: { a: 1 },
+    variationIndex: 3,
+    reason: { kind: 'RULE_MATCH' },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveObjectEvaluation<{ a: number }>(
+    'flag',
+    { a: 0 },
+    { targetingKey: 'u' },
+  );
+
+  expect(result).toEqual({ value: { a: 1 }, variant: '3', reason: 'RULE_MATCH' });
+});
+
+it.each([
+  ['boolean', 'resolveBooleanEvaluation', 'not-a-bool', false],
+  ['string', 'resolveStringEvaluation', 7, 'fallback'],
+  ['number', 'resolveNumberEvaluation', 'not-a-number', 0],
+  ['object', 'resolveObjectEvaluation', 'not-an-object', { a: 1 }],
+] as const)(
+  'returns wrong-type fallback when %s flag has wrong type',
+  async (_label, method, returnedValue, defaultValue) => {
+    const client = new MockLDClient();
+    client.variationDetail.mockResolvedValue({
+      value: returnedValue,
+      variationIndex: 0,
+      reason: { kind: 'OFF' },
+    });
+    const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+    const result = await (provider as any)[method]('flag', defaultValue, { targetingKey: 'u' });
+
+    expect(result).toEqual({
+      value: defaultValue,
+      reason: StandardResolutionReasons.ERROR,
+      errorCode: ErrorCode.TYPE_MISMATCH,
+    });
+  },
+);
+
+it.each([
+  ['CLIENT_NOT_READY', ErrorCode.PROVIDER_NOT_READY],
+  ['MALFORMED_FLAG', ErrorCode.PARSE_ERROR],
+  ['FLAG_NOT_FOUND', ErrorCode.FLAG_NOT_FOUND],
+  ['USER_NOT_SPECIFIED', ErrorCode.TARGETING_KEY_MISSING],
+  ['UNSPECIFIED', ErrorCode.GENERAL],
+  [undefined, ErrorCode.GENERAL],
+] as const)('translates ERROR-reason errorKind %s into OpenFeature error code', async (errorKind, expectedCode) => {
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: { yes: 'no' },
+    reason: { kind: 'ERROR', errorKind },
+  });
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  const result = await provider.resolveObjectEvaluation('flag', { yes: 'no' }, { targetingKey: 'u' });
+
+  expect(result).toMatchObject({
+    value: { yes: 'no' },
+    reason: 'ERROR',
+    errorCode: expectedCode,
+  });
+});
+
+it('track forwards the translated context, event details, and metric value', () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  provider.track(
+    'event',
+    { targetingKey: 'u', kind: 'user' },
+    { value: 1.5, foo: 'bar' },
+  );
+
+  expect(client.track).toHaveBeenCalledWith(
+    'event',
+    { kind: 'user', key: 'u' },
+    { foo: 'bar' },
+    1.5,
+  );
+});
+
+it('track passes undefined data when only the value is provided', () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  provider.track('event', { targetingKey: 'u' }, { value: 7 });
+
+  expect(client.track).toHaveBeenCalledWith(
+    'event',
+    { kind: 'user', key: 'u' },
+    undefined,
+    7,
+  );
+});
+
+it('track with empty event details passes undefined data and undefined metricValue', () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  provider.track('event', { targetingKey: 'u' }, {});
+
+  expect(client.track).toHaveBeenCalledWith(
+    'event',
+    { kind: 'user', key: 'u' },
+    undefined,
+    undefined,
+  );
+});
+
+it('track with data but no metricValue forwards data and undefined metricValue', () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  provider.track('event', { targetingKey: 'u' }, { key1: 'val1' });
+
+  expect(client.track).toHaveBeenCalledWith(
+    'event',
+    { kind: 'user', key: 'u' },
+    { key1: 'val1' },
+    undefined,
+  );
+});
+
+it('emits ConfigurationChanged events with the affected flag key', () => {
+  const provider = new TestProvider(baseConfig(new TestLogger()), new MockLDClient());
+  const handler = jest.fn();
+  provider.events.addHandler(ProviderEvents.ConfigurationChanged, handler);
+
+  provider.emitChange('my-flag');
+
+  expect(handler).toHaveBeenCalledWith({ flagsChanged: ['my-flag'] });
+});
+
+it('onClose flushes and closes the client', async () => {
+  const client = new MockLDClient();
+  const provider = new TestProvider(baseConfig(new TestLogger()), client);
+
+  await provider.onClose();
+
+  expect(client.flush).toHaveBeenCalled();
+  expect(client.close).toHaveBeenCalled();
+});
+
+it('logs the construction error when setClientError is called', () => {
+  const logger = new TestLogger();
+  // eslint-disable-next-line no-new
+  new TestProvider(baseConfig(logger), undefined, new Error('init fail'));
+  expect(logger.logs.some((line) => line.includes('init fail'))).toEqual(true);
+});
+
+it('wraps a host logger that throws so flag evaluation does not crash', async () => {
+  const throwingLogger = {
+    error: () => {
+      throw new Error('logger error path threw');
+    },
+    warn: () => {
+      throw new Error('logger warn path threw');
+    },
+    info: () => {},
+    debug: () => {},
+  };
+  const client = new MockLDClient();
+  client.variationDetail.mockResolvedValue({
+    value: true,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+  const provider = new TestProvider(
+    { logger: throwingLogger, providerName: 'p' },
+    client,
+  );
+
+  await expect(
+    provider.resolveBooleanEvaluation('flag', false, {
+      targetingKey: 'u',
+      kind: 42 as unknown as string,
+    }),
+  ).resolves.toEqual({ value: true, variant: '0', reason: 'OFF' });
+});

--- a/packages/shared/openfeature-server-common/__tests__/TestLogger.ts
+++ b/packages/shared/openfeature-server-common/__tests__/TestLogger.ts
@@ -1,0 +1,25 @@
+import type { LDLogger } from '@launchdarkly/js-sdk-common';
+
+export default class TestLogger implements LDLogger {
+  public logs: string[] = [];
+
+  error(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  warn(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  info(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  debug(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  reset() {
+    this.logs = [];
+  }
+}

--- a/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
@@ -1,0 +1,218 @@
+import { translateContext } from '../src/translateContext';
+import TestLogger from './TestLogger';
+
+it('Uses the targetingKey as the user key', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'the-key' })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('gives targetingKey precedence over key', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'target-key', key: 'key-key' })).toEqual({
+    key: 'target-key',
+    kind: 'user',
+  });
+  // Should log a warning about both being defined.
+  expect(logger.logs.length).toEqual(1);
+});
+
+describe.each([
+  ['name', 'value2'],
+  ['firstName', 'value3'],
+  ['lastName', 'value4'],
+  ['email', 'value5'],
+  ['avatar', 'value6'],
+  ['ip', 'value7'],
+  ['country', 'value8'],
+  ['anonymous', true],
+])('given correct built-in attributes', (key, value) => {
+  const logger = new TestLogger();
+  it('translates the key correctly', () => {
+    expect(translateContext(logger, { targetingKey: 'the-key', [key]: value })).toEqual({
+      key: 'the-key',
+      [key]: value,
+      kind: 'user',
+    });
+    expect(logger.logs.length).toEqual(0);
+  });
+});
+
+it.each(['key', 'targetingKey'])('handles key or targetingKey', (key) => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { [key]: 'the-key' })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+describe.each([
+  ['name', 17],
+  ['anonymous', 'value'],
+])('given incorrect built-in attributes', (key, value) => {
+  it('the bad key is omitted', () => {
+    const logger = new TestLogger();
+    expect(translateContext(logger, { targetingKey: 'the-key', [key]: value })).toEqual({
+      key: 'the-key',
+      kind: 'user',
+    });
+    expect(logger.logs[0]).toMatch(new RegExp(`The attribute '${key}' must be of type.*`));
+  });
+});
+
+it('accepts custom attributes', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'the-key', someAttr: 'someValue' })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    someAttr: 'someValue',
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('accepts string/boolean/number arrays', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      targetingKey: 'the-key',
+      strings: ['a', 'b', 'c'],
+      numbers: [1, 2, 3],
+      booleans: [true, false],
+    }),
+  ).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    strings: ['a', 'b', 'c'],
+    numbers: [1, 2, 3],
+    booleans: [true, false],
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('converts date to ISO strings', () => {
+  const date = new Date();
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'the-key', date })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    date: date.toISOString(),
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('can convert a single kind context', () => {
+  const evaluationContext = {
+    kind: 'organization',
+    targetingKey: 'my-org-key',
+  };
+
+  const expectedContext = {
+    kind: 'organization',
+    key: 'my-org-key',
+  };
+
+  const logger = new TestLogger();
+  expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('can convert a multi-context', () => {
+  const evaluationContext = {
+    kind: 'multi',
+    organization: {
+      targetingKey: 'my-org-key',
+      myCustomAttribute: 'myAttributeValue',
+    },
+    user: {
+      targetingKey: 'my-user-key',
+    },
+  };
+
+  const expectedContext = {
+    kind: 'multi',
+    organization: {
+      key: 'my-org-key',
+      myCustomAttribute: 'myAttributeValue',
+    },
+    user: {
+      key: 'my-user-key',
+    },
+  };
+
+  const logger = new TestLogger();
+  expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('can handle privateAttributes in a single context', () => {
+  const evaluationContext = {
+    kind: 'organization',
+    name: 'the-org-name',
+    targetingKey: 'my-org-key',
+    myCustomAttribute: 'myCustomValue',
+    privateAttributes: ['myCustomAttribute'],
+  };
+
+  const expectedContext = {
+    kind: 'organization',
+    name: 'the-org-name',
+    key: 'my-org-key',
+    myCustomAttribute: 'myCustomValue',
+    _meta: {
+      privateAttributes: ['myCustomAttribute'],
+    },
+  };
+
+  const logger = new TestLogger();
+  expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('detects a cycle and logs an error', () => {
+  const a: any = {
+    b: { c: {} },
+  };
+
+  a.b.c = a;
+  const evaluationContext = {
+    key: 'a-key',
+    kind: 'singularity',
+    a,
+  };
+
+  const expectedContext = {
+    key: 'a-key',
+    kind: 'singularity',
+    a: { b: {} },
+  };
+
+  const logger = new TestLogger();
+  expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
+  expect(logger.logs.length).toEqual(1);
+});
+
+it('allows references in different branches', () => {
+  const a = { test: 'test' };
+
+  const evaluationContext = {
+    key: 'a-key',
+    kind: 'singularity',
+    b: { a },
+    c: { a },
+  };
+
+  const expectedContext = {
+    key: 'a-key',
+    kind: 'singularity',
+    b: { a: { test: 'test' } },
+    c: { a: { test: 'test' } },
+  };
+
+  const logger = new TestLogger();
+  expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
+  expect(logger.logs.length).toEqual(0);
+});

--- a/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
@@ -216,3 +216,74 @@ it('allows references in different branches', () => {
   expect(translateContext(logger, evaluationContext)).toEqual(expectedContext);
   expect(logger.logs.length).toEqual(0);
 });
+
+it('falls back to user kind when kind is not a string and does not leak the invalid value', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, { targetingKey: 'the-key', kind: 42 as unknown as string }),
+  ).toEqual({
+    key: 'the-key',
+    kind: 'user',
+  });
+  expect(logger.logs).toEqual(["Specified 'kind' of context was not a string."]);
+});
+
+it('preserves other attributes when kind is non-string', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      targetingKey: 'the-key',
+      kind: 42 as unknown as string,
+      name: 'Sandy',
+      custom: 'value',
+    }),
+  ).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    name: 'Sandy',
+    custom: 'value',
+  });
+  expect(logger.logs).toEqual(["Specified 'kind' of context was not a string."]);
+});
+
+it('preserves null attribute values without crashing', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'the-key', myAttr: null })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    myAttr: null,
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('preserves null values inside nested structure attributes', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      targetingKey: 'the-key',
+      profile: { nickname: 'sandy', sponsor: null },
+    }),
+  ).toEqual({
+    key: 'the-key',
+    kind: 'user',
+    profile: { nickname: 'sandy', sponsor: null },
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('logs an error and skips null sub-contexts in a multi-context without crashing', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      kind: 'multi',
+      organization: { targetingKey: 'org-key' },
+      user: null as unknown as Record<string, never>,
+    }),
+  ).toEqual({
+    kind: 'multi',
+    organization: { key: 'org-key' },
+  });
+  expect(logger.logs).toEqual([
+    'Top level attributes in a multi-kind context should be Structure types.',
+  ]);
+});

--- a/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
@@ -1,0 +1,62 @@
+import { translateResult } from '../src/translateResult';
+
+it.each([true, 'potato', 42, { yes: 'no' }])('puts the value into the result.', (value) => {
+  expect(
+    translateResult<typeof value>({
+      value,
+      reason: {
+        kind: 'OFF',
+      },
+    }).value,
+  ).toEqual(value);
+});
+
+it('converts the variationIndex into a string variant', () => {
+  expect(
+    translateResult<boolean>({
+      value: true,
+      variationIndex: 9,
+      reason: {
+        kind: 'OFF',
+      },
+    }).variant,
+  ).toEqual('9');
+});
+
+it.each(['OFF', 'FALLTHROUGH', 'TARGET_MATCH', 'PREREQUISITE_FAILED', 'ERROR'])(
+  'populates the resolution reason',
+  (reason) => {
+    expect(
+      translateResult<boolean>({
+        value: true,
+        variationIndex: 9,
+        reason: {
+          kind: reason,
+        },
+      }).reason,
+    ).toEqual(reason);
+  },
+);
+
+it('does not populate the errorCode when there is not an error', () => {
+  const translated = translateResult<boolean>({
+    value: true,
+    variationIndex: 9,
+    reason: {
+      kind: 'OFF',
+    },
+  });
+  expect(translated.errorCode).toBeUndefined();
+});
+
+it('does populate the errorCode when there is an error', () => {
+  const translated = translateResult<boolean>({
+    value: true,
+    variationIndex: 9,
+    reason: {
+      kind: 'ERROR',
+      errorKind: 'BAD_APPLE',
+    },
+  });
+  expect(translated.errorCode).toEqual('GENERAL');
+});

--- a/packages/shared/openfeature-server-common/__tests__/translateTrackingEventDetails.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateTrackingEventDetails.test.ts
@@ -1,0 +1,22 @@
+import { translateTrackingEventDetails } from '../src/translateTrackingEventDetails';
+
+it('returns undefined if details are empty', () => {
+  expect(translateTrackingEventDetails({})).toBeUndefined();
+});
+
+it('returns undefined if details only contains value', () => {
+  expect(translateTrackingEventDetails({ value: 12345 })).toBeUndefined();
+});
+
+it('returns an object without the value attribute', () => {
+  expect(
+    translateTrackingEventDetails({
+      value: 12345,
+      key1: 'val1',
+      key2: 'val2',
+    }),
+  ).toEqual({
+    key1: 'val1',
+    key2: 'val2',
+  });
+});

--- a/packages/shared/openfeature-server-common/jest.config.mjs
+++ b/packages/shared/openfeature-server-common/jest.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  transform: { '^.+\\.ts?$': 'ts-jest' },
+  testMatch: ['**/__tests__/**/*test.ts?(x)'],
+  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  collectCoverageFrom: ['src/**/*.ts'],
+};

--- a/packages/shared/openfeature-server-common/package.json
+++ b/packages/shared/openfeature-server-common/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@launchdarkly/openfeature-js-server-common",
+  "version": "0.1.0",
+  "description": "LaunchDarkly OpenFeature common provider for server-side JavaScript SDKs",
+  "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/shared/openfeature-server-common",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/js-core.git"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/src/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/src/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/src/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup-node && npx tsc --emitDeclarationOnly --declaration --outDir dist",
+    "lint": "npx eslint . --ext .ts",
+    "lint:fix": "yarn run lint --fix",
+    "test": "jest",
+    "check": "yarn lint && yarn build && yarn test"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "launchdarkly",
+    "openfeature",
+    "feature-flags"
+  ],
+  "author": "LaunchDarkly",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@launchdarkly/js-sdk-common": "2.24.1"
+  },
+  "peerDependencies": {
+    "@openfeature/server-sdk": "^1.16.0"
+  },
+  "devDependencies": {
+    "@openfeature/core": "^1.10.0",
+    "@openfeature/server-sdk": "^1.16.0",
+    "@types/jest": "^29.5.3",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "eslint": "^8.45.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.6.3",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.6.1",
+    "prettier": "^3.0.0",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.5.1",
+    "typescript": "5.1.6"
+  }
+}

--- a/packages/shared/openfeature-server-common/package.json
+++ b/packages/shared/openfeature-server-common/package.json
@@ -9,22 +9,22 @@
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
       "require": {
-        "types": "./dist/src/index.d.ts",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       },
       "import": {
-        "types": "./dist/src/index.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
     }
   },
   "scripts": {
-    "build": "tsup-node && npx tsc --emitDeclarationOnly --declaration --outDir dist",
+    "build": "tsup-node",
     "lint": "npx eslint . --ext .ts",
     "lint:fix": "yarn run lint --fix",
     "test": "jest",
@@ -41,7 +41,7 @@
   "author": "LaunchDarkly",
   "license": "Apache-2.0",
   "dependencies": {
-    "@launchdarkly/js-sdk-common": "2.24.1"
+    "@launchdarkly/js-sdk-common": "2.24.3"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": "^1.16.0"

--- a/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
+++ b/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
@@ -1,0 +1,206 @@
+import type {
+  EvaluationContext,
+  Hook,
+  JsonValue,
+  Paradigm,
+  Provider,
+  ProviderMetadata,
+  ResolutionDetails,
+  TrackingEventDetails,
+} from '@openfeature/server-sdk';
+import {
+  ErrorCode,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  StandardResolutionReasons,
+} from '@openfeature/server-sdk';
+
+import type { LDLogger } from '@launchdarkly/js-sdk-common';
+
+import type { OpenFeatureLDClientContract } from './OpenFeatureLDClientContract';
+import { translateContext } from './translateContext';
+import { translateResult } from './translateResult';
+import { translateTrackingEventDetails } from './translateTrackingEventDetails';
+
+/**
+ * Create a ResolutionDetails for an evaluation that produced a type different
+ * than the expected type.
+ */
+function wrongTypeResult<T>(value: T): ResolutionDetails<T> {
+  return {
+    value,
+    reason: StandardResolutionReasons.ERROR,
+    errorCode: ErrorCode.TYPE_MISMATCH,
+  };
+}
+
+/**
+ * Configuration for constructing a {@link BaseOpenFeatureProvider}.
+ */
+export interface BaseProviderConfig {
+  /** The logger to use for diagnostics. */
+  logger: LDLogger;
+  /** The provider name reported in OpenFeature metadata. */
+  providerName: string;
+  /** The default timeout in seconds for waitForInitialization. Defaults to 10. */
+  initTimeoutSeconds?: number;
+}
+
+/**
+ * Base OpenFeature provider for LaunchDarkly server-side SDKs.
+ *
+ * Subclasses must:
+ * 1. Construct or receive an LDClient and pass it to {@link setClient} in their constructor.
+ * 2. Optionally wire SDK-specific events by calling {@link emitConfigurationChanged}.
+ */
+export abstract class BaseOpenFeatureProvider<
+  TClient extends OpenFeatureLDClientContract = OpenFeatureLDClientContract,
+> implements Provider {
+  readonly metadata: ProviderMetadata;
+
+  readonly runsOn: Paradigm = 'server';
+
+  readonly events = new OpenFeatureEventEmitter();
+
+  private _client?: TClient;
+
+  private _clientConstructionError?: unknown;
+
+  private _logger: LDLogger;
+
+  private _initTimeoutSeconds: number;
+
+  protected constructor(config: BaseProviderConfig) {
+    this.metadata = { name: config.providerName };
+    this._logger = config.logger;
+    this._initTimeoutSeconds = config.initTimeoutSeconds ?? 10;
+  }
+
+  /**
+   * Called by subclass constructors to register the LDClient instance.
+   */
+  protected setClient(client: TClient): void {
+    this._client = client;
+  }
+
+  /**
+   * Called by subclass constructors when client construction throws.
+   * The error will be re-thrown from {@link initialize}.
+   */
+  protected setClientError(error: unknown): void {
+    this._clientConstructionError = error;
+    this._logger.error(`Encountered unrecoverable initialization error, ${error}`);
+  }
+
+  /**
+   * Emit an OpenFeature ConfigurationChanged event for the given flag key.
+   * Per-SDK providers call this from their event wiring.
+   */
+  protected emitConfigurationChanged(flagKey: string): void {
+    this.events.emit(ProviderEvents.ConfigurationChanged, {
+      flagsChanged: [flagKey],
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async initialize(context?: EvaluationContext): Promise<void> {
+    if (!this._client) {
+      if (this._clientConstructionError) {
+        throw this._clientConstructionError;
+      }
+      throw new Error('Unknown problem encountered during initialization');
+    }
+    await this._client.waitForInitialization({ timeout: this._initTimeoutSeconds });
+  }
+
+  async resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<boolean>> {
+    const res = await this._client!.variationDetail(
+      flagKey,
+      translateContext(this._logger, context),
+      defaultValue,
+    );
+    if (typeof res.value === 'boolean') {
+      return translateResult(res);
+    }
+    return wrongTypeResult(defaultValue);
+  }
+
+  async resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<string>> {
+    const res = await this._client!.variationDetail(
+      flagKey,
+      translateContext(this._logger, context),
+      defaultValue,
+    );
+    if (typeof res.value === 'string') {
+      return translateResult(res);
+    }
+    return wrongTypeResult(defaultValue);
+  }
+
+  async resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<number>> {
+    const res = await this._client!.variationDetail(
+      flagKey,
+      translateContext(this._logger, context),
+      defaultValue,
+    );
+    if (typeof res.value === 'number') {
+      return translateResult(res);
+    }
+    return wrongTypeResult(defaultValue);
+  }
+
+  async resolveObjectEvaluation<U extends JsonValue>(
+    flagKey: string,
+    defaultValue: U,
+    context: EvaluationContext,
+  ): Promise<ResolutionDetails<U>> {
+    const res = await this._client!.variationDetail(
+      flagKey,
+      translateContext(this._logger, context),
+      defaultValue,
+    );
+    if (typeof res.value === 'object') {
+      return translateResult(res);
+    }
+    return wrongTypeResult<U>(defaultValue);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get hooks(): Hook[] {
+    return [];
+  }
+
+  getClient(): TClient {
+    return this._client!;
+  }
+
+  async onClose(): Promise<void> {
+    await this._client?.flush();
+    this._client?.close();
+  }
+
+  track(
+    trackingEventName: string,
+    context: EvaluationContext,
+    trackingEventDetails: TrackingEventDetails,
+  ): void {
+    this._client?.track(
+      trackingEventName,
+      translateContext(this._logger, context),
+      translateTrackingEventDetails(trackingEventDetails),
+      trackingEventDetails?.value,
+    );
+  }
+}

--- a/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
+++ b/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
@@ -171,7 +171,7 @@ export abstract class BaseOpenFeatureProvider<
       translateContext(this._logger, context),
       defaultValue,
     );
-    if (typeof res.value === 'object') {
+   if (res.value !== null && typeof res.value === 'object') {
       return translateResult(res);
     }
     return wrongTypeResult<U>(defaultValue);

--- a/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
+++ b/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
@@ -187,8 +187,11 @@ export abstract class BaseOpenFeatureProvider<
   }
 
   async onClose(): Promise<void> {
-    await this._client?.flush();
-    this._client?.close();
+    try {
+      await this._client?.flush();
+    } finally {
+      this._client?.close();
+    }
   }
 
   track(

--- a/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
+++ b/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
@@ -15,7 +15,7 @@ import {
   StandardResolutionReasons,
 } from '@openfeature/server-sdk';
 
-import type { LDLogger } from '@launchdarkly/js-sdk-common';
+import { createSafeLogger, type LDLogger } from '@launchdarkly/js-sdk-common';
 
 import type { OpenFeatureLDClientContract } from './OpenFeatureLDClientContract';
 import { translateContext } from './translateContext';
@@ -72,7 +72,7 @@ export abstract class BaseOpenFeatureProvider<
 
   protected constructor(config: BaseProviderConfig) {
     this.metadata = { name: config.providerName };
-    this._logger = config.logger;
+    this._logger = createSafeLogger(config.logger);
     this._initTimeoutSeconds = config.initTimeoutSeconds ?? 10;
   }
 

--- a/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
+++ b/packages/shared/openfeature-server-common/src/BaseOpenFeatureProvider.ts
@@ -194,13 +194,14 @@ export abstract class BaseOpenFeatureProvider<
   track(
     trackingEventName: string,
     context: EvaluationContext,
-    trackingEventDetails: TrackingEventDetails,
+    trackingEventDetails?: TrackingEventDetails,
   ): void {
     this._client?.track(
       trackingEventName,
       translateContext(this._logger, context),
-      translateTrackingEventDetails(trackingEventDetails),
+      trackingEventDetails ? translateTrackingEventDetails(trackingEventDetails) : undefined,
       trackingEventDetails?.value,
     );
   }
 }
+

--- a/packages/shared/openfeature-server-common/src/OpenFeatureLDClientContract.ts
+++ b/packages/shared/openfeature-server-common/src/OpenFeatureLDClientContract.ts
@@ -1,0 +1,21 @@
+import type { LDContext, LDEvaluationDetail, LDFlagValue } from '@launchdarkly/js-sdk-common';
+
+/**
+ * The minimal LDClient contract required by the OpenFeature provider.
+ * Any LaunchDarkly server-side LDClient should satisfy this interface.
+ */
+export interface OpenFeatureLDClientContract {
+  variationDetail(
+    key: string,
+    context: LDContext,
+    defaultValue: LDFlagValue,
+  ): Promise<LDEvaluationDetail>;
+
+  waitForInitialization(options?: { timeout: number }): Promise<unknown>;
+
+  flush(): Promise<void>;
+
+  close(): void;
+
+  track(key: string, context: LDContext, data?: any, metricValue?: number): void;
+}

--- a/packages/shared/openfeature-server-common/src/index.ts
+++ b/packages/shared/openfeature-server-common/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * This is the API reference for the LaunchDarkly OpenFeature common provider for
+ * server-side JavaScript SDKs.
+ *
+ * @module @launchdarkly/openfeature-js-server-common
+ */
+
+export { BaseOpenFeatureProvider } from './BaseOpenFeatureProvider';
+export type { BaseProviderConfig } from './BaseOpenFeatureProvider';
+export type { OpenFeatureLDClientContract } from './OpenFeatureLDClientContract';
+export { translateContext } from './translateContext';
+export { translateResult } from './translateResult';
+export { translateTrackingEventDetails } from './translateTrackingEventDetails';

--- a/packages/shared/openfeature-server-common/src/index.ts
+++ b/packages/shared/openfeature-server-common/src/index.ts
@@ -8,6 +8,3 @@
 export { BaseOpenFeatureProvider } from './BaseOpenFeatureProvider';
 export type { BaseProviderConfig } from './BaseOpenFeatureProvider';
 export type { OpenFeatureLDClientContract } from './OpenFeatureLDClientContract';
-export { translateContext } from './translateContext';
-export { translateResult } from './translateResult';
-export { translateTrackingEventDetails } from './translateTrackingEventDetails';

--- a/packages/shared/openfeature-server-common/src/translateContext.ts
+++ b/packages/shared/openfeature-server-common/src/translateContext.ts
@@ -1,0 +1,149 @@
+import type { EvaluationContext, EvaluationContextValue } from '@openfeature/server-sdk';
+
+import type {
+  LDContext,
+  LDContextCommon,
+  LDLogger,
+  LDSingleKindContext,
+} from '@launchdarkly/js-sdk-common';
+
+const LDContextBuiltIns: Record<string, string> = {
+  name: 'string',
+  anonymous: 'boolean',
+};
+
+/**
+ * Convert attributes, potentially recursively, into appropriate types.
+ * @param logger Logger to use if issues are encountered.
+ * @param key The key for the attribute.
+ * @param value The value of the attribute.
+ * @param object Object to place the value in.
+ * @param visited Array of objects that have already been visited to detect cycles.
+ */
+function convertAttributes(
+  logger: LDLogger,
+  key: string,
+  value: any,
+  object: any,
+  visited: any[],
+): void {
+  if (visited.includes(value)) {
+    logger.error(
+      'Detected a cycle within the evaluation context. The ' +
+        'affected part of the context will not be included in evaluation.',
+    );
+    return;
+  }
+  if (value instanceof Date) {
+    // eslint-disable-next-line no-param-reassign
+    object[key] = value.toISOString();
+  } else if (typeof value === 'object' && !Array.isArray(value)) {
+    // eslint-disable-next-line no-param-reassign
+    object[key] = {};
+    Object.entries(value).forEach(([objectKey, objectValue]) => {
+      convertAttributes(logger, objectKey, objectValue, object[key], [...visited, value]);
+    });
+  } else {
+    // eslint-disable-next-line no-param-reassign
+    object[key] = value;
+  }
+}
+
+/**
+ * Translate the common part of a context. This could either be the attributes
+ * of a single context, or it could be the attributes of a nested context
+ * in a multi-context.
+ * @param logger Logger to use if issues are encountered.
+ * @param inCommon The source context information. Could be an EvaluationContext, or a value
+ * within an Evaluation context.
+ * @param inTargetingKey The targetingKey, either it or the key may be used.
+ * @returns A populated common context.
+ */
+function translateContextCommon(
+  logger: LDLogger,
+  inCommon: Record<string, EvaluationContextValue>,
+  inTargetingKey: string | undefined,
+): LDContextCommon {
+  const keyAttr = inCommon.key as string;
+  const finalKey = inTargetingKey ?? keyAttr;
+
+  if (keyAttr != null && inTargetingKey != null) {
+    logger.warn(
+      "The EvaluationContext contained both a 'targetingKey' and a 'key' attribute. The" +
+        " 'key' attribute will be discarded.",
+    );
+  }
+
+  if (finalKey == null) {
+    logger.error(
+      "The EvaluationContext must contain either a 'targetingKey' or a 'key' and the " +
+        'type must be a string.',
+    );
+  }
+
+  const convertedContext: LDContextCommon = { key: finalKey };
+  Object.entries(inCommon).forEach(([key, value]) => {
+    if (key === 'targetingKey' || key === 'key') {
+      return;
+    }
+    if (key === 'privateAttributes') {
+      // eslint-disable-next-line no-underscore-dangle
+      convertedContext._meta = {
+        privateAttributes: value as string[],
+      };
+    } else if (key in LDContextBuiltIns) {
+      if (typeof value === LDContextBuiltIns[key]) {
+        (convertedContext as any)[key] = value;
+      } else {
+        logger.error(`The attribute '${key}' must be of type ${LDContextBuiltIns[key]}`);
+      }
+    } else {
+      convertAttributes(logger, key, value, convertedContext, [inCommon]);
+    }
+  });
+
+  return convertedContext;
+}
+
+/**
+ * Convert an OpenFeature evaluation context into an LDContext.
+ * @param evalContext The OpenFeature evaluation context to translate.
+ * @returns An LDContext based on the evaluation context.
+ */
+export function translateContext(logger: LDLogger, evalContext: EvaluationContext): LDContext {
+  let finalKind = 'user';
+
+  // A multi-context.
+  if (evalContext.kind === 'multi') {
+    return Object.entries(evalContext).reduce(
+      (acc: any, [key, value]: [string, EvaluationContextValue]) => {
+        if (key === 'kind') {
+          acc.kind = value;
+        } else if (typeof value === 'object' && !Array.isArray(value)) {
+          const valueRecord = value as Record<string, EvaluationContextValue>;
+          acc[key] = translateContextCommon(
+            logger,
+            valueRecord,
+            valueRecord.targetingKey as string,
+          );
+        } else {
+          logger.error('Top level attributes in a multi-kind context should be Structure types.');
+        }
+        return acc;
+      },
+      {},
+    );
+  }
+  if (evalContext.kind !== undefined && typeof evalContext.kind === 'string') {
+    finalKind = evalContext.kind;
+  } else if (evalContext.kind !== undefined && typeof evalContext.kind !== 'string') {
+    logger.warn("Specified 'kind' of context was not a string.");
+  }
+
+  const convertedContext: LDContext = {
+    kind: finalKind,
+    ...translateContextCommon(logger, evalContext, evalContext.targetingKey),
+  } as LDSingleKindContext;
+
+  return convertedContext;
+}

--- a/packages/shared/openfeature-server-common/src/translateContext.ts
+++ b/packages/shared/openfeature-server-common/src/translateContext.ts
@@ -37,7 +37,7 @@ function convertAttributes(
   if (value instanceof Date) {
     // eslint-disable-next-line no-param-reassign
     object[key] = value.toISOString();
-  } else if (typeof value === 'object' && !Array.isArray(value)) {
+  } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     // eslint-disable-next-line no-param-reassign
     object[key] = {};
     Object.entries(value).forEach(([objectKey, objectValue]) => {
@@ -83,7 +83,7 @@ function translateContextCommon(
 
   const convertedContext: LDContextCommon = { key: finalKey };
   Object.entries(inCommon).forEach(([key, value]) => {
-    if (key === 'targetingKey' || key === 'key') {
+    if (key === 'targetingKey' || key === 'key' || key === 'kind') {
       return;
     }
     if (key === 'privateAttributes') {
@@ -119,7 +119,7 @@ export function translateContext(logger: LDLogger, evalContext: EvaluationContex
       (acc: any, [key, value]: [string, EvaluationContextValue]) => {
         if (key === 'kind') {
           acc.kind = value;
-        } else if (typeof value === 'object' && !Array.isArray(value)) {
+        } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
           const valueRecord = value as Record<string, EvaluationContextValue>;
           acc[key] = translateContextCommon(
             logger,

--- a/packages/shared/openfeature-server-common/src/translateResult.ts
+++ b/packages/shared/openfeature-server-common/src/translateResult.ts
@@ -1,0 +1,39 @@
+import { ErrorCode } from '@openfeature/server-sdk';
+import type { ResolutionDetails } from '@openfeature/server-sdk';
+
+import type { LDEvaluationDetail } from '@launchdarkly/js-sdk-common';
+
+/**
+ * Convert an `errorKind` into an OpenFeature `errorCode`.
+ */
+function translateErrorKind(errorKind: string | undefined): ErrorCode {
+  switch (errorKind) {
+    case 'CLIENT_NOT_READY':
+      return ErrorCode.PROVIDER_NOT_READY;
+    case 'MALFORMED_FLAG':
+      return ErrorCode.PARSE_ERROR;
+    case 'FLAG_NOT_FOUND':
+      return ErrorCode.FLAG_NOT_FOUND;
+    case 'USER_NOT_SPECIFIED':
+      return ErrorCode.TARGETING_KEY_MISSING;
+    default:
+      return ErrorCode.GENERAL;
+  }
+}
+
+/**
+ * Translate an {@link LDEvaluationDetail} to a {@link ResolutionDetails}.
+ *
+ */
+export function translateResult<T>(result: LDEvaluationDetail): ResolutionDetails<T> {
+  const resolution: ResolutionDetails<T> = {
+    value: result.value,
+    variant: result.variationIndex?.toString(),
+    reason: result.reason.kind,
+  };
+
+  if (result.reason.kind === 'ERROR') {
+    resolution.errorCode = translateErrorKind(result.reason.errorKind);
+  }
+  return resolution;
+}

--- a/packages/shared/openfeature-server-common/src/translateTrackingEventDetails.ts
+++ b/packages/shared/openfeature-server-common/src/translateTrackingEventDetails.ts
@@ -1,0 +1,16 @@
+import type { TrackingEventDetails } from '@openfeature/server-sdk';
+
+/**
+ * Translate {@link TrackingEventDetails} to an object suitable for use as the data
+ * parameter in LDClient.track().
+ *
+ * The value attribute will be removed and if the resulting object is empty,
+ * returns undefined.
+ *
+ */
+export function translateTrackingEventDetails(
+  details: TrackingEventDetails,
+): Record<string, unknown> | undefined {
+  const { value, ...data } = details;
+  return Object.keys(data).length ? data : undefined;
+}

--- a/packages/shared/openfeature-server-common/tsconfig.json
+++ b/packages/shared/openfeature-server-common/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "module": "ESNext",
+    "strict": true,
+    "noImplicitOverride": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "stripInternal": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "dist", "node_modules", "__tests__"]
+}

--- a/packages/shared/openfeature-server-common/tsconfig.ref.json
+++ b/packages/shared/openfeature-server-common/tsconfig.ref.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "package.json"],
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/shared/openfeature-server-common/tsup.config.ts
+++ b/packages/shared/openfeature-server-common/tsup.config.ts
@@ -1,0 +1,16 @@
+// It is a dev dependency and the linter doesn't understand.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  // DTS is generated via tsc instead of rollup-dts because @openfeature/server-sdk
+  // re-exports from @openfeature/core as a peer dependency which confuses the DTS rollup.
+  dts: false,
+});

--- a/packages/shared/openfeature-server-common/tsup.config.ts
+++ b/packages/shared/openfeature-server-common/tsup.config.ts
@@ -10,7 +10,5 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
-  // DTS is generated via tsc instead of rollup-dts because @openfeature/server-sdk
-  // re-exports from @openfeature/core as a peer dependency which confuses the DTS rollup.
-  dts: false,
+  dts: true,
 });

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -301,7 +301,8 @@
       ]
     },
     "packages/shared/openfeature-server-common": {
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "prerelease": true
     }
   },
   "plugins": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -299,6 +299,9 @@
           "jsonpath": "$.dependencies['@launchdarkly/react-sdk']"
         }
       ]
+    },
+    "packages/shared/openfeature-server-common": {
+      "bump-minor-pre-major": true
     }
   },
   "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "./packages/shared/akamai-edgeworker-sdk/tsconfig.ref.json"
     },
     {
+      "path": "./packages/shared/openfeature-server-common/tsconfig.ref.json"
+    },
+    {
       "path": "./packages/sdk/server-node/tsconfig.ref.json"
     },
     {


### PR DESCRIPTION
This PR will initialize the migration of openfeature node server provider to js-core. Specifically, this PR will create a shared openfeature server provider base class.

REVIEWER: The logic in this should be a more generalized version of https://github.com/launchdarkly/openfeature-node-server/tree/main.

Theoretically, this would allow us to implement openfeature providers pretty easily (eg https://github.com/launchdarkly/js-core/blob/skz/sdk-2213/openfeature-migration/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts)

> NOTE: at the moment this code won't do anything until we implement the implementing provider in the next PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds a new, pre-release shared package and wiring (workspace/tsc/release-please) without changing behavior of existing SDKs. Main risk is limited to build/release configuration and the correctness of the new translation/provider utilities for future adopters.
> 
> **Overview**
> Introduces a new pre-release workspace package, `@launchdarkly/openfeature-js-server-common`, exporting `BaseOpenFeatureProvider` plus utilities to translate OpenFeature evaluation contexts/results and tracking event details to LaunchDarkly equivalents.
> 
> Adds full package scaffolding (tsup/tsconfig/jest config, README/LICENSE, and unit tests) and wires it into the monorepo via `package.json` workspaces, root `tsconfig` references, and `release-please` manifest/config so it can be versioned and built independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf81b26b2edbf98760f34ead6847868373766a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->