### PR TITLE
fix(server-node): honor x-ld-fd-fallback directive in FDv2 initializer phase

### DIFF
--- a/packages/sdk/server-node/contract-tests/src/index.ts
+++ b/packages/sdk/server-node/contract-tests/src/index.ts
@@ -44,6 +44,7 @@ app.get('/', (req: Request, res: Response) => {
       'event-gzip',
       'optional-event-gzip',
       'flag-change-listeners',
+      'fdv1-fallback',
     ],
   });
 });

--- a/packages/sdk/server-node/contract-tests/src/sdkClientEntity.ts
+++ b/packages/sdk/server-node/contract-tests/src/sdkClientEntity.ts
@@ -160,6 +160,16 @@ export function makeSdkConfig(options: ServerSDKConfigParams, tag: string): LDOp
     cf.dataSystem = {
       dataSource: dataSourceOptions,
     };
+
+    // FDv1Fallback configures the SDK's FDv1 Fallback Synchronizer -- engaged only in
+    // response to a server-directed FDv1 Fallback Directive, separate from the FDv2
+    // Primary/Fallback synchronizer chain configured above.
+    if (options.dataSystem.fdv1Fallback) {
+      cf.dataSystem.fdv1Fallback = {
+        baseUri: options.dataSystem.fdv1Fallback.baseUri,
+        pollInterval: maybeTime(options.dataSystem.fdv1Fallback.pollIntervalMs),
+      };
+    }
   }
 
   return cf;

--- a/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
+++ b/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
@@ -650,6 +650,238 @@ it('terminates when FDv1 fallback is requested but no FDv1 fallback synchronizer
   expect(lastCall[0]).toBe(DataSourceState.Closed);
 });
 
