### PR TITLE
ci: Run v3 (FDv2) contract tests for server-node via gh-actions

### DIFF
--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -41,19 +41,17 @@ jobs:
         run: yarn workspace @launchdarkly/node-server-sdk-contract-tests build
       - name: Launch the test service in the background
         run: yarn workspace @launchdarkly/node-server-sdk-contract-tests start 2>&1 &
-      - name: Clone and run contract tests from feat/fdv2 branch
-        run: |
-          mkdir -p /tmp/sdk-test-harness
-          git clone https://github.com/launchdarkly/sdk-test-harness.git /tmp/sdk-test-harness
-          cp ./packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt /tmp/sdk-test-harness/testharness-suppressions-fdv2.txt
-          cd /tmp/sdk-test-harness
-          git checkout feat/fdv2
-          go build -o test-harness .
-          ./test-harness -url http://localhost:8000 -debug --skip-from=testharness-suppressions-fdv2.txt
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: launchdarkly/gh-actions/actions/contract-tests@0b3ff8f7ffc27033ba68fe8e98cf9dd263887147 # contract-tests-v1.0.2
+      - name: Run contract tests (v2)
+        uses: launchdarkly/gh-actions/actions/contract-tests@0b3ff8f7ffc27033ba68fe8e98cf9dd263887147 # contract-tests-v1.0.2
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
-          extra_params: '--skip-from=./packages/sdk/server-node/contract-tests/testharness-suppressions.txt -stop-service-at-end'
+          stop_service: 'false'
+          extra_params: '--skip-from=./packages/sdk/server-node/contract-tests/testharness-suppressions.txt'
+      - name: Run contract tests (v3)
+        uses: launchdarkly/gh-actions/actions/contract-tests@0b3ff8f7ffc27033ba68fe8e98cf9dd263887147 # contract-tests-v1.0.2
+        with:
+          test_service_port: 8000
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v3.0.0-alpha.6
+          extra_params: '--skip-from=./packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt'

--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Launch the test service in the background
         run: yarn workspace @launchdarkly/node-server-sdk-contract-tests start 2>&1 &
       - name: Run contract tests (v2)
-        uses: launchdarkly/gh-actions/actions/contract-tests@0b3ff8f7ffc27033ba68fe8e98cf9dd263887147 # contract-tests-v1.0.2
+        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
           stop_service: 'false'
           extra_params: '--skip-from=./packages/sdk/server-node/contract-tests/testharness-suppressions.txt'
       - name: Run contract tests (v3)
-        uses: launchdarkly/gh-actions/actions/contract-tests@0b3ff8f7ffc27033ba68fe8e98cf9dd263887147 # contract-tests-v1.0.2
+        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/sdk/server-node/contract-tests/README.md
+++ b/packages/sdk/server-node/contract-tests/README.md
@@ -17,5 +17,5 @@ The service will listen on http://localhost:8000. You can then run the test harn
 
 Suppression files for tests that are not yet supported or are known to differ:
 
-- `testharness-suppressions.txt` – used by the default contract test run
-- `testharness-suppressions-fdv2.txt` – used when running the harness from the feat/fdv2 branch
+- `testharness-suppressions.txt` – used when running the v2 test harness
+- `testharness-suppressions-fdv2.txt` – used when running the v3 test harness (FDv2 protocol)


### PR DESCRIPTION
## Summary

- Replace the manual `feat/fdv2` branch clone in `.github/workflows/server-node.yml` with a second invocation of `launchdarkly/gh-actions/actions/contract-tests` pinned to `version: v3.0.0-alpha.6`, mirroring the python-server-sdk pattern.
- Order the runs v2-then-v3 and set `stop_service: 'false'` on the v2 run so the test service stays alive for the v3 run.
- Drop the redundant `-stop-service-at-end` from `extra_params` -- the action injects it via `stop_service`.
- Update `packages/sdk/server-node/contract-tests/README.md` to describe the suppression files in terms of v2/v3 instead of the now-removed `feat/fdv2` branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by switching from a manual harness checkout/build to the `contract-tests` GitHub Action and adding a second (v3) run; failures or action/version mismatches could break the server-node pipeline.
> 
> **Overview**
> Updates the server-node CI contract test workflow to **run both v2 and v3 (FDv2) harness suites** using the `launchdarkly/gh-actions/actions/contract-tests` action, removing the previous manual clone/build of the `sdk-test-harness` `feat/fdv2` branch.
> 
> The v2 run is configured to keep the test service alive (`stop_service: 'false'`) so a second invocation can execute the v3 alpha harness (`version: v3.0.0-alpha.6`) with its own suppression list. Documentation in `contract-tests/README.md` is updated to describe suppression files in terms of v2 vs v3 rather than the removed branch-based flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d2a6c75ab56bf3b90363b1f36c08af1adf9165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->