### PR TITLE
chore: Add managed-agent example to server-sdk-ai

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "packages/sdk/server-ai/examples/chat-judge",
     "packages/sdk/server-ai/examples/direct-judge",
     "packages/sdk/server-ai/examples/openai",
+    "packages/sdk/server-ai/examples/managed-agent",
     "packages/sdk/server-ai/examples/tracked-chat",
     "packages/sdk/server-ai/examples/chat-observability",
     "packages/sdk/server-ai/examples/openai-observability",

--- a/packages/sdk/server-ai/examples/chat-judge/package.json
+++ b/packages/sdk/server-ai/examples/chat-judge/package.json
@@ -14,10 +14,10 @@
     "@launchdarkly/node-server-sdk": "9.10.13",
     "@launchdarkly/server-sdk-ai": "0.18.1",
     "@launchdarkly/server-sdk-ai-langchain": "0.6.1",
-    "langchain": "^1.0.0",
     "@launchdarkly/server-sdk-ai-openai": "0.5.8",
     "@launchdarkly/server-sdk-ai-vercel": "0.5.8",
-    "dotenv": "^16.0.0"
+    "dotenv": "^16.0.0",
+    "langchain": "^1.0.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.4",

--- a/packages/sdk/server-ai/examples/direct-judge/package.json
+++ b/packages/sdk/server-ai/examples/direct-judge/package.json
@@ -14,10 +14,10 @@
     "@launchdarkly/node-server-sdk": "9.10.13",
     "@launchdarkly/server-sdk-ai": "0.18.1",
     "@launchdarkly/server-sdk-ai-langchain": "0.6.1",
-    "langchain": "^1.0.0",
     "@launchdarkly/server-sdk-ai-openai": "0.5.8",
     "@launchdarkly/server-sdk-ai-vercel": "0.5.8",
-    "dotenv": "^16.0.0"
+    "dotenv": "^16.0.0",
+    "langchain": "^1.0.0"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.4",

