### PR TITLE
fix(common): remove non-spec fields from FDv2 GoodbyeObject

### DIFF
--- a/packages/shared/common/src/internal/fdv2/proto.ts
+++ b/packages/shared/common/src/internal/fdv2/proto.ts
@@ -66,8 +66,6 @@ export interface DeleteObject {
 
 export interface GoodbyeObject {
   reason: string;
-  silent: boolean;
-  catastrophe: boolean;
 }
 
 export interface ErrorObject {

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/PollingBase.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/PollingBase.test.ts
@@ -286,7 +286,7 @@ describe('given a goodbye event in the response', () => {
       },
       {
         event: 'goodbye',
-        data: { reason: 'server-shutdown', silent: false, catastrophe: false },
+        data: { reason: 'server-shutdown' },
       },
     ]);
     const requestor = makeRequestor({

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/PollingInitializer.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/PollingInitializer.test.ts
@@ -174,7 +174,7 @@ it('does not retry on goodbye result', async () => {
     },
     {
       event: 'goodbye',
-      data: { reason: 'server-shutdown', silent: false, catastrophe: false },
+      data: { reason: 'server-shutdown' },
     },
   ]);
   const requestor: FDv2Requestor = {

--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/StreamingFDv2Base.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/StreamingFDv2Base.test.ts
@@ -125,8 +125,6 @@ it('produces a goodbye status result', async () => {
 
   simulateEvent(mockEventSource, 'goodbye', {
     reason: 'server restarting',
-    silent: false,
-    catastrophe: false,
   });
 
   const result = await base.takeResult();
@@ -416,8 +414,6 @@ it('produces results in order', async () => {
 
   simulateEvent(mockEventSource, 'goodbye', {
     reason: 'bye',
-    silent: false,
-    catastrophe: false,
   });
 
   const r1 = await base.takeResult();


### PR DESCRIPTION
## Summary
- The FDv2 `goodbye` event is specified to carry only a `reason` field. The `GoodbyeObject` interface in `packages/shared/common/src/internal/fdv2/proto.ts` incorrectly declared `silent: boolean` and `catastrophe: boolean`. This PR removes them.
- The runtime protocol handler in `protocolHandler.ts` already only read `data.reason`, so this is purely a type-shape correction plus a few test fixture updates.

## Test plan
- [x] Grep across the monorepo confirms no consumers reference `goodbye.silent` or `goodbye.catastrophe`.
- [x] `tsc --noEmit` passes for `@launchdarkly/js-sdk-common` and `@launchdarkly/js-client-sdk-common`.
- [x] Tests pass: `js-sdk-common` (28 suites / 464 tests), `js-client-sdk-common` (54 suites / 786 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-shape correction: it narrows the `goodbye` event payload to match the spec and only requires updating test fixtures; no runtime behavior changes are implied.
> 
> **Overview**
> Aligns the FDv2 protocol typings with the spec by trimming `GoodbyeObject` to only include `reason` (removing the previously-declared `silent` and `catastrophe` fields).
> 
> Updates FDv2 polling/streaming test fixtures to emit `goodbye` events with just `{ reason }`, ensuring tests reflect the corrected payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1afdd0e20ef14f437993fd4564122e209317a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->