### PR TITLE
ci(react-sdk): remove release version pinning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -281,7 +281,6 @@
       "bump-minor-pre-major": true
     },
     "packages/sdk/react": {
-      "release-as": "4.0.0",
       "extra-files": [
         "src/client/LDReactClient.tsx",
         {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/release automation change that only affects how `release-please` determines the next version for `packages/sdk/react`. Main risk is unintended version bumps if prior manual pinning was relied on.
> 
> **Overview**
> Removes the `release-as: "4.0.0"` override for `packages/sdk/react` in `release-please-config.json`, so `release-please` will no longer force the React SDK to release as 4.0.0 and will instead follow normal version calculation.
> 
> No other package release configuration is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84aa98ee4a11b09ec66225390938c88a66b9fbcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->