### PR TITLE
chore: rename _buildNodeMetrics to _trackNodeMetrics (AIC-2388)

### DIFF
--- a/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
+++ b/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
@@ -48,7 +48,7 @@ export class ManagedAgentGraph {
       path: runnerResult.metrics.path,
       durationMs: runnerResult.metrics.durationMs,
       tokens: runnerResult.metrics.usage,
-      nodeMetrics: this._buildNodeMetrics(runnerResult.metrics.nodeMetrics),
+      nodeMetrics: this._trackNodeMetrics(runnerResult.metrics.nodeMetrics),
       resumptionToken: graphTracker.resumptionToken,
     };
 
@@ -66,7 +66,7 @@ export class ManagedAgentGraph {
    * Converts per-node LDAIMetrics from the runner into LDAIMetricSummary by
    * creating a per-node tracker, firing tracking events, and calling getSummary().
    */
-  private _buildNodeMetrics(
+  private _trackNodeMetrics(
     nodeMetrics: Record<string, LDAIMetrics>,
   ): Record<string, LDAIMetricSummary> {
     const summaries: Record<string, LDAIMetricSummary> = {};


### PR DESCRIPTION
## Summary

- Renames `_buildNodeMetrics` → `_trackNodeMetrics` in `ManagedAgentGraph` to align with the Python SDK's `_track_node_metrics` naming convention.

## Test plan

- [ ] Existing `ManagedAgentGraph` tests pass (method is private, no test changes needed)
- [ ] Stacks on #1335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only renames a private helper and updates its single call site; no behavior changes are introduced.
> 
> **Overview**
> Renames `ManagedAgentGraph`’s private per-node metrics helper from `_buildNodeMetrics` to `_trackNodeMetrics`, and updates `run()` to call the renamed method (aligning naming with other SDKs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee06364c9f8d65f537b69b5af7252c899144034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->