+// Regression for the bug where a data source delivered basis-during-init AND THEN emitted
+// LDFlagDeliveryFallbackError as a status callback: the auto-transition on basis would
+// disable the callback handler before the fallback signal was processed, leaving
+// `_syncFactories` pointing at the FDv2 list. The fix is to ride the directive on the data
+// callback itself (via `data.fallbackToFDv1`), so the swap to FDv1 is atomic with the
+// payload application.
+it('switches to FDv1 when an initializer delivers basis with fallbackToFDv1 marker', async () => {
+  const mockInitData = { fallbackToFDv1: true, payload: { key: 'init-payload' } };
+  const mockInitializer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid);
+          // Basis arrives with the directive attached. The composite must apply the payload
+          // (via dataCallback) AND swap synchronizer factories to FDv1 atomically; the
+          // FDv2 synchronizer below must NOT be started.
+          _dataCallback(true, mockInitData);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const mockFDv2Synchronizer = {
+    start: jest.fn().mockImplementation(() => {
+      throw new Error('FDv2 synchronizer should not be started after FDv1 fallback');
+    }),
+    stop: jest.fn(),
+  };
+
+  const mockFDv1Data = { key: 'FDv1Data' };
+  const mockFDv1Synchronizer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid, null);
+          _dataCallback(true, mockFDv1Data);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const underTest = new CompositeDataSource(
+    [makeDataSourceFactory(mockInitializer)],
+    [makeDataSourceFactory(mockFDv2Synchronizer)],
+    [makeDataSourceFactory(mockFDv1Synchronizer)],
+    undefined,
+    makeTestTransitionConditions(),
+    makeZeroBackoff(),
+  );
+
+  const dataReceived: any[] = [];
+  const statusCallback = jest.fn();
+  await new Promise<void>((resolve) => {
+    const dataCallback = jest.fn((_: boolean, data: any) => {
+      dataReceived.push(data);
+      if (data === mockFDv1Data) {
+        resolve();
+      }
+    });
+    underTest.start(dataCallback, statusCallback);
+  });
+
+  // The composite forwarded the initializer's payload AND then ran the FDv1 synchronizer.
+  // FDv2 synchronizers must not have been started.
+  expect(mockInitializer.start).toHaveBeenCalledTimes(1);
+  expect(mockFDv2Synchronizer.start).not.toHaveBeenCalled();
+  expect(mockFDv1Synchronizer.start).toHaveBeenCalledTimes(1);
+
+  // The init payload was forwarded to the outer dataCallback before FDv1 took over.
+  expect(dataReceived[0]).toBe(mockInitData);
+  expect(dataReceived[1]).toBe(mockFDv1Data);
+});
+
+// Regression for the bug where a synchronizer delivered a payload with fallbackToFDv1 AND
+// THEN emitted an error: the basis-during-init auto-transition (or the error status path)
+// would disable the callback handler before the fallback signal was processed.
+it('switches to FDv1 when a synchronizer delivers a payload with fallbackToFDv1 marker', async () => {
+  const mockSynchronizerData = { fallbackToFDv1: true, payload: { key: 'sync-payload' } };
+  const mockSynchronizer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid);
+          // Payload + directive on a single dataCallback invocation. There are no
+          // initializers configured here so this exercises the synchronizer-phase path.
+          _dataCallback(true, mockSynchronizerData);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const mockFDv1Data = { key: 'FDv1Data' };
+  const mockFDv1Synchronizer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid, null);
+          _dataCallback(true, mockFDv1Data);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const underTest = new CompositeDataSource(
+    [],
+    [makeDataSourceFactory(mockSynchronizer)],
+    [makeDataSourceFactory(mockFDv1Synchronizer)],
+    undefined,
+    makeTestTransitionConditions(),
+    makeZeroBackoff(),
+  );
+
+  const dataReceived: any[] = [];
+  await new Promise<void>((resolve) => {
+    const dataCallback = jest.fn((_: boolean, data: any) => {
+      dataReceived.push(data);
+      if (data === mockFDv1Data) {
+        resolve();
+      }
+    });
+    underTest.start(dataCallback, jest.fn());
+  });
+
+  expect(mockSynchronizer.start).toHaveBeenCalledTimes(1);
+  expect(mockFDv1Synchronizer.start).toHaveBeenCalledTimes(1);
+  expect(dataReceived[0]).toBe(mockSynchronizerData);
+  expect(dataReceived[1]).toBe(mockFDv1Data);
+});
+
+// Regression: subsequent fallback signals after the FDv1 synchronizer is engaged must be
+// ignored so the composite does not loop replacing its synchronizer list with itself.
+// This guards against an FDv1 endpoint that erroneously echoes `x-ld-fd-fallback` -- the
+// circular DataSourceList for `_fdv1Synchronizers` would otherwise restart the same
+// FDv1 synchronizer indefinitely after each repeated directive.
+it('ignores subsequent FDv1 fallback signals once FDv1 fallback is engaged', async () => {
+  const mockFDv2Sync = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(
+            DataSourceState.Closed,
+            new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              'fallback from FDv2',
+              500,
+            ),
+          );
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  // The FDv1 fallback synchronizer continually delivers a basis with a fallback marker --
+  // this would loop indefinitely without the engagement guard, since `_fdv1Synchronizers`
+  // is a circular list and `switchToSync` restarts from its head.
+  const fdv1Data = { fallbackToFDv1: true, payload: { key: 'fdv1-data' } };
+  let fdv1StartCount = 0;
+  const mockFDv1Synchronizer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          fdv1StartCount += 1;
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid, null);
+          _dataCallback(true, fdv1Data);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const underTest = new CompositeDataSource(
+    [],
+    [makeDataSourceFactory(mockFDv2Sync)],
+    [makeDataSourceFactory(mockFDv1Synchronizer)],
+    undefined,
+    makeTestTransitionConditions(),
+    makeZeroBackoff(),
+  );
+
+  const dataReceived: any[] = [];
+  const statusCallback = jest.fn();
+  // Wait for the FDv1 data callback so we know the FDv1 synchronizer ran. After that, we
+  // give the event loop a tick to confirm the FDv1 synchronizer is not restarted.
+  await new Promise<void>((resolve) => {
+    const dataCallback = jest.fn((_: boolean, data: any) => {
+      dataReceived.push(data);
+      if (data === fdv1Data) {
+        resolve();
+      }
+    });
+    underTest.start(dataCallback, statusCallback);
+  });
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+  // FDv1 was started exactly once -- the engagement guard prevented re-engagement when
+  // FDv1 itself echoed the directive.
+  expect(fdv1StartCount).toBe(1);
+  // The FDv1 payload was applied even though we ignored the (redundant) directive.
+  expect(dataReceived).toContain(fdv1Data);
+});
+
 it('reports error when all initializers fail', async () => {
   const mockInitializer1Error = {
     name: 'Error',

--- a/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
+++ b/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
@@ -650,12 +650,9 @@ it('terminates when FDv1 fallback is requested but no FDv1 fallback synchronizer
   expect(lastCall[0]).toBe(DataSourceState.Closed);
 });
 
-// Regression for the bug where a data source delivered basis-during-init AND THEN emitted
-// LDFlagDeliveryFallbackError as a status callback: the auto-transition on basis would
-// disable the callback handler before the fallback signal was processed, leaving
-// `_syncFactories` pointing at the FDv2 list. The fix is to ride the directive on the data
-// callback itself (via `data.fallbackToFDv1`), so the swap to FDv1 is atomic with the
-// payload application.
+// When an initializer delivers basis with `data.fallbackToFDv1`, the composite must apply
+// the payload AND swap to the FDv1 synchronizer atomically -- without starting any FDv2
+// synchronizer.
 it('switches to FDv1 when an initializer delivers basis with fallbackToFDv1 marker', async () => {
   const mockInitData = { fallbackToFDv1: true, payload: { key: 'init-payload' } };
   const mockInitializer = {
@@ -733,9 +730,8 @@ it('switches to FDv1 when an initializer delivers basis with fallbackToFDv1 mark
   expect(dataReceived[1]).toBe(mockFDv1Data);
 });
 
-// Regression for the bug where a synchronizer delivered a payload with fallbackToFDv1 AND
-// THEN emitted an error: the basis-during-init auto-transition (or the error status path)
-// would disable the callback handler before the fallback signal was processed.
+// Same atomic swap during synchronizer phase: a payload + directive on one dataCallback
+// must hand off to FDv1 instead of staying on the FDv2 synchronizer.
 it('switches to FDv1 when a synchronizer delivers a payload with fallbackToFDv1 marker', async () => {
   const mockSynchronizerData = { fallbackToFDv1: true, payload: { key: 'sync-payload' } };
   const mockSynchronizer = {
@@ -799,11 +795,8 @@ it('switches to FDv1 when a synchronizer delivers a payload with fallbackToFDv1 
   expect(dataReceived[1]).toBe(mockFDv1Data);
 });
 
-// Regression: subsequent fallback signals after the FDv1 synchronizer is engaged must be
-// ignored so the composite does not loop replacing its synchronizer list with itself.
-// This guards against an FDv1 endpoint that erroneously echoes `x-ld-fd-fallback` -- the
-// circular DataSourceList for `_fdv1Synchronizers` would otherwise restart the same
-// FDv1 synchronizer indefinitely after each repeated directive.
+// The FDv1 fallback list is circular, so re-engaging on a repeated directive would loop
+// restarting the same synchronizer. Once engaged, subsequent signals must be ignored.
 it('ignores subsequent FDv1 fallback signals once FDv1 fallback is engaged', async () => {
   const mockFDv2Sync = {
     start: jest

--- a/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
+++ b/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
@@ -875,6 +875,98 @@ it('ignores subsequent FDv1 fallback signals once FDv1 fallback is engaged', asy
   expect(dataReceived).toContain(fdv1Data);
 });
 
+// The backoff bypass applies only to the initial engagement; subsequent
+// LDFlagDeliveryFallbackErrors from the FDv1 synchronizer must be throttled.
+it('throttles FDv1 retries with backoff after the initial engagement', async () => {
+  const mockFDv2Sync = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(
+            DataSourceState.Closed,
+            new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              'fallback from FDv2',
+              500,
+            ),
+          );
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  // Two FDv1 factories so the composite cycles through 'fallback' transitions instead
+  // of stopping after the first cull -- each cycle is a chance to (incorrectly) skip
+  // backoff. The tracking Backoff below counts fail() calls as the observable proxy.
+  const makeFDv1Sync = () => ({
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(
+            DataSourceState.Closed,
+            new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              'fallback from FDv1',
+              500,
+            ),
+          );
+        },
+      ),
+    stop: jest.fn(),
+  });
+  const mockFDv1Sync1 = makeFDv1Sync();
+  const mockFDv1Sync2 = makeFDv1Sync();
+
+  let failCalls = 0;
+  let successCalls = 0;
+  const trackingBackoff: Backoff = {
+    success() {
+      successCalls += 1;
+      return 0;
+    },
+    fail() {
+      failCalls += 1;
+      return 0;
+    },
+  };
+
+  const underTest = new CompositeDataSource(
+    [],
+    [makeDataSourceFactory(mockFDv2Sync)],
+    [makeDataSourceFactory(mockFDv1Sync1), makeDataSourceFactory(mockFDv1Sync2)],
+    undefined,
+    makeTestTransitionConditions(),
+    trackingBackoff,
+  );
+
+  const statusCallback = jest.fn();
+  await new Promise<void>((resolve) => {
+    statusCallback.mockImplementation((state: DataSourceState) => {
+      if (state === DataSourceState.Closed) {
+        resolve();
+      }
+    });
+    underTest.start(jest.fn(), statusCallback);
+  });
+
+  expect(mockFDv2Sync.start).toHaveBeenCalledTimes(1);
+  expect(mockFDv1Sync1.start).toHaveBeenCalledTimes(1);
+  expect(mockFDv1Sync2.start).toHaveBeenCalledTimes(1);
+  // One fail() per post-engagement retry; the initial engagement is not counted.
+  expect(failCalls).toBe(2);
+  expect(successCalls).toBe(0);
+});
+
 it('reports error when all initializers fail', async () => {
   const mockInitializer1Error = {
     name: 'Error',

--- a/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
+++ b/packages/shared/common/__tests__/subsystem/DataSystem/CompositeDataSource.test.ts
@@ -489,6 +489,167 @@ it('falls back to FDv1 synchronizers when FDv1 fallback error is reported', asyn
   expect(statusCallback).toHaveBeenNthCalledWith(5, DataSourceState.Valid, undefined); // sync1 valid
 });
 
+// Per the FDv2 spec, the FDv1 Fallback Directive can arrive during the initializer phase.
+// When that happens the SDK must switch immediately to the FDv1 Fallback Synchronizer --
+// without trying remaining initializers or any FDv2 synchronizers.
+it('falls back to FDv1 from initializer phase, skipping remaining initializers and FDv2 syncs', async () => {
+  const mockInitializer1 = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(
+            DataSourceState.Closed,
+            new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              `Response header indicates to fallback to FDv1`,
+              500,
+            ),
+          );
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const mockInitializer2: DataSource = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Closed, {
+            name: 'Error',
+            message: 'I should NOT be called due to FDv1 fallback from init1',
+          });
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const mockSynchronizer1 = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Closed, {
+            name: 'Error',
+            message: 'I should NOT be called due to FDv1 fallback from init1',
+          });
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const mockFDv1Data = { key: 'FDv1Data' };
+  const mockFDv1Synchronizer = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(DataSourceState.Valid, null);
+          _dataCallback(true, mockFDv1Data);
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const underTest = new CompositeDataSource(
+    [makeDataSourceFactory(mockInitializer1), makeDataSourceFactory(mockInitializer2)],
+    [makeDataSourceFactory(mockSynchronizer1)],
+    [makeDataSourceFactory(mockFDv1Synchronizer)],
+    undefined,
+    makeTestTransitionConditions(),
+    makeZeroBackoff(),
+  );
+
+  let dataCallback;
+  const statusCallback = jest.fn();
+  await new Promise<void>((resolve) => {
+    dataCallback = jest.fn((_: boolean, data: any) => {
+      if (data === mockFDv1Data) {
+        resolve();
+      }
+    });
+    underTest.start(dataCallback, statusCallback);
+  });
+
+  expect(mockInitializer1.start).toHaveBeenCalledTimes(1);
+  expect(mockInitializer2.start).not.toHaveBeenCalled();
+  expect(mockSynchronizer1.start).not.toHaveBeenCalled();
+  expect(mockFDv1Synchronizer.start).toHaveBeenCalledTimes(1);
+  expect(dataCallback).toHaveBeenCalledTimes(1);
+  expect(dataCallback).toHaveBeenCalledWith(true, mockFDv1Data);
+});
+
+// When the FDv1 Fallback Directive arrives but the SDK has not been configured with an
+// FDv1 fallback synchronizer, the data source must transition to a terminal Closed state
+// instead of looping or trying other FDv2 sources.
+it('terminates when FDv1 fallback is requested but no FDv1 fallback synchronizer is configured', async () => {
+  const mockSynchronizer1 = {
+    start: jest
+      .fn()
+      .mockImplementation(
+        (
+          _dataCallback: (basis: boolean, data: any) => void,
+          _statusCallback: (status: DataSourceState, err?: any) => void,
+        ) => {
+          _statusCallback(DataSourceState.Initializing);
+          _statusCallback(
+            DataSourceState.Closed,
+            new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              `Response header indicates to fallback to FDv1`,
+              500,
+            ),
+          );
+        },
+      ),
+    stop: jest.fn(),
+  };
+
+  const underTest = new CompositeDataSource(
+    [],
+    [makeDataSourceFactory(mockSynchronizer1)],
+    [], // no FDv1 fallback synchronizer
+    undefined,
+    makeTestTransitionConditions(),
+    makeZeroBackoff(),
+  );
+
+  const statusCallback = jest.fn();
+  const dataCallback = jest.fn();
+  await new Promise<void>((resolve) => {
+    statusCallback.mockImplementation((state: DataSourceState) => {
+      if (state === DataSourceState.Closed) {
+        resolve();
+      }
+    });
+    underTest.start(dataCallback, statusCallback);
+  });
+
+  // The underlying synchronizer was started exactly once -- we did not loop trying other
+  // FDv2 sources after the directive arrived.
+  expect(mockSynchronizer1.start).toHaveBeenCalledTimes(1);
+  expect(dataCallback).not.toHaveBeenCalled();
+
+  // The terminal status is Closed (composite signals exhaustion when the FDv1 list is empty).
+  const lastCall = statusCallback.mock.calls[statusCallback.mock.calls.length - 1];
+  expect(lastCall[0]).toBe(DataSourceState.Closed);
+});
+
 it('reports error when all initializers fail', async () => {
   const mockInitializer1Error = {
     name: 'Error',

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -246,12 +246,19 @@ export class CompositeDataSource implements DataSource {
       // stop the underlying datasource before transitioning to next state
       currentDS?.stop();
 
+      // Skip backoff only on the initial server-directed FDv1 engagement (a `switchToSync`
+      // transition resolved by `engageFDv1Fallback` carries an `LDFlagDeliveryFallbackError`).
+      // Any subsequent `LDFlagDeliveryFallbackError` is an ordinary retry from the FDv1
+      // synchronizer (or a follow-up FDv1 factory) and must be throttled like any other
+      // error retry.
+      const isInitialFDv1Engagement =
+        transitionRequest.transition === 'switchToSync' &&
+        transitionRequest.err instanceof LDFlagDeliveryFallbackError;
+
       if (
         transitionRequest.err &&
         transitionRequest.transition !== 'stop' &&
-        // The server-directed FDv1 fallback is not an error retry -- the directive should be
-        // honored immediately so the FDv1 synchronizer can take over without delay.
-        !(transitionRequest.err instanceof LDFlagDeliveryFallbackError)
+        !isInitialFDv1Engagement
       ) {
         // if the transition was due to an error we're not in the initializer phase, throttle the transition. Fallback between initializers is not throttled.
         const delay = this._initPhaseActive ? 0 : this._backoff.fail();

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -144,13 +144,30 @@ export class CompositeDataSource implements DataSource {
                   // don't use this datasource's factory again
                   this._logger?.debug(`Culling data source due to err ${err}`);
                   cullDSFactory?.();
-
-                  // this error indicates we should fallback to only using FDv1 synchronizers
-                  if (err instanceof LDFlagDeliveryFallbackError) {
-                    this._logger?.debug(`Falling back to FDv1`);
-                    this._syncFactories = this._fdv1Synchronizers;
-                  }
                 }
+
+                // The FDv1 fallback directive is server-directed and one-way. As soon as we
+                // observe it, end any in-progress initializer phase and replace the FDv2
+                // synchronizers with the configured FDv1 fallback list. If no FDv1 fallback
+                // is configured, the synchronizer list becomes empty and the composite will
+                // terminate via the exhausted-sources path.
+                if (err instanceof LDFlagDeliveryFallbackError) {
+                  if (this._fdv1Synchronizers.length() > 0) {
+                    this._logger?.warn(`Falling back to FDv1`);
+                  } else {
+                    this._logger?.warn(
+                      `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
+                    );
+                  }
+                  this._syncFactories = this._fdv1Synchronizers;
+                  sanitizedStatusCallback(state, err);
+                  this._consumeCancelToken(cancelScheduledTransition);
+                  // switchToSync ends init phase and starts the FDv1 synchronizer list from
+                  // its head, bypassing any remaining initializers and FDv2 synchronizers.
+                  transitionResolve({ transition: 'switchToSync', err });
+                  return;
+                }
+
                 sanitizedStatusCallback(state, err);
                 this._consumeCancelToken(cancelScheduledTransition);
                 transitionResolve({ transition: 'fallback', err }); // unrecoverable error has occurred, so fallback
@@ -205,7 +222,13 @@ export class CompositeDataSource implements DataSource {
       // stop the underlying datasource before transitioning to next state
       currentDS?.stop();
 
-      if (transitionRequest.err && transitionRequest.transition !== 'stop') {
+      if (
+        transitionRequest.err &&
+        transitionRequest.transition !== 'stop' &&
+        // The server-directed FDv1 fallback is not an error retry -- the directive should be
+        // honored immediately so the FDv1 synchronizer can take over without delay.
+        !(transitionRequest.err instanceof LDFlagDeliveryFallbackError)
+      ) {
         // if the transition was due to an error we're not in the initializer phase, throttle the transition. Fallback between initializers is not throttled.
         const delay = this._initPhaseActive ? 0 : this._backoff.fail();
         const { promise, cancel: cancelDelay } = this._cancellableDelay(delay);

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -41,6 +41,11 @@ export class CompositeDataSource implements DataSource {
   private _initFactories: DataSourceList<LDDataSourceFactory>;
   private _syncFactories: DataSourceList<LDDataSourceFactory>;
   private _fdv1Synchronizers: DataSourceList<LDDataSourceFactory>;
+  // Set after the server-directed FDv1 fallback has been engaged. The directive is
+  // one-way: subsequent fallback signals from the FDv1 synchronizer (e.g. if the FDv1
+  // endpoint were to echo `x-ld-fd-fallback`) are ignored so the data source does not
+  // loop replacing its synchronizer list with itself.
+  private _fdv1FallbackEngaged: boolean = false;
 
   private _stopped: boolean = true;
   private _externalTransitionPromise: Promise<TransitionRequest>;
@@ -123,6 +128,31 @@ export class CompositeDataSource implements DataSource {
             (basis: boolean, data: any) => {
               this._backoff.success();
               dataCallback(basis, data);
+
+              // The FDv1 fallback directive can ride along on the same data callback that
+              // delivers a payload (initializer or synchronizer phase). Apply the payload
+              // first (above), then swap the synchronizer list to FDv1 and transition.
+              // This is atomic with the data callback so the basis-during-init auto-
+              // transition below cannot race ahead and switch to the FDv2 synchronizer list.
+              // Once engaged, the directive is one-way -- ignore any subsequent occurrence
+              // (e.g. the FDv1 endpoint echoing the header) so we don't re-enter this branch.
+              if (data?.fallbackToFDv1 && !this._fdv1FallbackEngaged) {
+                if (this._fdv1Synchronizers.length() > 0) {
+                  this._logger?.warn(`Falling back to FDv1`);
+                } else {
+                  this._logger?.warn(
+                    `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
+                  );
+                }
+                this._fdv1FallbackEngaged = true;
+                this._syncFactories = this._fdv1Synchronizers;
+                callbackHandler.disable();
+                this._consumeCancelToken(cancelScheduledTransition);
+                sanitizedStatusCallback(DataSourceState.Interrupted);
+                transitionResolve({ transition: 'switchToSync' });
+                return;
+              }
+
               if (basis && this._initPhaseActive) {
                 // transition to sync if we get basis during init
                 callbackHandler.disable();
@@ -150,8 +180,11 @@ export class CompositeDataSource implements DataSource {
                 // observe it, end any in-progress initializer phase and replace the FDv2
                 // synchronizers with the configured FDv1 fallback list. If no FDv1 fallback
                 // is configured, the synchronizer list becomes empty and the composite will
-                // terminate via the exhausted-sources path.
-                if (err instanceof LDFlagDeliveryFallbackError) {
+                // terminate via the exhausted-sources path. Subsequent occurrences of the
+                // directive (e.g. if the FDv1 endpoint were to echo `x-ld-fd-fallback`) are
+                // ignored so the data source does not loop replacing its synchronizer list
+                // with itself.
+                if (err instanceof LDFlagDeliveryFallbackError && !this._fdv1FallbackEngaged) {
                   if (this._fdv1Synchronizers.length() > 0) {
                     this._logger?.warn(`Falling back to FDv1`);
                   } else {
@@ -159,6 +192,7 @@ export class CompositeDataSource implements DataSource {
                       `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
                     );
                   }
+                  this._fdv1FallbackEngaged = true;
                   this._syncFactories = this._fdv1Synchronizers;
                   sanitizedStatusCallback(state, err);
                   this._consumeCancelToken(cancelScheduledTransition);
@@ -272,6 +306,7 @@ export class CompositeDataSource implements DataSource {
     this._initFactories.reset();
     this._syncFactories.reset();
     this._fdv1Synchronizers.reset();
+    this._fdv1FallbackEngaged = false;
     this._externalTransitionPromise = new Promise<TransitionRequest>((tr) => {
       this._externalTransitionResolve = tr;
     });

--- a/packages/shared/common/src/datasource/CompositeDataSource.ts
+++ b/packages/shared/common/src/datasource/CompositeDataSource.ts
@@ -123,6 +123,29 @@ export class CompositeDataSource implements DataSource {
           let lastState: DataSourceState | undefined;
           let cancelScheduledTransition: () => void = () => {};
 
+          // Engages the FDv1 Fallback Directive: swaps the synchronizer list to FDv1 (or
+          // empties it when no FDv1 fallback is configured), reports the in-progress status
+          // through the sanitizer, cancels any pending scheduled transition, and resolves
+          // a switchToSync transition. The directive is one-way; the engagement flag is
+          // checked by the callers so we don't re-enter this branch on repeated signals.
+          const engageFDv1Fallback = (
+            statusToReport: DataSourceState,
+            err: unknown,
+          ) => {
+            if (this._fdv1Synchronizers.length() > 0) {
+              this._logger?.warn(`Falling back to FDv1`);
+            } else {
+              this._logger?.warn(
+                `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
+              );
+            }
+            this._fdv1FallbackEngaged = true;
+            this._syncFactories = this._fdv1Synchronizers;
+            sanitizedStatusCallback(statusToReport, err);
+            this._consumeCancelToken(cancelScheduledTransition);
+            transitionResolve({ transition: 'switchToSync', err: err as Error | undefined });
+          };
+
           // this callback handler can be disabled and ensures only one transition request occurs
           const callbackHandler = new CallbackHandler(
             (basis: boolean, data: any) => {
@@ -130,26 +153,11 @@ export class CompositeDataSource implements DataSource {
               dataCallback(basis, data);
 
               // The FDv1 fallback directive can ride along on the same data callback that
-              // delivers a payload (initializer or synchronizer phase). Apply the payload
-              // first (above), then swap the synchronizer list to FDv1 and transition.
-              // This is atomic with the data callback so the basis-during-init auto-
-              // transition below cannot race ahead and switch to the FDv2 synchronizer list.
-              // Once engaged, the directive is one-way -- ignore any subsequent occurrence
-              // (e.g. the FDv1 endpoint echoing the header) so we don't re-enter this branch.
+              // delivers a payload, so the swap to FDv1 is atomic with payload application.
+              // Once engaged, the directive is one-way -- subsequent signals are ignored.
               if (data?.fallbackToFDv1 && !this._fdv1FallbackEngaged) {
-                if (this._fdv1Synchronizers.length() > 0) {
-                  this._logger?.warn(`Falling back to FDv1`);
-                } else {
-                  this._logger?.warn(
-                    `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
-                  );
-                }
-                this._fdv1FallbackEngaged = true;
-                this._syncFactories = this._fdv1Synchronizers;
                 callbackHandler.disable();
-                this._consumeCancelToken(cancelScheduledTransition);
-                sanitizedStatusCallback(DataSourceState.Interrupted);
-                transitionResolve({ transition: 'switchToSync' });
+                engageFDv1Fallback(DataSourceState.Interrupted, undefined);
                 return;
               }
 
@@ -176,29 +184,11 @@ export class CompositeDataSource implements DataSource {
                   cullDSFactory?.();
                 }
 
-                // The FDv1 fallback directive is server-directed and one-way. As soon as we
-                // observe it, end any in-progress initializer phase and replace the FDv2
-                // synchronizers with the configured FDv1 fallback list. If no FDv1 fallback
-                // is configured, the synchronizer list becomes empty and the composite will
-                // terminate via the exhausted-sources path. Subsequent occurrences of the
-                // directive (e.g. if the FDv1 endpoint were to echo `x-ld-fd-fallback`) are
-                // ignored so the data source does not loop replacing its synchronizer list
-                // with itself.
+                // Status-callback path for the FDv1 Fallback Directive (used when the
+                // server-directed signal arrives without an accompanying payload, e.g. on
+                // an HTTP error or a malformed body).
                 if (err instanceof LDFlagDeliveryFallbackError && !this._fdv1FallbackEngaged) {
-                  if (this._fdv1Synchronizers.length() > 0) {
-                    this._logger?.warn(`Falling back to FDv1`);
-                  } else {
-                    this._logger?.warn(
-                      `FDv1 fallback was requested but no FDv1 fallback synchronizer is configured; data source will terminate`,
-                    );
-                  }
-                  this._fdv1FallbackEngaged = true;
-                  this._syncFactories = this._fdv1Synchronizers;
-                  sanitizedStatusCallback(state, err);
-                  this._consumeCancelToken(cancelScheduledTransition);
-                  // switchToSync ends init phase and starts the FDv1 synchronizer list from
-                  // its head, bypassing any remaining initializers and FDv2 synchronizers.
-                  transitionResolve({ transition: 'switchToSync', err });
+                  engageFDv1Fallback(state, err);
                   return;
                 }
 

--- a/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
@@ -1,6 +1,6 @@
 import { LDFlagDeliveryFallbackError } from '@launchdarkly/js-sdk-common';
 
-import { subsystem } from '../../src';
+import { LDPollingError, subsystem } from '../../src';
 import OneShotInitializerFDv2 from '../../src/data_sources/OneShotInitializerFDv2';
 import Requestor from '../../src/data_sources/Requestor';
 import TestLogger from '../Logger';
@@ -79,13 +79,8 @@ describe('given a one shot initializer', () => {
     });
   });
 
-  // Per the FDv2 spec, when the server returns the FDv1 fallback directive alongside a
-  // valid 200 response the SDK must apply the accompanying payload AND surface the
-  // fallback signal atomically. The directive rides on the same data callback as the
-  // payload via `data.fallbackToFDv1`, so CompositeDataSource can swap its synchronizer
-  // list to FDv1 before its basis-during-init auto-transition fires. A separate status
-  // callback after the data callback would be silently dropped because the composite's
-  // callback handler disables itself on basis-during-init.
+  // On a 200 + directive, the payload and the directive must arrive atomically on the same
+  // dataCallback so the composite can swap to FDv1 without losing either.
   it('applies the payload and signals fallback atomically on a 200 + directive', () => {
     const dataCb = jest.fn();
     const statusCb = jest.fn();
@@ -113,8 +108,8 @@ describe('given a one shot initializer', () => {
     });
   });
 
-  // When the fallback signal arrives alongside an HTTP error, no payload can be applied
-  // but the directive must still be honored so we stop attempting FDv2 sources.
+  // Error response + directive: there is no payload to apply, but the directive must still
+  // engage FDv1 instead of being treated as an ordinary error.
   it('signals fallback when an error response carries the fallback directive', () => {
     const dataCb = jest.fn();
     const statusCb = jest.fn();
@@ -129,8 +124,36 @@ describe('given a one shot initializer', () => {
     expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
   });
 
-  // A malformed body that arrives with the fallback directive must not get stuck retrying
-  // FDv2 -- the directive is one-way and takes precedence over the parse failure.
+  // 200 + directive but the body parses to an event sequence that triggers an actionable
+  // PayloadProcessor error. The initializer must still engage FDv1 -- the per-event error
+  // must not slip through as a generic LDPollingError.
+  it('engages FDv1 when the PayloadProcessor reports an error and the directive is in flight', () => {
+    const dataCb = jest.fn();
+    const statusCb = jest.fn();
+    // payload-transferred without a server-intent triggers PROTOCOL_ERROR (actionable).
+    const protocolErrorEvents = {
+      events: [
+        {
+          event: 'payload-transferred',
+          data: { state: 'mockState', version: 1 },
+        },
+      ],
+    };
+    requestor.requestAllData = jest.fn((cb) =>
+      cb(undefined, JSON.stringify(protocolErrorEvents), undefined, true),
+    );
+    initializer.start(dataCb, statusCb);
+
+    // The terminal status emitted to the composite must be the FDv1-fallback error.
+    const errorCalls = statusCb.mock.calls.filter((call: any[]) => call[1] !== undefined);
+    expect(errorCalls.length).toBeGreaterThan(0);
+    expect(errorCalls[errorCalls.length - 1][1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    statusCb.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDPollingError);
+    });
+  });
+
+  // Malformed body + directive: the parse failure must not suppress the directive.
   it('still signals fallback when the body cannot be parsed', () => {
     const dataCb = jest.fn();
     const statusCb = jest.fn();

--- a/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
@@ -1,3 +1,5 @@
+import { LDFlagDeliveryFallbackError } from '@launchdarkly/js-sdk-common';
+
 import { subsystem } from '../../src';
 import OneShotInitializerFDv2 from '../../src/data_sources/OneShotInitializerFDv2';
 import Requestor from '../../src/data_sources/Requestor';
@@ -75,5 +77,63 @@ describe('given a one shot initializer', () => {
         version: 1,
       },
     });
+  });
+
+  // Per the FDv2 spec, when the server returns the FDv1 fallback directive alongside a
+  // valid 200 response the SDK must apply the accompanying payload first, then surface the
+  // fallback signal so the CompositeDataSource can swap to the FDv1 synchronizer.
+  it('applies the payload before signalling fallback when fallback rides along on a 200', () => {
+    const dataCb = jest.fn();
+    const statusCb = jest.fn();
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, jsonData, undefined, true));
+    initializer.start(dataCb, statusCb);
+
+    // The server-provided data was applied to the data store via dataCallback.
+    expect(dataCb).toHaveBeenCalledTimes(1);
+    expect(dataCb).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          type: 'full',
+          state: 'mockState',
+        }),
+      }),
+    );
+
+    // The Closed status carries an LDFlagDeliveryFallbackError so the composite swaps to
+    // the FDv1 synchronizer rather than treating this as an ordinary completion.
+    const lastCall = statusCb.mock.calls[statusCb.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+  });
+
+  // When the fallback signal arrives alongside an HTTP error, no payload can be applied
+  // but the directive must still be honored so we stop attempting FDv2 sources.
+  it('signals fallback when an error response carries the fallback directive', () => {
+    const dataCb = jest.fn();
+    const statusCb = jest.fn();
+    requestor.requestAllData = jest.fn((cb) =>
+      cb({ status: 500, message: 'Internal Server Error' }, undefined, undefined, true),
+    );
+    initializer.start(dataCb, statusCb);
+
+    expect(dataCb).not.toHaveBeenCalled();
+    const lastCall = statusCb.mock.calls[statusCb.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+  });
+
+  // A malformed body that arrives with the fallback directive must not get stuck retrying
+  // FDv2 -- the directive is one-way and takes precedence over the parse failure.
+  it('still signals fallback when the body cannot be parsed', () => {
+    const dataCb = jest.fn();
+    const statusCb = jest.fn();
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, '{not json', undefined, true));
+    initializer.start(dataCb, statusCb);
+
+    expect(dataCb).not.toHaveBeenCalled();
+    const lastCall = statusCb.mock.calls[statusCb.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
   });
 });

--- a/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/OneShotInitializerFDv2.test.ts
@@ -80,19 +80,24 @@ describe('given a one shot initializer', () => {
   });
 
   // Per the FDv2 spec, when the server returns the FDv1 fallback directive alongside a
-  // valid 200 response the SDK must apply the accompanying payload first, then surface the
-  // fallback signal so the CompositeDataSource can swap to the FDv1 synchronizer.
-  it('applies the payload before signalling fallback when fallback rides along on a 200', () => {
+  // valid 200 response the SDK must apply the accompanying payload AND surface the
+  // fallback signal atomically. The directive rides on the same data callback as the
+  // payload via `data.fallbackToFDv1`, so CompositeDataSource can swap its synchronizer
+  // list to FDv1 before its basis-during-init auto-transition fires. A separate status
+  // callback after the data callback would be silently dropped because the composite's
+  // callback handler disables itself on basis-during-init.
+  it('applies the payload and signals fallback atomically on a 200 + directive', () => {
     const dataCb = jest.fn();
     const statusCb = jest.fn();
     requestor.requestAllData = jest.fn((cb) => cb(undefined, jsonData, undefined, true));
     initializer.start(dataCb, statusCb);
 
-    // The server-provided data was applied to the data store via dataCallback.
+    // A single dataCallback invocation carries both the payload and the fallback marker.
     expect(dataCb).toHaveBeenCalledTimes(1);
     expect(dataCb).toHaveBeenCalledWith(
       true,
       expect.objectContaining({
+        fallbackToFDv1: true,
         payload: expect.objectContaining({
           type: 'full',
           state: 'mockState',
@@ -100,11 +105,12 @@ describe('given a one shot initializer', () => {
       }),
     );
 
-    // The Closed status carries an LDFlagDeliveryFallbackError so the composite swaps to
-    // the FDv1 synchronizer rather than treating this as an ordinary completion.
-    const lastCall = statusCb.mock.calls[statusCb.mock.calls.length - 1];
-    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
-    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    // No LDFlagDeliveryFallbackError must be emitted via status callback when the
+    // directive rides along on a payload -- the composite would have already disabled
+    // its callback handler by the time we tried to emit it.
+    statusCb.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDFlagDeliveryFallbackError);
+    });
   });
 
   // When the fallback signal arrives alongside an HTTP error, no payload can be applied

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -144,12 +144,8 @@ describe('given a polling processor', () => {
     });
   });
 
-  // Per the FDv2 spec, the fallback directive can ride along on a successful response.
-  // The processor must deliver the payload AND the directive atomically via the data
-  // callback (`data.fallbackToFDv1`) so CompositeDataSource can swap its synchronizer
-  // list to FDv1 before its basis-during-init auto-transition fires. A separate status
-  // callback after the data callback would be silently dropped because the composite's
-  // callback handler disables itself on basis-during-init.
+  // On a 200 with the fallback header, the payload and the directive must arrive atomically
+  // on the same dataCallback so CompositeDataSource can swap to FDv1 without losing either.
   it('attaches fallback marker to data callback when fallback header rides along on a 200', async () => {
     requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv2JsonData, headers, true));
 
@@ -183,11 +179,8 @@ describe('given a polling processor', () => {
     expect(requestor.requestAllData).toHaveBeenCalledTimes(1);
   });
 
-  // Bug fix: when the polling response carries the fallback header AND the body is
-  // malformed, the processor previously emitted Interrupted/LDPollingError before the
-  // fallbackToFDv1 check could run. CompositeDataSource's CallbackHandler disables itself
-  // on that first error callback, silently dropping the subsequent fallback signal. The
-  // directive must be emitted FIRST so it isn't lost.
+  // Malformed body + fallback header: the directive must be emitted before any
+  // Interrupted/LDPollingError so the composite can engage FDv1 instead of retrying.
   it('emits the fallback directive before the malformed-body error so it is not dropped', async () => {
     requestor.requestAllData = jest.fn((cb) => cb(undefined, '{not json', headers, true));
 
@@ -209,9 +202,47 @@ describe('given a polling processor', () => {
     expect(requestor.requestAllData).toHaveBeenCalledTimes(1);
   });
 
-  // When the fallback directive arrives alongside an error response, the processor must
-  // emit the directive without scheduling a retry, even if the status would otherwise be
-  // recoverable.
+  // 200 + directive but the body parses to an event sequence that triggers an actionable
+  // PayloadProcessor error (e.g. payload-transferred without a preceding server-intent).
+  // The processor must still engage FDv1 -- the per-event error must not slip through as
+  // a generic LDPollingError that the composite would treat as an ordinary failure.
+  it('engages FDv1 when the PayloadProcessor reports an error and the directive is in flight', async () => {
+    // payload-transferred without a server-intent is a PROTOCOL_ERROR (actionable).
+    const protocolErrorEvents = {
+      events: [
+        {
+          event: 'payload-transferred',
+          data: { state: 'mockState', version: 1 },
+        },
+      ],
+    };
+    requestor.requestAllData = jest.fn((cb) =>
+      cb(undefined, JSON.stringify(protocolErrorEvents), headers, true),
+    );
+
+    const dataCallback = jest.fn();
+    const statusCallback = jest.fn();
+    processor.start(dataCallback, statusCallback);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The terminal status emitted to the composite must be the FDv1-fallback error so that
+    // CompositeDataSource engages FDv1 instead of falling through to the next FDv2 source.
+    const errorCalls = statusCallback.mock.calls.filter(
+      (call: any[]) => call[1] !== undefined,
+    );
+    expect(errorCalls.length).toBeGreaterThan(0);
+    expect(errorCalls[errorCalls.length - 1][1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+
+    // No LDPollingError must be reported -- that path would let the composite treat the
+    // failure as an ordinary error and fall through to the next FDv2 source.
+    statusCallback.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDPollingError);
+    });
+  });
+
+  // Error response + directive: emit the directive and don't reschedule a poll, even
+  // when the HTTP status would otherwise be recoverable.
   it('signals fallback on an error response without retrying', async () => {
     requestor.requestAllData = jest.fn((cb) =>
       cb({ status: 500 }, undefined, headers, true),

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -145,21 +145,16 @@ describe('given a polling processor', () => {
   });
 
   // Per the FDv2 spec, the fallback directive can ride along on a successful response.
-  // The processor must apply the payload first, then emit the fallback signal so that the
-  // CompositeDataSource can swap to the FDv1 synchronizer.
-  it('applies payload then signals fallback when fallback header rides along on a 200', async () => {
+  // The processor must deliver the payload AND the directive atomically via the data
+  // callback (`data.fallbackToFDv1`) so CompositeDataSource can swap its synchronizer
+  // list to FDv1 before its basis-during-init auto-transition fires. A separate status
+  // callback after the data callback would be silently dropped because the composite's
+  // callback handler disables itself on basis-during-init.
+  it('attaches fallback marker to data callback when fallback header rides along on a 200', async () => {
     requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv2JsonData, headers, true));
 
-    let dataCallback;
-    let resolveStatus: () => void = () => {};
-    const sawFallback = new Promise<void>((resolve) => {
-      resolveStatus = resolve;
-    });
-    const statusCallback = jest.fn((state, err) => {
-      if (state === subsystem.DataSourceState.Closed && err instanceof LDFlagDeliveryFallbackError) {
-        resolveStatus();
-      }
-    });
+    let dataCallback: jest.Mock = jest.fn();
+    const statusCallback = jest.fn();
 
     await new Promise<void>((resolve) => {
       dataCallback = jest.fn(() => {
@@ -168,13 +163,50 @@ describe('given a polling processor', () => {
       processor.start(dataCallback, statusCallback);
     });
 
-    await sawFallback;
-
-    // The server-provided data was applied before the fallback signal was emitted.
+    // A single dataCallback invocation carries both the payload and the fallback marker.
     expect(dataCallback).toHaveBeenCalledTimes(1);
-    const lastCall = statusCallback.mock.calls[statusCallback.mock.calls.length - 1];
-    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
-    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    expect(dataCallback).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        fallbackToFDv1: true,
+        payload: expect.objectContaining({ type: 'full' }),
+      }),
+    );
+
+    // No LDFlagDeliveryFallbackError on the status callback path -- the composite would
+    // have disabled its handler before we got there.
+    statusCallback.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDFlagDeliveryFallbackError);
+    });
+
+    // No subsequent poll should be scheduled. requestAllData was only called once.
+    expect(requestor.requestAllData).toHaveBeenCalledTimes(1);
+  });
+
+  // Bug fix: when the polling response carries the fallback header AND the body is
+  // malformed, the processor previously emitted Interrupted/LDPollingError before the
+  // fallbackToFDv1 check could run. CompositeDataSource's CallbackHandler disables itself
+  // on that first error callback, silently dropping the subsequent fallback signal. The
+  // directive must be emitted FIRST so it isn't lost.
+  it('emits the fallback directive before the malformed-body error so it is not dropped', async () => {
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, '{not json', headers, true));
+
+    const dataCallback = jest.fn();
+    const statusCallback = jest.fn();
+    processor.start(dataCallback, statusCallback);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The very first non-Initializing status update carries the LDFlagDeliveryFallbackError.
+    const errorCalls = statusCallback.mock.calls.filter(
+      (call: any[]) => call[0] !== subsystem.DataSourceState.Initializing,
+    );
+    expect(errorCalls.length).toBeGreaterThan(0);
+    expect(errorCalls[0][0]).toBe(subsystem.DataSourceState.Closed);
+    expect(errorCalls[0][1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+
+    // The processor must not schedule another poll.
+    expect(requestor.requestAllData).toHaveBeenCalledTimes(1);
   });
 
   // When the fallback directive arrives alongside an error response, the processor must

--- a/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/PollingProcessorFDv2.test.ts
@@ -1,3 +1,5 @@
+import { LDFlagDeliveryFallbackError } from '@launchdarkly/js-sdk-common';
+
 import { DataSourceErrorKind, LDPollingError, subsystem } from '../../src';
 import PollingProcessorFDv2 from '../../src/data_sources/PollingProcessorFDv2';
 import Requestor from '../../src/data_sources/Requestor';
@@ -140,6 +142,59 @@ describe('given a polling processor', () => {
         version: 1,
       },
     });
+  });
+
+  // Per the FDv2 spec, the fallback directive can ride along on a successful response.
+  // The processor must apply the payload first, then emit the fallback signal so that the
+  // CompositeDataSource can swap to the FDv1 synchronizer.
+  it('applies payload then signals fallback when fallback header rides along on a 200', async () => {
+    requestor.requestAllData = jest.fn((cb) => cb(undefined, fdv2JsonData, headers, true));
+
+    let dataCallback;
+    let resolveStatus: () => void = () => {};
+    const sawFallback = new Promise<void>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const statusCallback = jest.fn((state, err) => {
+      if (state === subsystem.DataSourceState.Closed && err instanceof LDFlagDeliveryFallbackError) {
+        resolveStatus();
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      dataCallback = jest.fn(() => {
+        resolve();
+      });
+      processor.start(dataCallback, statusCallback);
+    });
+
+    await sawFallback;
+
+    // The server-provided data was applied before the fallback signal was emitted.
+    expect(dataCallback).toHaveBeenCalledTimes(1);
+    const lastCall = statusCallback.mock.calls[statusCallback.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+  });
+
+  // When the fallback directive arrives alongside an error response, the processor must
+  // emit the directive without scheduling a retry, even if the status would otherwise be
+  // recoverable.
+  it('signals fallback on an error response without retrying', async () => {
+    requestor.requestAllData = jest.fn((cb) =>
+      cb({ status: 500 }, undefined, headers, true),
+    );
+
+    const statusCallback = jest.fn();
+    processor.start(mockDataCallback, statusCallback);
+
+    // Wait for the synchronous fallback emission.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(requestor.requestAllData).toHaveBeenCalledTimes(1);
+    const lastCall = statusCallback.mock.calls[statusCallback.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
   });
 
   it('uses selectorGetter when provided', async () => {

--- a/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/Requestor.test.ts
@@ -2,6 +2,7 @@ import {
   EventSource,
   EventSourceInitDict,
   Headers,
+  LDFlagDeliveryFallbackError,
   Options,
   Requests,
   Response,
@@ -167,5 +168,49 @@ describe('given a requestor', () => {
     });
 
     expect(res.headers).toEqual(testHeaders);
+  });
+
+  // Per the FDv2 spec, the FDv1 Fallback Directive can ride along on a successful 200
+  // response. The Requestor must surface both the body (so the consumer can apply the
+  // accompanying payload) and the fallback signal.
+  it('passes body and fallback signal to callback when a 200 carries the fallback header', async () => {
+    testStatus = 200;
+    testResponse = 'a response';
+    testHeaders = {
+      'x-ld-fd-fallback': 'true',
+    };
+
+    const res = await promisify<{
+      err: any;
+      body: any;
+      headers: any;
+      fallbackToFDv1: boolean | undefined;
+    }>((cb) => {
+      requestor.requestAllData((err, body, headers, fallbackToFDv1) =>
+        cb({ err, body, headers, fallbackToFDv1 }),
+      );
+    });
+
+    expect(res.err).toBeUndefined();
+    expect(res.body).toEqual(testResponse);
+    expect(res.fallbackToFDv1).toBe(true);
+  });
+
+  // When the directive arrives alongside an HTTP error, the Requestor should still surface
+  // the fallback signal so the consumer can switch to FDv1 instead of retrying.
+  it('returns an LDFlagDeliveryFallbackError and the fallback signal on an error response with the directive', async () => {
+    testStatus = 500;
+    testHeaders = {
+      'x-ld-fd-fallback': 'true',
+    };
+
+    const res = await promisify<{ err: any; fallbackToFDv1: boolean | undefined }>((cb) => {
+      requestor.requestAllData((err, _body, _headers, fallbackToFDv1) =>
+        cb({ err, fallbackToFDv1 }),
+      );
+    });
+
+    expect(res.err).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    expect(res.fallbackToFDv1).toBe(true);
   });
 });

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
@@ -263,12 +263,9 @@ describe('given a stream processor with mock event source', () => {
     });
   });
 
-  // The server can signal FDv1 fallback alongside a valid streaming payload by setting the
-  // `x-ld-fd-fallback` header on the connection-open response. The processor must deliver
-  // both the payload and the fallback marker on the same data callback (`data.fallbackToFDv1`)
-  // so CompositeDataSource can swap its synchronizer list to FDv1 before its basis-during-
-  // init auto-transition fires. A separate status callback after the data callback would be
-  // silently dropped because the composite's callback handler disables itself.
+  // When the connection-open response carries `x-ld-fd-fallback`, the next payload and
+  // the directive must arrive atomically on the same dataCallback so the composite can
+  // swap to FDv1 without losing either.
   it('attaches fallback marker to data callback when fallback header rides along on open', () => {
     mockEventSource.onopen({
       headers: { ...openHeaders, 'x-ld-fd-fallback': 'true' },
@@ -307,6 +304,30 @@ describe('given a stream processor with mock event source', () => {
       subsystem.DataSourceState.Interrupted,
       new LDStreamingError(DataSourceErrorKind.InvalidData, 'Malformed data in EventStream.'),
     );
+  });
+
+  // Connection opened with the directive but a subsequent event triggers a parse error
+  // before any payload is emitted. The processor must engage FDv1 (LDFlagDeliveryFallbackError
+  // on Closed) rather than report an ordinary LDStreamingError that the composite would
+  // treat as a recoverable failure.
+  it('engages FDv1 when a parse error fires while the directive is in flight', () => {
+    mockEventSource.onopen({
+      headers: { ...openHeaders, 'x-ld-fd-fallback': 'true' },
+    });
+    simulateEvents({
+      'server-intent': {
+        data: '{"payloads": [{"intent INTENTIONAL CORRUPTION MUWAHAHAHA',
+      },
+    });
+
+    const lastCall = mockStatusCallback.mock.calls[mockStatusCallback.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    // No LDStreamingError must be reported -- that path would let the composite treat the
+    // failure as an ordinary error.
+    mockStatusCallback.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDStreamingError);
+    });
   });
 
   it('calls error handler if event.data prop is missing', async () => {

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
@@ -264,26 +264,32 @@ describe('given a stream processor with mock event source', () => {
   });
 
   // The server can signal FDv1 fallback alongside a valid streaming payload by setting the
-  // `x-ld-fd-fallback` header on the connection-open response. The processor must apply the
-  // payload first and then surface the directive so the CompositeDataSource can switch to
-  // the FDv1 synchronizer.
-  it('applies payload then signals fallback when fallback header rides along on open', () => {
+  // `x-ld-fd-fallback` header on the connection-open response. The processor must deliver
+  // both the payload and the fallback marker on the same data callback (`data.fallbackToFDv1`)
+  // so CompositeDataSource can swap its synchronizer list to FDv1 before its basis-during-
+  // init auto-transition fires. A separate status callback after the data callback would be
+  // silently dropped because the composite's callback handler disables itself.
+  it('attaches fallback marker to data callback when fallback header rides along on open', () => {
     mockEventSource.onopen({
       headers: { ...openHeaders, 'x-ld-fd-fallback': 'true' },
     });
     simulateEvents();
 
-    // The payload was delivered to the data callback before the fallback signal was emitted.
+    // A single dataCallback invocation carries both the payload and the fallback marker.
     expect(mockDataCallback).toHaveBeenCalledTimes(1);
-    expect(mockDataCallback).toHaveBeenCalledWith(true, expect.objectContaining({
-      payload: expect.objectContaining({ type: 'full' }),
-    }));
+    expect(mockDataCallback).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        fallbackToFDv1: true,
+        payload: expect.objectContaining({ type: 'full' }),
+      }),
+    );
 
-    // The most recent status update is Closed with an LDFlagDeliveryFallbackError -- this is
-    // what triggers the CompositeDataSource swap to FDv1.
-    const lastCall = mockStatusCallback.mock.calls[mockStatusCallback.mock.calls.length - 1];
-    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
-    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+    // No LDFlagDeliveryFallbackError on the status callback path -- the composite would
+    // have disabled its handler before we got there.
+    mockStatusCallback.mock.calls.forEach((call: any[]) => {
+      expect(call[1]).not.toBeInstanceOf(LDFlagDeliveryFallbackError);
+    });
 
     // The processor must close the underlying stream so it doesn't keep consuming FDv2.
     expect(mockEventSource.close).toBeCalled();

--- a/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
+++ b/packages/shared/sdk-server/__tests__/data_sources/StreamingProcessorFDv2.test.ts
@@ -3,6 +3,7 @@ import {
   defaultHeaders,
   Info,
   internal,
+  LDFlagDeliveryFallbackError,
   LDLogger,
   LDStreamingError,
   subsystem,
@@ -260,6 +261,32 @@ describe('given a stream processor with mock event source', () => {
         version: 1,
       },
     });
+  });
+
+  // The server can signal FDv1 fallback alongside a valid streaming payload by setting the
+  // `x-ld-fd-fallback` header on the connection-open response. The processor must apply the
+  // payload first and then surface the directive so the CompositeDataSource can switch to
+  // the FDv1 synchronizer.
+  it('applies payload then signals fallback when fallback header rides along on open', () => {
+    mockEventSource.onopen({
+      headers: { ...openHeaders, 'x-ld-fd-fallback': 'true' },
+    });
+    simulateEvents();
+
+    // The payload was delivered to the data callback before the fallback signal was emitted.
+    expect(mockDataCallback).toHaveBeenCalledTimes(1);
+    expect(mockDataCallback).toHaveBeenCalledWith(true, expect.objectContaining({
+      payload: expect.objectContaining({ type: 'full' }),
+    }));
+
+    // The most recent status update is Closed with an LDFlagDeliveryFallbackError -- this is
+    // what triggers the CompositeDataSource swap to FDv1.
+    const lastCall = mockStatusCallback.mock.calls[mockStatusCallback.mock.calls.length - 1];
+    expect(lastCall[0]).toBe(subsystem.DataSourceState.Closed);
+    expect(lastCall[1]).toBeInstanceOf(LDFlagDeliveryFallbackError);
+
+    // The processor must close the underlying stream so it doesn't keep consuming FDv2.
+    expect(mockEventSource.close).toBeCalled();
   });
 
   it('passes error to callback if json data is malformed', async () => {

--- a/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
+++ b/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
@@ -472,4 +472,37 @@ describe('when setting different options', () => {
     expect(isStandardOptions(config.dataSystem!.dataSource)).toEqual(true);
     expect(logger(config).getCount()).toEqual(0);
   });
+
+  // The FDv1 Fallback Synchronizer is server-directed: callers configure it via
+  // `dataSystem.fdv1Fallback`, and the Configuration must surface the value unchanged so
+  // LDClientImpl can wire it up.
+  it('passes through the fdv1Fallback configuration', () => {
+    const config = new Configuration(
+      withLogger({
+        dataSystem: {
+          dataSource: { dataSourceOptionsType: 'standard' },
+          fdv1Fallback: { baseUri: 'https://fallback.example', pollInterval: 60 },
+        },
+      }),
+    );
+    expect(config.dataSystem!.fdv1Fallback).toEqual({
+      baseUri: 'https://fallback.example',
+      pollInterval: 60,
+    });
+  });
+
+  // Setting fdv1Fallback to null is the documented way to disable the FDv1 fallback. The
+  // Configuration must preserve the null so LDClientImpl can skip wiring the synchronizer.
+  it('preserves a null fdv1Fallback so the FDv1 fallback synchronizer can be opted out', () => {
+    const config = new Configuration(
+      withLogger({
+        dataSystem: {
+          dataSource: { dataSourceOptionsType: 'standard' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          fdv1Fallback: null as any,
+        },
+      }),
+    );
+    expect(config.dataSystem!.fdv1Fallback).toBeNull();
+  });
 });

--- a/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
+++ b/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
@@ -505,4 +505,83 @@ describe('when setting different options', () => {
     );
     expect(config.dataSystem!.fdv1Fallback).toBeNull();
   });
+
+  // Misconfiguration: fdv1Fallback is not an object. The validator must drop the value
+  // (so the SDK falls back to defaults) and warn so the misconfiguration is visible.
+  it('drops fdv1Fallback and warns when it is not an object', () => {
+    const opts = withLogger({
+      dataSystem: {
+        dataSource: { dataSourceOptionsType: 'standard' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fdv1Fallback: 'not an object' as any,
+      },
+    });
+    const config = new Configuration(opts);
+    expect(config.dataSystem!.fdv1Fallback).toBeUndefined();
+    logger(opts).expectMessages([
+      {
+        level: LogLevel.Warn,
+        matches: /Config option "dataSystem.fdv1Fallback" should be of type FDv1FallbackConfiguration/,
+      },
+    ]);
+  });
+
+  // Misconfiguration: a field on fdv1Fallback has the wrong type. The validator must drop
+  // that field and warn, while preserving any valid sibling fields.
+  it('drops fdv1Fallback fields with the wrong type and preserves valid siblings', () => {
+    const opts = withLogger({
+      dataSystem: {
+        dataSource: { dataSourceOptionsType: 'standard' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fdv1Fallback: { baseUri: 42 as any, pollInterval: 60 },
+      },
+    });
+    const config = new Configuration(opts);
+    expect(config.dataSystem!.fdv1Fallback).toEqual({ pollInterval: 60 });
+    logger(opts).expectMessages([
+      {
+        level: LogLevel.Warn,
+        matches: /Config option "dataSystem.fdv1Fallback.baseUri" should be of type string/,
+      },
+    ]);
+  });
+
+  // Misconfiguration: fdv1Fallback.pollInterval below the minimum. The validator must
+  // clamp it to the minimum and warn.
+  it('clamps fdv1Fallback.pollInterval to the minimum and warns when below it', () => {
+    const opts = withLogger({
+      dataSystem: {
+        dataSource: { dataSourceOptionsType: 'standard' },
+        fdv1Fallback: { pollInterval: 5 },
+      },
+    });
+    const config = new Configuration(opts);
+    expect(config.dataSystem!.fdv1Fallback).toEqual({ pollInterval: 30 });
+    logger(opts).expectMessages([
+      {
+        level: LogLevel.Warn,
+        matches: /Config option "dataSystem.fdv1Fallback.pollInterval".*minimum/,
+      },
+    ]);
+  });
+
+  // Misconfiguration: an unknown field on fdv1Fallback. The validator must warn so typos
+  // surface during development.
+  it('warns about unknown fdv1Fallback fields', () => {
+    const opts = withLogger({
+      dataSystem: {
+        dataSource: { dataSourceOptionsType: 'standard' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fdv1Fallback: { baseUri: 'https://fallback.example', bogus: 'value' } as any,
+      },
+    });
+    const config = new Configuration(opts);
+    expect(config.dataSystem!.fdv1Fallback).toEqual({ baseUri: 'https://fallback.example' });
+    logger(opts).expectMessages([
+      {
+        level: LogLevel.Warn,
+        matches: /Ignoring unknown config option "dataSystem.fdv1Fallback.bogus"/,
+      },
+    ]);
+  });
 });

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -14,6 +14,7 @@ import {
   LDPluginEnvironmentMetadata,
   LDTimeoutError,
   Platform,
+  ServiceEndpoints,
   subsystem,
   TypeValidators,
 } from '@launchdarkly/js-sdk-common';
@@ -439,16 +440,43 @@ function constructFDv2(
       }
     }
 
-    // This is short term handling and will be removed once FDv2 adoption is sufficient.
-    fdv1FallbackSynchronizers.push(
-      () =>
-        new PollingProcessorFDv2(
-          new Requestor(config, platform.requests, baseHeaders, '/sdk/latest-all', config.logger),
-          config.pollInterval ?? DEFAULT_POLL_INTERVAL,
-          config.logger,
-          true,
-        ),
-    );
+    // FDv1 Fallback Synchronizer: engaged only in response to a server-directed FDv1
+    // Fallback Directive (the `x-ld-fd-fallback: true` response header). When configured
+    // explicitly via `dataSystem.fdv1Fallback`, those values take precedence over the
+    // top-level baseUri/pollInterval. Setting `dataSystem.fdv1Fallback` to `null` leaves
+    // the SDK without an FDv1 fallback so the data source terminates on the directive.
+    const fdv1FallbackConfig = dataSystem.fdv1Fallback;
+    if (fdv1FallbackConfig !== null) {
+      const fdv1FallbackPollInterval =
+        fdv1FallbackConfig?.pollInterval ?? config.pollInterval ?? DEFAULT_POLL_INTERVAL;
+      const fdv1FallbackEndpoints = fdv1FallbackConfig?.baseUri
+        ? new ServiceEndpoints(
+            config.serviceEndpoints.streaming,
+            fdv1FallbackConfig.baseUri,
+            config.serviceEndpoints.events,
+            config.serviceEndpoints.analyticsEventPath,
+            config.serviceEndpoints.diagnosticEventPath,
+            config.serviceEndpoints.includeAuthorizationHeader,
+            config.serviceEndpoints.payloadFilterKey,
+          )
+        : undefined;
+      fdv1FallbackSynchronizers.push(
+        () =>
+          new PollingProcessorFDv2(
+            new Requestor(
+              config,
+              platform.requests,
+              baseHeaders,
+              '/sdk/latest-all',
+              config.logger,
+              fdv1FallbackEndpoints,
+            ),
+            fdv1FallbackPollInterval,
+            config.logger,
+            true,
+          ),
+      );
+    }
 
     dataSource = new CompositeDataSource(
       initializers,

--- a/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
+++ b/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
@@ -68,6 +68,34 @@ export interface LDDataSystemOptions {
    * store integration) that is populated by the relay. By default, this is false.
    */
   useLdd?: boolean;
+
+  /**
+   * Configuration for the SDK's FDv1 Fallback Synchronizer.
+   *
+   * The FDv1 Fallback Synchronizer is engaged only in response to a server-directed FDv1
+   * Fallback Directive (the `x-ld-fd-fallback: true` response header) -- it is independent
+   * of the FDv2 initializer/synchronizer chain configured via {@link dataSource}.
+   *
+   * If omitted, the SDK uses sensible defaults derived from the rest of the configuration.
+   * If explicitly set to `null` or `false`, no FDv1 fallback synchronizer is configured and
+   * the SDK will transition to a terminal Closed state when the directive is received.
+   */
+  fdv1Fallback?: FDv1FallbackConfiguration;
+}
+
+/**
+ * Configuration options for the FDv1 Fallback Synchronizer.
+ */
+export interface FDv1FallbackConfiguration {
+  /**
+   * Override the polling base URI used by the FDv1 Fallback Synchronizer. Defaults to the
+   * SDK's configured polling base URI.
+   */
+  baseUri?: string;
+  /**
+   * The interval between polls, in seconds. Defaults to the SDK's configured pollInterval.
+   */
+  pollInterval?: number;
 }
 
 export type DataSourceOptions =

--- a/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
+++ b/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
@@ -77,10 +77,10 @@ export interface LDDataSystemOptions {
    * of the FDv2 initializer/synchronizer chain configured via {@link dataSource}.
    *
    * If omitted, the SDK uses sensible defaults derived from the rest of the configuration.
-   * If explicitly set to `null` or `false`, no FDv1 fallback synchronizer is configured and
-   * the SDK will transition to a terminal Closed state when the directive is received.
+   * If explicitly set to `null`, no FDv1 fallback synchronizer is configured and the SDK
+   * will transition to a terminal Closed state when the directive is received.
    */
-  fdv1Fallback?: FDv1FallbackConfiguration;
+  fdv1Fallback?: FDv1FallbackConfiguration | null;
 }
 
 /**

--- a/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDFeatureRequestor.ts
@@ -3,14 +3,17 @@
  *
  * The client uses this internally to retrieve feature flags from LaunchDarkly.
  *
- * @param cb The callback with error or information from the response if successful
+ * @param cb The callback invoked with the result of the request. The fourth argument,
+ * `fallbackToFDv1`, is `true` when the response carried the `x-ld-fd-fallback: true`
+ * header, regardless of whether the response was otherwise successful. Callers must
+ * apply any accompanying body/headers before honoring the fallback signal.
  * @param queryParams Additional query params that will be included with the request. Values passed into this
  * function should already be encoded as this function will not perform encoding.
  * @ignore
  */
 export interface LDFeatureRequestor {
   requestAllData: (
-    cb: (err: any, body: any, headers: any) => void,
+    cb: (err: any, body: any, headers: any, fallbackToFDv1?: boolean) => void,
     queryParams?: { key: string; value: string }[],
   ) => void;
 }

--- a/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
@@ -109,18 +109,28 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
 
         statusCallback(subsystemCommon.DataSourceState.Valid);
 
+        // When the fallback directive rides along on a 200 response with a valid payload,
+        // the directive must be applied atomically with the data callback. CompositeData-
+        // Source disables its callback handler as soon as basis-during-init arrives, so a
+        // separate status callback emitted afterwards would be silently dropped. Instead,
+        // attach a fallbackToFDv1 marker to the data object: CompositeDataSource will swap
+        // its synchronizer list to FDv1 before resolving the switchToSync transition.
         payloadProcessor.addPayloadListener((payload) => {
-          dataCallback(payload.type === 'full', { initMetadata, payload });
+          const data: { initMetadata: any; payload: any; fallbackToFDv1?: boolean } = {
+            initMetadata,
+            payload,
+          };
+          if (fallbackToFDv1) {
+            data.fallbackToFDv1 = true;
+            this._logger?.warn(`Response header indicates to fallback to FDv1`);
+          }
+          dataCallback(payload.type === 'full', data);
         });
 
         payloadProcessor.processEvents(parsed.events);
 
-        // Any accompanying payload has been applied. Honor the fallback directive (if any)
-        // before declaring the initializer Closed so the composite swaps to FDv1.
-        if (fallbackToFDv1) {
-          emitFallback();
-          return;
-        }
+        // The fallback directive (if any) was already attached to the data callback above,
+        // so CompositeDataSource has already taken over the transition. Just close out.
         statusCallback(subsystemCommon.DataSourceState.Closed);
       } catch (parseError: any) {
         // We could not parse this JSON. Report the problem.
@@ -128,7 +138,8 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
         this._logger?.debug(`${parseError} - Body follows: ${body}`);
         if (fallbackToFDv1) {
           // Even when the accompanying body could not be parsed, the directive must still
-          // be honored so we don't get stuck retrying FDv2 indefinitely.
+          // be honored so we don't get stuck retrying FDv2 indefinitely. No payload was
+          // applied here so we can use the status callback path safely.
           emitFallback();
           return;
         }

--- a/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
@@ -99,6 +99,15 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
             },
           },
           (errorKind: DataSourceErrorKind, message: string) => {
+            // If a per-event error fires while the fallback directive is in flight, route it
+            // through the LDFlagDeliveryFallbackError path so CompositeDataSource still
+            // engages FDv1. Otherwise the directive would be lost: the composite's status
+            // handler would treat the LDPollingError as an ordinary failure and fall through
+            // to the next FDv2 source.
+            if (fallbackToFDv1) {
+              emitFallback();
+              return;
+            }
             statusCallback(
               subsystemCommon.DataSourceState.Interrupted,
               new LDPollingError(errorKind, message),

--- a/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/OneShotInitializerFDv2.ts
@@ -2,6 +2,7 @@ import {
   DataSourceErrorKind,
   httpErrorMessage,
   internal,
+  LDFlagDeliveryFallbackError,
   LDLogger,
   LDPollingError,
   subsystem as subsystemCommon,
@@ -30,12 +31,33 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
     statusCallback(subsystemCommon.DataSourceState.Initializing);
 
     this._logger?.debug('Performing initialization request to LaunchDarkly for feature flag data.');
-    this._requestor.requestAllData((err, body, headers) => {
+    this._requestor.requestAllData((err, body, headers, fallbackToFDv1) => {
       if (this._stopped) {
         return;
       }
 
+      // Helper used to emit the FDv1 fallback signal once any accompanying payload has been
+      // applied. Callers should `return` immediately after invoking it.
+      const emitFallback = () => {
+        const status = err?.status;
+        const message = err
+          ? httpErrorMessage(err, 'initializer', 'falling back to FDv1')
+          : `Response header indicates to fallback to FDv1`;
+        this._logger?.warn(message);
+        statusCallback(
+          subsystemCommon.DataSourceState.Closed,
+          new LDFlagDeliveryFallbackError(DataSourceErrorKind.ErrorResponse, message, status),
+        );
+      };
+
       if (err) {
+        // An error response can still carry the fallback directive. Emit the directive in
+        // that case so the CompositeDataSource can hand off to the FDv1 synchronizer.
+        if (fallbackToFDv1) {
+          emitFallback();
+          return;
+        }
+
         const { status } = err;
         const message = httpErrorMessage(err, 'initializer', 'initializer does not retry');
         this._logger?.error(message);
@@ -47,6 +69,10 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
       }
 
       if (!body) {
+        if (fallbackToFDv1) {
+          emitFallback();
+          return;
+        }
         statusCallback(
           subsystemCommon.DataSourceState.Closed,
           new LDPollingError(
@@ -89,11 +115,23 @@ export default class OneShotInitializerFDv2 implements subsystemCommon.DataSourc
 
         payloadProcessor.processEvents(parsed.events);
 
+        // Any accompanying payload has been applied. Honor the fallback directive (if any)
+        // before declaring the initializer Closed so the composite swaps to FDv1.
+        if (fallbackToFDv1) {
+          emitFallback();
+          return;
+        }
         statusCallback(subsystemCommon.DataSourceState.Closed);
-      } catch (error: any) {
+      } catch (parseError: any) {
         // We could not parse this JSON. Report the problem.
         this._logger?.error('Response contained invalid data');
-        this._logger?.debug(`${err} - Body follows: ${body}`);
+        this._logger?.debug(`${parseError} - Body follows: ${body}`);
+        if (fallbackToFDv1) {
+          // Even when the accompanying body could not be parsed, the directive must still
+          // be honored so we don't get stuck retrying FDv2 indefinitely.
+          emitFallback();
+          return;
+        }
         statusCallback(
           subsystemCommon.DataSourceState.Closed,
           new LDPollingError(DataSourceErrorKind.InvalidData, 'Malformed data in polling response'),

--- a/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
@@ -73,7 +73,7 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
 
     const startTime = Date.now();
     this._logger?.debug('Polling LaunchDarkly for feature flag updates');
-    this._requestor.requestAllData((err, body, headers) => {
+    this._requestor.requestAllData((err, body, headers, fallbackToFDv1) => {
       if (this._stopped) {
         return;
       }
@@ -81,17 +81,33 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
       const elapsed = Date.now() - startTime;
       const sleepFor = Math.max(this._pollInterval * 1000 - elapsed, 0);
 
+      // Helper to emit the terminal FDv1 fallback signal. Callers must `return` after
+      // invoking this; no further poll is scheduled.
+      const emitFallback = () => {
+        const fallbackErr =
+          err instanceof LDFlagDeliveryFallbackError
+            ? err
+            : new LDFlagDeliveryFallbackError(
+                DataSourceErrorKind.ErrorResponse,
+                err
+                  ? httpErrorMessage(err, 'polling request', 'falling back to FDv1')
+                  : `Response header indicates to fallback to FDv1`,
+                err?.status,
+              );
+        this._logger?.warn(fallbackErr.message);
+        statusCallback(subsystemCommon.DataSourceState.Closed, fallbackErr);
+      };
+
       this._logger?.debug('Elapsed: %d ms, sleeping for %d ms', elapsed, sleepFor);
       if (err) {
-        const { status } = err;
-        // this is a short term error and will be removed once FDv2 adoption is sufficient.
-        if (err instanceof LDFlagDeliveryFallbackError) {
-          this._logger?.error(err.message);
-          statusCallback(subsystemCommon.DataSourceState.Closed, err);
-          // It is not recoverable, return and do not trigger another poll.
+        // The fallback directive can ride along on either an error or a successful response.
+        // Honor it before any other error handling so we always switch to FDv1 when asked.
+        if (fallbackToFDv1 || err instanceof LDFlagDeliveryFallbackError) {
+          emitFallback();
           return;
         }
 
+        const { status } = err;
         if (status && !isHttpRecoverable(status)) {
           const message = httpErrorMessage(err, 'polling request');
           this._logger?.error(message);
@@ -170,6 +186,14 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
             ),
           );
         }
+      }
+
+      // The fallback directive may ride along on a successful response. Apply the payload
+      // first (above) so evaluations can serve the server-provided data, then switch to
+      // FDv1 instead of scheduling another poll.
+      if (fallbackToFDv1) {
+        emitFallback();
+        return;
       }
 
       // schedule poll

--- a/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
@@ -148,6 +148,15 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
               },
             },
             (errorKind: DataSourceErrorKind, message: string) => {
+              // If a per-event error fires while the fallback directive is in flight, route
+              // it through the LDFlagDeliveryFallbackError path so CompositeDataSource still
+              // engages FDv1. Otherwise the directive would be lost: the composite's status
+              // handler would treat the LDPollingError as an ordinary failure and fall
+              // through to the next FDv2 source.
+              if (fallbackToFDv1) {
+                emitFallback();
+                return;
+              }
               statusCallback(
                 subsystemCommon.DataSourceState.Interrupted,
                 new LDPollingError(errorKind, message),

--- a/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/PollingProcessorFDv2.ts
@@ -156,8 +156,23 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
             this._logger,
           );
 
+          // When the fallback directive rides along on a 200 response with a valid payload,
+          // the directive must be applied atomically with the data callback. CompositeData-
+          // Source disables its callback handler as soon as basis-during-init arrives or an
+          // error status is reported, so a separate status callback emitted afterwards
+          // would be silently dropped. Instead, attach a fallbackToFDv1 marker to the data
+          // object: CompositeDataSource will swap its synchronizer list to FDv1 before
+          // resolving the switchToSync transition.
           payloadProcessor.addPayloadListener((payload) => {
-            dataCallback(payload.type === 'full', { initMetadata, payload });
+            const data: { initMetadata: any; payload: any; fallbackToFDv1?: boolean } = {
+              initMetadata,
+              payload,
+            };
+            if (fallbackToFDv1) {
+              data.fallbackToFDv1 = true;
+              this._logger?.warn(`Response header indicates to fallback to FDv1`);
+            }
+            dataCallback(payload.type === 'full', data);
           });
 
           this._logger?.debug(`Got body: ${body}`);
@@ -172,12 +187,30 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
             processFDv1FlagsAndSegments(payloadProcessor, parsed);
           }
 
+          // The fallback directive (if any) was attached to the data callback above so
+          // CompositeDataSource has already taken over the transition. Skip the Valid
+          // status report and the next-poll scheduling in that case.
+          if (fallbackToFDv1) {
+            return;
+          }
+
           statusCallback(subsystemCommon.DataSourceState.Valid);
         } catch {
           // We could not parse this JSON. Report the problem and fallthrough to
           // start another poll.
           this._logger?.error('Response contained invalid data');
           this._logger?.debug(`${err} - Body follows: ${body}`);
+
+          // The fallback directive must be honored even when the body could not be parsed.
+          // Emit it BEFORE the generic Interrupted/LDPollingError status callback below --
+          // CompositeDataSource disables its callback handler on the first error status,
+          // so the LDFlagDeliveryFallbackError must be emitted first or the directive is
+          // silently dropped and the SDK retries FDv2 sources.
+          if (fallbackToFDv1) {
+            emitFallback();
+            return;
+          }
+
           statusCallback(
             subsystemCommon.DataSourceState.Interrupted,
             new LDPollingError(
@@ -186,12 +219,8 @@ export default class PollingProcessorFDv2 implements subsystemCommon.DataSource 
             ),
           );
         }
-      }
-
-      // The fallback directive may ride along on a successful response. Apply the payload
-      // first (above) so evaluations can serve the server-provided data, then switch to
-      // FDv1 instead of scheduling another poll.
-      if (fallbackToFDv1) {
+      } else if (fallbackToFDv1) {
+        // 200/304 with no body but a fallback directive: emit the directive directly.
         emitFallback();
         return;
       }

--- a/packages/shared/sdk-server/src/data_sources/Requestor.ts
+++ b/packages/shared/sdk-server/src/data_sources/Requestor.ts
@@ -34,9 +34,10 @@ export default class Requestor implements LDFeatureRequestor {
     baseHeaders: LDHeaders,
     private readonly _path: string = '/sdk/latest-all',
     private readonly _logger?: LDLogger,
+    serviceEndpointsOverride?: ServiceEndpoints,
   ) {
     this._headers = { ...baseHeaders };
-    this._serviceEndpoints = config.serviceEndpoints;
+    this._serviceEndpoints = serviceEndpointsOverride ?? config.serviceEndpoints;
   }
 
   /**
@@ -74,7 +75,7 @@ export default class Requestor implements LDFeatureRequestor {
   }
 
   async requestAllData(
-    cb: (err: any, body: any, headers: any) => void,
+    cb: (err: any, body: any, headers: any, fallbackToFDv1?: boolean) => void,
     queryParams: { key: string; value: string }[] = [],
   ) {
     const options: Options = {
@@ -89,30 +90,35 @@ export default class Requestor implements LDFeatureRequestor {
       const { res, body } = await this._requestWithETagCache(uri, options);
       this._logger?.debug(`Requestor got (possibly cached) body: ${JSON.stringify(body)}`);
 
-      if (res.headers.get(`x-ld-fd-fallback`) === `true`) {
-        const err = new LDFlagDeliveryFallbackError(
-          DataSourceErrorKind.ErrorResponse,
-          `Response header indicates to fallback to FDv1.`,
-          res.status,
-        );
-        return cb(err, undefined, undefined);
-      }
+      // Per the FDv2 spec, x-ld-fd-fallback signals that the SDK should switch to FDv1
+      // for the remainder of the lifetime. The signal can ride along on either a successful
+      // response or an error response -- in both cases callers must apply any accompanying
+      // payload before honoring the directive.
+      const fallbackToFDv1 = res.headers.get(`x-ld-fd-fallback`) === `true`;
+      const responseHeaders = Object.fromEntries(res.headers.entries());
 
       if (res.status !== 200 && res.status !== 304) {
-        const err = new LDPollingError(
-          DataSourceErrorKind.ErrorResponse,
-          `Unexpected status code: ${res.status}`,
-          res.status,
-        );
-        return cb(err, undefined, undefined);
+        const err = fallbackToFDv1
+          ? new LDFlagDeliveryFallbackError(
+              DataSourceErrorKind.ErrorResponse,
+              `Response header indicates to fallback to FDv1.`,
+              res.status,
+            )
+          : new LDPollingError(
+              DataSourceErrorKind.ErrorResponse,
+              `Unexpected status code: ${res.status}`,
+              res.status,
+            );
+        return cb(err, undefined, responseHeaders, fallbackToFDv1);
       }
       return cb(
         undefined,
         res.status === 304 ? null : body,
-        Object.fromEntries(res.headers.entries()),
+        responseHeaders,
+        fallbackToFDv1,
       );
     } catch (err) {
-      return cb(err, undefined, undefined);
+      return cb(err, undefined, undefined, false);
     }
   }
 }

--- a/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
@@ -150,10 +150,24 @@ export default class StreamingProcessorFDv2 implements subsystemCommon.DataSourc
         },
       },
       (errorKind: DataSourceErrorKind, message: string) => {
-        statusCallback(
-          subsystemCommon.DataSourceState.Interrupted,
-          new LDStreamingError(errorKind, message),
-        );
+        // If a parse error fires while the fallback directive is in flight, route it
+        // through the LDFlagDeliveryFallbackError path so CompositeDataSource still engages
+        // FDv1. Otherwise the directive would be lost: the composite's status handler would
+        // treat the LDStreamingError as an ordinary failure and fall through to the next
+        // FDv2 source.
+        if (fallbackRequested) {
+          const fallbackErr = new LDFlagDeliveryFallbackError(
+            DataSourceErrorKind.ErrorResponse,
+            `Response header indicates to fallback to FDv1`,
+          );
+          this._logger?.warn(fallbackErr.message);
+          statusCallback(subsystemCommon.DataSourceState.Closed, fallbackErr);
+        } else {
+          statusCallback(
+            subsystemCommon.DataSourceState.Interrupted,
+            new LDStreamingError(errorKind, message),
+          );
+        }
 
         // parsing error was encountered, defensively close the data source
         this.stop();

--- a/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
@@ -162,19 +162,26 @@ export default class StreamingProcessorFDv2 implements subsystemCommon.DataSourc
     );
     payloadReader.addPayloadListener((payload) => {
       this._logConnectionResult(true);
-      dataCallback(payload.type === 'full', { initMetadata: this._initMetadata, payload });
 
       // The server may signal FDv1 fallback alongside a valid streaming payload via the
-      // response headers on the initial connection. Apply the payload first (above) so
-      // evaluations can serve the server-provided data, then surface the directive so the
-      // CompositeDataSource can switch to the FDv1 synchronizer.
+      // response headers on the initial connection. Attach a fallbackToFDv1 marker to the
+      // data callback so the directive is delivered atomically with the payload --
+      // CompositeDataSource will swap its synchronizer list to FDv1 before resolving the
+      // switchToSync transition. A separate status callback after the data callback would
+      // be silently dropped because the basis-during-init auto-transition disables the
+      // composite's callback handler.
+      const data: { initMetadata: any; payload: any; fallbackToFDv1?: boolean } = {
+        initMetadata: this._initMetadata,
+        payload,
+      };
       if (fallbackRequested) {
-        const fallbackErr = new LDFlagDeliveryFallbackError(
-          DataSourceErrorKind.ErrorResponse,
-          `Response header indicates to fallback to FDv1`,
-        );
-        this._logger?.warn(fallbackErr.message);
-        statusCallback(subsystemCommon.DataSourceState.Closed, fallbackErr);
+        data.fallbackToFDv1 = true;
+        this._logger?.warn(`Response header indicates to fallback to FDv1`);
+      }
+      dataCallback(payload.type === 'full', data);
+
+      if (fallbackRequested) {
+        // Stop consuming the FDv2 stream now that the directive has been delivered.
         this.stop();
       }
     });

--- a/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
+++ b/packages/shared/sdk-server/src/data_sources/StreamingProcessorFDv2.ts
@@ -124,6 +124,11 @@ export default class StreamingProcessorFDv2 implements subsystemCommon.DataSourc
     const uri = getStreamingUri(this._serviceEndpoints, this._streamUriPath, params);
     this._logger?.debug(`Streaming processor opening event source to uri: ${uri}`);
 
+    // Set when the most recent successful connection carried `x-ld-fd-fallback: true`. We
+    // finish applying the next payload before emitting the fallback signal so evaluations
+    // can serve the server-provided data while the FDv1 synchronizer takes over.
+    let fallbackRequested = false;
+
     const eventSource = this._requests.createEventSource(uri, {
       headers: this._headers,
       errorFilter: (error: HttpErrorResponse) => this._retryAndHandleError(error, statusCallback),
@@ -158,6 +163,20 @@ export default class StreamingProcessorFDv2 implements subsystemCommon.DataSourc
     payloadReader.addPayloadListener((payload) => {
       this._logConnectionResult(true);
       dataCallback(payload.type === 'full', { initMetadata: this._initMetadata, payload });
+
+      // The server may signal FDv1 fallback alongside a valid streaming payload via the
+      // response headers on the initial connection. Apply the payload first (above) so
+      // evaluations can serve the server-provided data, then surface the directive so the
+      // CompositeDataSource can switch to the FDv1 synchronizer.
+      if (fallbackRequested) {
+        const fallbackErr = new LDFlagDeliveryFallbackError(
+          DataSourceErrorKind.ErrorResponse,
+          `Response header indicates to fallback to FDv1`,
+        );
+        this._logger?.warn(fallbackErr.message);
+        statusCallback(subsystemCommon.DataSourceState.Closed, fallbackErr);
+        this.stop();
+      }
     });
 
     eventSource.onclose = () => {
@@ -172,6 +191,11 @@ export default class StreamingProcessorFDv2 implements subsystemCommon.DataSourc
     eventSource.onopen = (e) => {
       this._logger?.info('Opened LaunchDarkly stream connection');
       this._initMetadata = internal.initMetadataFromHeaders(e.headers);
+      // The fallback signal is captured here from the connection-open response headers and
+      // is honored by the payload listener above once the next payload has been applied.
+      if (e.headers?.[`x-ld-fd-fallback`] === `true`) {
+        fallbackRequested = true;
+      }
       statusCallback(subsystemCommon.DataSourceState.Valid);
     };
 

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -16,6 +16,7 @@ import { LDBigSegmentsOptions, LDOptions, LDProxyOptions, LDTLSOptions } from '.
 import { Hook } from '../api/integrations';
 import {
   DataSourceOptions,
+  FDv1FallbackConfiguration,
   isCustomOptions,
   isPollingOnlyOptions,
   isStandardOptions,
@@ -271,6 +272,7 @@ export interface DataSystemConfiguration {
   dataSource?: DataSourceOptions;
   featureStoreFactory: (clientContext: LDClientContext) => LDTransactionalFeatureStore;
   useLdd?: boolean;
+  fdv1Fallback?: FDv1FallbackConfiguration;
 }
 
 /**
@@ -381,6 +383,7 @@ export default class Configuration {
       this.dataSystem = {
         dataSource: validatedDSOptions.dataSource,
         useLdd: validatedDSOptions.useLdd,
+        fdv1Fallback: validatedDSOptions.fdv1Fallback,
         // @ts-ignore
         featureStoreFactory: (clientContext) => {
           if (validatedDSOptions.persistentStore === undefined) {

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -203,6 +203,62 @@ function validateEndpoints(options: LDOptions, validatedOptions: Options) {
   }
 }
 
+// Validators for fields inside dataSystem.fdv1Fallback. baseUri is an arbitrary string
+// (the polling endpoint URI) and pollInterval reuses the same minimum as the top-level
+// pollInterval option.
+const fdv1FallbackValidations: Record<string, TypeValidator> = {
+  baseUri: TypeValidators.String,
+  pollInterval: TypeValidators.numberWithMin(30),
+};
+
+function validateFDv1FallbackOptions(
+  options: FDv1FallbackConfiguration,
+): {
+  errors: string[];
+  validatedOptions: FDv1FallbackConfiguration;
+} {
+  const errors: string[] = [];
+  const validatedOptions: { [k: string]: any } = {};
+
+  Object.keys(options).forEach((optionName) => {
+    const optionValue = (options as { [k: string]: any })[optionName];
+    const validator = fdv1FallbackValidations[optionName];
+    if (!validator) {
+      // Unknown field on the fdv1Fallback object: drop it and warn so misconfigurations
+      // surface during development.
+      errors.push(OptionMessages.unknownOption(`dataSystem.fdv1Fallback.${optionName}`));
+      return;
+    }
+    if (!validator.is(optionValue)) {
+      if (validator instanceof NumberWithMinimum && TypeValidators.Number.is(optionValue)) {
+        const { min } = validator as NumberWithMinimum;
+        errors.push(
+          OptionMessages.optionBelowMinimum(
+            `dataSystem.fdv1Fallback.${optionName}`,
+            optionValue,
+            min,
+          ),
+        );
+        validatedOptions[optionName] = min;
+      } else {
+        errors.push(
+          OptionMessages.wrongOptionType(
+            `dataSystem.fdv1Fallback.${optionName}`,
+            validator.getType(),
+            typeof optionValue,
+          ),
+        );
+        // Drop the invalid value so the SDK falls back to defaults derived from the
+        // top-level configuration.
+      }
+    } else {
+      validatedOptions[optionName] = optionValue;
+    }
+  });
+
+  return { errors, validatedOptions: validatedOptions as FDv1FallbackConfiguration };
+}
+
 function validateDataSystemOptions(options: Options): {
   errors: string[];
   validatedOptions: Options;
@@ -219,6 +275,30 @@ function validateDataSystemOptions(options: Options): {
         typeof options.persistentStore,
       ),
     );
+  }
+
+  // fdv1Fallback may be: undefined (use defaults), null (opt out so the data source
+  // terminates on the directive), or an FDv1FallbackConfiguration object. Validate the
+  // fields of the object form; preserve null and undefined.
+  if (options.fdv1Fallback !== undefined && options.fdv1Fallback !== null) {
+    if (TypeValidators.Object.is(options.fdv1Fallback)) {
+      const { errors: fbErrors, validatedOptions: fbValidated } = validateFDv1FallbackOptions(
+        options.fdv1Fallback as FDv1FallbackConfiguration,
+      );
+      validatedOptions.fdv1Fallback = fbValidated;
+      allErrors.push(...fbErrors);
+    } else {
+      // Anything else (string, number, etc) is a misconfiguration. Drop it so the SDK
+      // falls back to default FDv1 fallback behavior.
+      validatedOptions.fdv1Fallback = undefined;
+      allErrors.push(
+        OptionMessages.wrongOptionType(
+          'dataSystem.fdv1Fallback',
+          'FDv1FallbackConfiguration',
+          typeof options.fdv1Fallback,
+        ),
+      );
+    }
   }
 
   if (options.dataSource) {
@@ -272,7 +352,7 @@ export interface DataSystemConfiguration {
   dataSource?: DataSourceOptions;
   featureStoreFactory: (clientContext: LDClientContext) => LDTransactionalFeatureStore;
   useLdd?: boolean;
-  fdv1Fallback?: FDv1FallbackConfiguration;
+  fdv1Fallback?: FDv1FallbackConfiguration | null;
 }
 
 /**

--- a/packages/tooling/contract-test-utils/src/types/ConfigParams.ts
+++ b/packages/tooling/contract-test-utils/src/types/ConfigParams.ts
@@ -158,5 +158,6 @@ export interface SDKDataSystemInitializerParams {
 export interface SDKDataSystemParams {
   initializers?: SDKDataSystemInitializerParams[];
   synchronizers?: SDKDataSystemSynchronizerParams[];
+  fdv1Fallback?: SDKDataSourcePollingParams;
   payloadFilter?: string;
 }


### PR DESCRIPTION
## Summary

- `OneShotInitializerFDv2` now applies any payload that arrives with `X-LD-FD-Fallback: true` before surfacing `LDFlagDeliveryFallbackError` (previously the directive was wrapped as a generic `LDPollingError` and silently dropped). `Requestor` propagates the directive to its callback so it rides along on 2xx, 3xx, and error responses.
- `CompositeDataSource` reacts to `LDFlagDeliveryFallbackError` immediately: it skips remaining initializers and FDv2 synchronizers, switches to the FDv1 fallback synchronizer without backoff, and transitions to a terminal Closed state when no FDv1 fallback is configured. `PollingProcessorFDv2` and `StreamingProcessorFDv2` honor the directive on success-paths the same way they already did on errors.
- Adds first-class `dataSystem.fdv1Fallback` config (optional `baseUri` + `pollInterval`) and wires it to the SDK's FDv1 fallback synchronizer in `LDClientImpl`. Contract test service declares the `fdv1-fallback` capability and accepts the new config object directly (no longer inferring it from the last synchronizer entry).

Mirrors the Go reference change in [go-server-sdk#365](https://github.com/launchdarkly/go-server-sdk/pull/365) and contract-test wiring in [go-server-sdk#368](https://github.com/launchdarkly/go-server-sdk/pull/368). Spec rationale lives in [sdk-specs#155](https://github.com/launchdarkly/sdk-specs/pull/155); the new harness suite is in [sdk-test-harness#336](https://github.com/launchdarkly/sdk-test-harness/pull/336).

## Test plan

- [x] `js-sdk-common`: 466/466 pass.
- [x] `js-server-sdk-common`: 979 pass / 5 pre-existing skips.
- [x] `node-server-sdk`: 63/63 pass.
- [x] `js-client-sdk-common`: 800/800 pass (regression check; sdk-client uses its own FDv2 implementation).
- [x] New deterministic tests for fallback on initializer success-with-payload, error, malformed body, polling success, streaming `onopen`, composite-level skip-and-switch, and `null` fdv1Fallback config.
- [ ] Contract-test workflow against `feat/fdv2` runs the new "FDv1 Fallback Directive" suite cleanly in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core data-source failover behavior and request handling to honor the server-directed `x-ld-fd-fallback` directive, which could affect initialization/streaming/polling transitions and retry/backoff behavior if incorrect. Covered by extensive new unit tests, but it still touches critical flag delivery paths.
> 
> **Overview**
> Ensures the server-side Node SDK **immediately honors the server-directed FDv1 fallback directive** (`x-ld-fd-fallback: true`) even during the FDv2 initializer phase, including cases where the directive arrives alongside a valid payload.
> 
> This updates `Requestor` to always surface a `fallbackToFDv1` signal (on success, 304, and error responses), updates FDv2 processors (`OneShotInitializerFDv2`, `PollingProcessorFDv2`, `StreamingProcessorFDv2`) to deliver the directive *atomically* with any payload (via a `fallbackToFDv1` marker) or emit `LDFlagDeliveryFallbackError` on error/parse failures, and updates `CompositeDataSource` to engage FDv1 fallback as a one-way switch (skip remaining initializers/FDv2 syncs, avoid re-engagement loops, bypass backoff only on initial engagement, and terminate if no FDv1 fallback is configured).
> 
> Adds first-class `dataSystem.fdv1Fallback` configuration (optional `baseUri`/`pollInterval`, nullable to opt out), wires it in `LDClientImpl` (including endpoint override support in `Requestor`), and updates contract-test wiring/capabilities plus expands test coverage across all affected components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2770530b7a4adc5726b6038fb9499be1e51e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->