### PR TITLE
chore: update recommendations to use node 20

### DIFF
--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -15,7 +15,7 @@ alwaysApply: true
   - Tooling packages (development tools)
 
 ## Build Requirements
-- Node environment version 16 required, this is a minimum.
+- Node environment version 20 required, this is a minimum.
 - yarn required
 - Some projects may have specific environment prerequisites
 

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -34,7 +34,7 @@ jobs:
           workspace_name: '@launchdarkly/js-client-sdk'
           workspace_path: packages/sdk/browser
       - name: Check package size
-        if: github.event_name == 'pull_request' && matrix.version == '21'
+        if: github.event_name == 'pull_request' && matrix.version == '22'
         uses: ./actions/package-size
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [18, 21]
+        version: [20, 22]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/combined-browser.yml
+++ b/.github/workflows/combined-browser.yml
@@ -34,7 +34,7 @@ jobs:
           workspace_name: '@launchdarkly/browser'
           workspace_path: packages/sdk/combined-browser
       - name: Check package size
-        if: github.event_name == 'pull_request' && matrix.version == '21'
+        if: github.event_name == 'pull_request' && matrix.version == '22'
         uses: ./actions/package-size
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/combined-browser.yml
+++ b/.github/workflows/combined-browser.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [18, 21]
+        version: [20, 22]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [18, 22]
+        version: [20, 22]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
   - Tooling packages (development tools)
 
 ## Build Requirements
-- Node environment version 16 required (minimum)
+- Node environment version 20 required (minimum)
 - yarn required
 - Some projects may have specific environment prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
 
 ### Prerequisites
 
-A node environment of version 16 and npm or yarn are required to develop in this repository.
+A node environment of version 20 and npm or yarn are required to develop in this repository.
 
 This monorepo may contain projects that are not suitable for execution using node, and those
 projects will have specific environment prerequisites.


### PR DESCRIPTION
This PR is updating our nodejs tests and recommendations up to nodejs 20. This is to keep in line with Node end of support.

> NOTE: technically 20 support ended earlier this year, but I think we can lag behind a bit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc/CI-only change that updates supported Node versions; main risk is CI/build failures if any package still relies on older Node behavior.
> 
> **Overview**
> Updates repository guidance to require **Node.js 20+** (from 16) in `CONTRIBUTING.md`, `CLAUDE.md`, and `.cursor` development rules.
> 
> Adjusts GitHub Actions Node test matrices to run on **20 and 22** (replacing 18/21 or 18/22) for browser, combined-browser, and server-node workflows, and shifts the PR-only package size check to run on Node 22.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab79530cd00e8c61c761102ec81fd0c578fe345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->