### PR TITLE
chore: scaffolding node-client-sdk migration

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,6 +8,7 @@
   "packages/sdk/cloudflare": "2.7.24",
   "packages/sdk/combined-browser": "0.1.22",
   "packages/sdk/fastly": "0.2.14",
+  "packages/sdk/node-client": "0.0.1",
   "packages/sdk/react-native": "10.17.6",
   "packages/sdk/server-ai": "1.0.1",
   "packages/sdk/server-node": "9.11.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "packages/sdk/electron",
     "packages/sdk/electron/example",
     "packages/sdk/electron/contract-tests/entity",
+    "packages/sdk/node-client",
     "packages/sdk/fastly",
     "packages/sdk/fastly/example",
     "packages/sdk/react",

--- a/packages/sdk/node-client/.eslintrc.cjs
+++ b/packages/sdk/node-client/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['contract-tests/**/*.ts'],
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: './contract-tests/tsconfig.json',
+      },
+    },
+  ],
+};

--- a/packages/sdk/node-client/CHANGELOG.md
+++ b/packages/sdk/node-client/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to `@launchdarkly/node-client-sdk` will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).

--- a/packages/sdk/node-client/LICENSE
+++ b/packages/sdk/node-client/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2026 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/sdk/node-client/README.md
+++ b/packages/sdk/node-client/README.md
@@ -1,0 +1,49 @@
+# LaunchDarkly Node.js Client-Side SDK
+
+<!--
+[![NPM][npm-badge]][npm-link]
+[![Actions Status][ci-badge]][ci-link]
+[![Documentation][ghp-badge]][ghp-link]
+[![NPM][npm-dm-badge]][npm-link]
+[![NPM][npm-dt-badge]][npm-link]
+-->
+
+> [!CAUTION]
+> This SDK is experimental and should NOT be considered ready for production use.
+> It may change or be removed without notice and is not subject to backwards
+> compatibility guarantees.
+
+<!--
+> Pin to a specific minor version and review the [changelog](link-to-changelog) before upgrading.
+-->
+
+## Getting started
+
+Refer to the [SDK documentation](https://launchdarkly.com/docs/sdk/client-side/node-js#getting-started) for instructions on getting started with using the SDK.
+
+## About LaunchDarkly
+
+- LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard. With LaunchDarkly, you can:
+  - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+  - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+  - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan).
+  - Disable parts of your application to facilitate maintenance, without taking everything offline.
+- LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+- Explore LaunchDarkly
+  - [launchdarkly.com](https://www.launchdarkly.com/ 'LaunchDarkly Main Website') for more information
+  - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
+  - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
+  - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+
+<!--
+[npm-badge]: https://img.shields.io/npm/v/@launchdarkly/node-client-sdk.svg?style=flat-square
+[npm-link]: https://www.npmjs.com/package/@launchdarkly/node-client-sdk
+[npm-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/node-client-sdk.svg?style=flat-square
+[npm-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/node-client-sdk.svg?style=flat-square
+[ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml/badge.svg
+[ci-link]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml
+[ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/node-client/docs/
+-->

--- a/packages/sdk/node-client/jest.config.json
+++ b/packages/sdk/node-client/jest.config.json
@@ -1,0 +1,8 @@
+{
+  "transform": { "^.+\\.ts?$": "ts-jest" },
+  "testMatch": ["**/__tests__/**/*test.ts?(x)"],
+  "testEnvironment": "node",
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+  "collectCoverageFrom": ["src/**/*.ts"],
+  "testPathIgnorePatterns": ["node_modules", "examples", "dist"]
+}

--- a/packages/sdk/node-client/jest.config.json
+++ b/packages/sdk/node-client/jest.config.json
@@ -1,8 +1,0 @@
-{
-  "transform": { "^.+\\.ts?$": "ts-jest" },
-  "testMatch": ["**/__tests__/**/*test.ts?(x)"],
-  "testEnvironment": "node",
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
-  "collectCoverageFrom": ["src/**/*.ts"],
-  "testPathIgnorePatterns": ["node_modules", "examples", "dist"]
-}

--- a/packages/sdk/node-client/package.json
+++ b/packages/sdk/node-client/package.json
@@ -37,25 +37,14 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "yarn lint --fix",
-    "test": "jest"
-  },
-  "dependencies": {
-    "@launchdarkly/js-client-sdk-common": "1.26.2",
-    "https-proxy-agent": "^7.0.6",
-    "launchdarkly-eventsource": "2.2.0"
+    "lint:fix": "yarn lint --fix"
   },
   "devDependencies": {
-    "@types/jest": "^29.4.0",
-    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.45.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.6.3",
-    "jest": "^29.5.0",
-    "launchdarkly-js-test-helpers": "^2.2.0",
-    "ts-jest": "^29.0.5",
     "tsup": "^8.5.1",
     "typedoc": "0.25.0",
     "typescript": "5.1.6"

--- a/packages/sdk/node-client/package.json
+++ b/packages/sdk/node-client/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@launchdarkly/node-client-sdk",
+  "version": "0.0.1",
+  "description": "LaunchDarkly Client-Side SDK for Node.js",
+  "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/sdk/node-client",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/js-core.git"
+  },
+  "license": "Apache-2.0",
+  "packageManager": "yarn@3.4.1",
+  "keywords": [
+    "launchdarkly",
+    "node",
+    "client",
+    "feature flags",
+    "feature toggles",
+    "feature management"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "yarn lint --fix",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@launchdarkly/js-client-sdk-common": "1.26.2",
+    "https-proxy-agent": "^7.0.6",
+    "launchdarkly-eventsource": "2.2.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "^18.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "eslint": "^8.45.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.6.3",
+    "jest": "^29.5.0",
+    "launchdarkly-js-test-helpers": "^2.2.0",
+    "ts-jest": "^29.0.5",
+    "tsup": "^8.5.1",
+    "typedoc": "0.25.0",
+    "typescript": "5.1.6"
+  }
+}

--- a/packages/sdk/node-client/src/index.ts
+++ b/packages/sdk/node-client/src/index.ts
@@ -1,0 +1,6 @@
+// Placeholder entry point for @launchdarkly/node-client-sdk. The functional
+// implementation (createClient, basicLogger, type re-exports) is added in
+// the source-port slice (SDK-2312); this file exists so the package builds
+// and the version stamp is in place.
+
+export const version = '0.0.1'; // x-release-please-version

--- a/packages/sdk/node-client/tsconfig.eslint.json
+++ b/packages/sdk/node-client/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdk/node-client/tsconfig.json
+++ b/packages/sdk/node-client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "strict": true,
+    "noImplicitOverride": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "stripInternal": true,
+    "moduleResolution": "node"
+  },
+  "exclude": ["**/*.test.ts", "dist", "node_modules", "__tests__", "examples", "contract-tests"]
+}

--- a/packages/sdk/node-client/tsconfig.ref.json
+++ b/packages/sdk/node-client/tsconfig.ref.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "package.json"],
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/sdk/node-client/tsup.config.js
+++ b/packages/sdk/node-client/tsup.config.js
@@ -10,7 +10,6 @@ export default defineConfig([
     splitting: false,
     sourcemap: true,
     clean: true,
-    noExternal: ['@launchdarkly/js-sdk-common', '@launchdarkly/js-client-sdk-common'],
     dts: true,
     metafile: true,
   },

--- a/packages/sdk/node-client/tsup.config.js
+++ b/packages/sdk/node-client/tsup.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: {
+      index: 'src/index.ts',
+    },
+    minify: true,
+    format: ['esm', 'cjs'],
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    noExternal: ['@launchdarkly/js-sdk-common', '@launchdarkly/js-client-sdk-common'],
+    dts: true,
+    metafile: true,
+  },
+]);

