### PR TITLE
chore: skip tracking judge results that were not sampled

### DIFF
--- a/packages/sdk/server-ai/src/api/ManagedAgent.ts
+++ b/packages/sdk/server-ai/src/api/ManagedAgent.ts
@@ -46,6 +46,9 @@ export class ManagedAgent {
       .evaluate(prompt, output)
       .then((results) => {
         results.forEach((judgeResult) => {
+          if (!judgeResult.sampled) {
+            return;
+          }
           tracker.trackJudgeResult(judgeResult);
         });
         return results;

--- a/packages/sdk/server-ai/src/api/ManagedModel.ts
+++ b/packages/sdk/server-ai/src/api/ManagedModel.ts
@@ -46,6 +46,9 @@ export class ManagedModel {
       .evaluate(prompt, output)
       .then((results) => {
         results.forEach((judgeResult) => {
+          if (!judgeResult.sampled) {
+            return;
+          }
           tracker.trackJudgeResult(judgeResult);
         });
         return results;


### PR DESCRIPTION
## Summary

- Skip processing judge results where `judgeResult.sampled` is `false` in both `ManagedModel` and `ManagedAgent`
- Prevents unsampled evaluations from being tracked unnecessarily
- Mirrors the same fix applied to python-server-sdk-ai

## Test plan

- [ ] Verify judge results with `sampled=false` are skipped without being tracked
- [ ] Verify judge results with `sampled=true` continue to be tracked as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a guard to avoid calling `trackJudgeResult` for judge evaluations marked `sampled=false`, without changing evaluation execution or outputs.
> 
> **Overview**
> Stops tracking judge results that were not sampled by adding a `judgeResult.sampled` guard before calling `tracker.trackJudgeResult()` in both `ManagedAgent` and `ManagedModel`.
> 
> Judge evaluation still runs and returns all results, but only sampled results contribute to tracking/metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62355988f3cf56709bf34debc1b7d5930b539104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->