--- a/packages/sdk/server-ai/examples/managed-agent/README.md
+++ b/packages/sdk/server-ai/examples/managed-agent/README.md
@@ -1,0 +1,49 @@
+# Managed Agent Example
+
+This example demonstrates how to use the LaunchDarkly AI SDK agent functionality with multiple providers for managed agent interactions.
+
+## Prerequisites
+
+1. A LaunchDarkly account and SDK key
+1. An OpenAI API key (for the AI provider)
+1. Node.js 16 or later
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   yarn install
+   ```
+
+1. Set up environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+   
+   Edit `.env` and add your keys:
+   ```
+   LAUNCHDARKLY_SDK_KEY=your-sdk-key-here
+   OPENAI_API_KEY=your-openai-api-key-here
+   LAUNCHDARKLY_AI_CONFIG_KEY=sample-ai-agent-config
+   ```
+
+1. Create an AI Config in LaunchDarkly:
+   - Navigate to the AI Configs section in your LaunchDarkly dashboard
+   - Create a new AI Config with the key `sample-agent-config` and the **Agent** mode
+   - Add a variation with the following settings:
+     - **Model Selection**: Select "OpenAI" as the provider and "gpt-3.5-turbo" as the model
+     - **Instructions**: "You are a helpful assistant for {{companyName}}. You should be friendly and informative."
+     - Save the variation
+   - Update the default target rule to use the newly created variation
+
+## Running the Example
+
+```bash
+yarn start
+```
+
+This will:
+1. Initialize the LaunchDarkly client
+1. Create an agent using the AI Config
+1. Send a prompt to the agent and display the response
+1. Automatically track interaction metrics (duration, tokens, success/error)

--- a/packages/sdk/server-ai/examples/managed-agent/package.json
+++ b/packages/sdk/server-ai/examples/managed-agent/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@launchdarkly/managed-agent-example",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Example demonstrating LaunchDarkly AI SDK agent functionality with multiple providers",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "yarn build && node ./dist/index.js"
+  },
+  "dependencies": {
+    "@ai-sdk/google": "^2.0.20",
+    "@langchain/core": "^1.1.42",
+    "@langchain/google-genai": "^1.0.3",
+    "@langchain/openai": "^0.5.0",
+    "@launchdarkly/node-server-sdk": "9.10.13",
+    "@launchdarkly/server-sdk-ai": "0.18.1",
+    "@launchdarkly/server-sdk-ai-langchain": "0.6.1",
+    "@launchdarkly/server-sdk-ai-openai": "0.5.8",
+    "@launchdarkly/server-sdk-ai-vercel": "0.5.8",
+    "dotenv": "^16.0.0",
+    "langchain": "^1.3.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/sdk/server-ai/examples/managed-agent/src/index.ts
+++ b/packages/sdk/server-ai/examples/managed-agent/src/index.ts
@@ -1,0 +1,75 @@
+/* eslint-disable no-console */
+import 'dotenv/config';
+
+import { init, type LDContext } from '@launchdarkly/node-server-sdk';
+import { initAi } from '@launchdarkly/server-sdk-ai';
+
+// Environment variables
+const sdkKey = process.env.LAUNCHDARKLY_SDK_KEY;
+const aiConfigKey = process.env.LAUNCHDARKLY_AI_CONFIG_KEY || 'sample-agent-config';
+
+// Validate required environment variables
+if (!sdkKey) {
+  console.error('*** Please set the LAUNCHDARKLY_SDK_KEY env first');
+  process.exit(1);
+}
+
+// Initialize LaunchDarkly client
+const ldClient = init(sdkKey);
+
+// Set up the context properties. This context should appear on your LaunchDarkly contexts dashboard
+// soon after you run the demo.
+const context: LDContext = {
+  kind: 'user',
+  key: 'example-user-key',
+  name: 'Sandy',
+};
+
+async function main() {
+  try {
+    await ldClient.waitForInitialization({ timeout: 10 });
+    console.log('*** SDK successfully initialized');
+  } catch (error) {
+    console.log(`*** SDK failed to initialize: ${error}`);
+    process.exit(1);
+  }
+
+  const aiClient = initAi(ldClient);
+
+  // Get AI agent configuration from LaunchDarkly.
+  //
+  // Pass a defaultValue for improved resiliency when the flag is unavailable or LaunchDarkly is unreachable; omit for a disabled default.
+  // Example:
+  //   const defaultValue = {
+  //     enabled: true,
+  //     model: { name: 'gpt-4' },
+  //     provider: { name: 'openai' },
+  //     instructions: 'You are a helpful research assistant for {{companyName}}.'
+  //   };
+  //   const agent = await aiClient.createAgent(aiConfigKey, context, defaultValue, { companyName: 'LaunchDarkly' });
+  const agent = await aiClient.createAgent(aiConfigKey, context, undefined, {
+    companyName: 'LaunchDarkly',
+  });
+
+  if (!agent) {
+    console.log('*** AI agent configuration is not enabled');
+    process.exit(0);
+  }
+
+  // Example of using the agent functionality
+  console.log('\n*** Starting agent invocation:');
+  try {
+    const userInput = 'Hello! Can you help me understand how your company can help me?';
+    console.log('User Input:', userInput);
+
+    const result = await agent.run(userInput);
+
+    console.log('AI Response:', result.content);
+
+    console.log('Success.');
+  } catch (err) {
+    console.error('Error:', err);
+  }
+}
+
+main();

--- a/packages/sdk/server-ai/examples/managed-agent/tsconfig.json
+++ b/packages/sdk/server-ai/examples/managed-agent/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk/server-ai/examples/vercel-ai/src/index.ts
+++ b/packages/sdk/server-ai/examples/vercel-ai/src/index.ts
@@ -4,7 +4,12 @@ import { generateText, streamText } from 'ai';
 
 import { init, type LDClient, type LDContext } from '@launchdarkly/node-server-sdk';
 import { initAi } from '@launchdarkly/server-sdk-ai';
-import { VercelProvider } from '@launchdarkly/server-sdk-ai-vercel';
+import {
+  convertMessagesToVercel,
+  getAIMetricsFromResponse,
+  getAIMetricsFromStream,
+  VercelRunnerFactory,
+} from '@launchdarkly/server-sdk-ai-vercel';
 
 // Environment variables
 const sdkKey = process.env.LAUNCHDARKLY_SDK_KEY ?? '';
@@ -59,24 +64,22 @@ async function main() {
 
   console.log('Using model:', aiConfig.model?.name);
 
+  const model = openai(aiConfig.model?.name || 'gpt-4');
+  const parameters = VercelRunnerFactory.mapParameters(aiConfig.model?.parameters);
+
   try {
     const userMessage = {
       role: 'user' as const,
       content: 'What can you help me with?',
     };
 
-    // Example of using generateText (non-streaming)
     console.log('\n*** Generating text:');
 
-    // Convert config to Vercel AI SDK format
-    const vercelConfig = VercelProvider.toVercelAISDK(aiConfig, openai, {
-      nonInterpolatedMessages: [userMessage],
-    });
+    const messages = convertMessagesToVercel([...(aiConfig.messages || []), userMessage]);
 
-    // Call the model and track metrics for the ai config
     const tracker = aiConfig.createTracker!();
-    const result = await tracker.trackMetricsOf(VercelProvider.getAIMetricsFromResponse, () =>
-      generateText({ ...vercelConfig, messages: vercelConfig.messages ?? [] }),
+    const result = await tracker.trackMetricsOf(getAIMetricsFromResponse, () =>
+      generateText({ ...parameters, model, messages }),
     );
 
     console.log('Response:', result.text);
@@ -91,21 +94,16 @@ async function main() {
       content: 'Count from 1 to 5.',
     };
 
-    // Example of using generateText (non-streaming)
     console.log('\n*** Streaming text:');
-    // Convert config to Vercel AI SDK format
-    const vercelConfig = VercelProvider.toVercelAISDK(aiConfig, openai, {
-      nonInterpolatedMessages: [userMessage],
-    });
 
-    // Stream is returned immediately (synchronously), metrics tracked in background
+    const messages = convertMessagesToVercel([...(aiConfig.messages || []), userMessage]);
+
     const streamTracker = aiConfig.createTracker!();
     const streamResult = streamTracker.trackStreamMetricsOf(
-      () => streamText({ ...vercelConfig, messages: vercelConfig.messages ?? [] }),
-      VercelProvider.getAIMetricsFromStream,
+      () => streamText({ ...parameters, model, messages }),
+      getAIMetricsFromStream,
     );
 
-    // Consume the stream immediately - no await needed before this!
     for await (const textPart of streamResult.textStream) {
       process.stdout.write(textPart);
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
         },
         {
           "type": "json",
+          "path": "/packages/sdk/server-ai/examples/managed-agent/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-langchain']"
+        },
+        {
+          "type": "json",
           "path": "/packages/sdk/server-ai/examples/chat-judge/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-langchain']"
         },
@@ -37,6 +42,11 @@
         },
         {
           "type": "json",
+          "path": "/packages/sdk/server-ai/examples/managed-agent/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-vercel']"
+        },
+        {
+          "type": "json",
           "path": "/packages/sdk/server-ai/examples/chat-judge/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-vercel']"
         },
@@ -59,6 +69,11 @@
         {
           "type": "json",
           "path": "/packages/sdk/server-ai/examples/tracked-chat/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-openai']"
+        },
+        {
+          "type": "json",
+          "path": "/packages/sdk/server-ai/examples/managed-agent/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai-openai']"
         },
         {
@@ -160,6 +175,11 @@
         },
         {
           "type": "json",
+          "path": "/packages/sdk/server-ai/examples/managed-agent/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/node-server-sdk']"
+        },
+        {
+          "type": "json",
           "path": "/packages/sdk/server-ai/examples/chat-judge/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/node-server-sdk']"
         },
@@ -250,6 +270,11 @@
         {
           "type": "json",
           "path": "examples/tracked-chat/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai']"
+        },
+        {
+          "type": "json",
+          "path": "examples/managed-agent/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/server-sdk-ai']"
         },
         {


### PR DESCRIPTION
## Summary
- New `managed-agent` example under `packages/sdk/server-ai/examples/` that mirrors `tracked-chat` but exercises `createAgent` / `ManagedAgent` (only available on `next-ai-release`).
- Wired into root `package.json` workspaces and `release-please-config.json` (5 places, alongside `tracked-chat`).
- Picks up a small fix to the `vercel-ai` example so the workspace still builds: `VercelProvider` was removed on `next-ai-release` in #1339; switched to `VercelRunnerFactory` + `convertMessagesToVercel` + `getAIMetricsFrom*`.
- Cosmetic dep re-sort in `chat-judge` and `direct-judge` `package.json` (langchain moved to alphabetical position).

## Notes
- Targets `next-ai-release` because `createAgent` does not exist on `main`.
- Default AI config key is `sample-ai-agent-config` to avoid colliding with the chat config in shared LD projects.

## Test plan
- [ ] `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/managed-agent-example' run build` succeeds
- [ ] `yarn workspace @launchdarkly/server-sdk-ai test` still passes
- [ ] Manually run the example against a `sample-ai-agent-config` (Agent mode) and confirm `agent.run(input)` returns content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to example workspaces and release automation wiring, with a small refactor in the `vercel-ai` example to match updated provider APIs.
> 
> **Overview**
> Adds a new `managed-agent` example workspace demonstrating `initAi().createAgent(...)` and `agent.run(...)`, with accompanying `README`, `tsconfig`, and dependencies.
> 
> Updates the root workspaces list and `release-please-config.json` so dependency bumps propagate into the new example.
> 
> Fixes the `vercel-ai` example to stop using the removed `VercelProvider` API, switching to `VercelRunnerFactory` plus `convertMessagesToVercel` and `getAIMetricsFrom*` helpers, and makes minor dependency ordering tweaks in the judge examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7aedd75b5e40a6acb26c22482867db1ac31ff89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->