### PR TITLE
chore: add Runner and AgentGraphRunner protocol tests

### DIFF
--- a/packages/sdk/server-ai/__tests__/RunnerProtocol.test.ts
+++ b/packages/sdk/server-ai/__tests__/RunnerProtocol.test.ts
@@ -1,0 +1,72 @@
+import type { AgentGraphRunnerResult } from '../src/api/graph/types';
+import type { RunnerResult } from '../src/api/model/types';
+import type { AgentGraphRunner, Runner } from '../src/api/providers/Runner';
+
+/**
+ * Verify that the Runner and AgentGraphRunner protocols can be implemented
+ * by a plain object (no abstract class required).
+ */
+describe('Runner protocol', () => {
+  it('can be implemented as a plain object (no class extension required)', async () => {
+    const runnerResult: RunnerResult = {
+      content: 'Hello from runner',
+      metrics: { success: true },
+    };
+
+    const myRunner: Runner = {
+      run: jest.fn().mockResolvedValue(runnerResult),
+    };
+
+    const result = await myRunner.run('Hello');
+
+    expect(result.content).toBe('Hello from runner');
+    expect(result.metrics.success).toBe(true);
+  });
+
+  it('Runner.run() accepts optional outputType for structured output', async () => {
+    const runnerResult: RunnerResult = {
+      content: '',
+      metrics: { success: true },
+      parsed: { score: 0.9, reasoning: 'good' },
+    };
+
+    const myRunner: Runner = {
+      run: jest.fn().mockResolvedValue(runnerResult),
+    };
+
+    const schema = { type: 'object', properties: { score: { type: 'number' } } };
+    const result = await myRunner.run('Evaluate', schema);
+
+    expect(result.parsed).toEqual({ score: 0.9, reasoning: 'good' });
+    expect(myRunner.run).toHaveBeenCalledWith('Evaluate', schema);
+  });
+
+  it('AgentGraphRunner can be implemented as a plain object', async () => {
+    const graphResult: AgentGraphRunnerResult = {
+      content: 'Graph output',
+      metrics: {
+        success: true,
+        path: ['node-a'],
+        nodeMetrics: { 'node-a': { success: true } },
+      },
+    };
+
+    const myGraphRunner: AgentGraphRunner = {
+      run: jest.fn().mockResolvedValue(graphResult),
+    };
+
+    const result = await myGraphRunner.run('user input');
+
+    expect(result.content).toBe('Graph output');
+    expect(result.metrics.path).toEqual(['node-a']);
+  });
+
+  it('RunnerResult does not include evaluations field', () => {
+    const result: RunnerResult = {
+      content: 'test',
+      metrics: { success: true },
+    };
+
+    expect('evaluations' in result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Test plan
- [ ] 210 tests pass
- [ ] `RunnerProtocol.test.ts` verifies Runner and AgentGraphRunner can be implemented as plain objects (no class extension required)
- [ ] RunnerResult does not include evaluations field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Jest test file validating `Runner`/`AgentGraphRunner` can be implemented as plain objects and that `Runner.run` supports an optional `outputType`; no runtime code changes.
> 
> **Overview**
> Adds `RunnerProtocol.test.ts` to assert the `Runner` and `AgentGraphRunner` interfaces are usable as plain-object implementations, including coverage for the optional `outputType` parameter and `parsed` structured output.
> 
> Also locks in the `RunnerResult` contract by verifying it does **not** expose an `evaluations` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889986080ee440549eebb6a2b1d9422e4833f572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->