--- a/packages/sdk/node-client/typedoc.json
+++ b/packages/sdk/node-client/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -145,6 +145,12 @@
         }
       ]
     },
+    "packages/sdk/node-client": {
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        "src/index.ts"
+      ]
+    },
     "packages/sdk/server-node": {
       "extra-files": [
         "src/platform/NodeInfo.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,9 @@
     },
     {
       "path": "./packages/sdk/openfeature-node-server/tsconfig.ref.json"
+    },
+    {
+      "path": "./packages/sdk/node-client/tsconfig.ref.json"
     }
   ]
 }


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new workspace and release metadata with no runtime SDK behavior or changes to existing packages beyond repo configuration.
> 
> **Overview**
> Introduces **`@launchdarkly/node-client-sdk`** at `packages/sdk/node-client` as the first step of a Node **client-side** SDK migration. The package is wired into the monorepo (root **workspaces**, root **`tsconfig` project reference**, **`.release-please-manifest`** at `0.0.1`, and **`release-please-config`** with `bump-minor-pre-major` and version bumps in `src/index.ts`).
> 
> The new package ships **build/lint/docs scaffolding** (`tsup` ESM+CJS, TypeScript configs, Typedoc, ESLint override for future contract tests) plus **LICENSE**, **CHANGELOG**, and a **README** that marks the SDK as **experimental / not production-ready**. The public entry point is a **placeholder**: `src/index.ts` only exports a **`version`** constant; comments note that **`createClient`**, logging, and types land in a follow-up (SDK-2312).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a15d58fffe245c1a07f69b58f5ac4b8fd3ace00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->