### PR TITLE
feat!: consolidate graph metric summary into LDAIGraphMetricSummary

### DIFF
--- a/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
@@ -12,7 +12,7 @@ import type { LDClientMin } from './LDClientMin';
  * {@link LDGraphTrackerImpl.fromResumptionToken}.
  */
 export class LDGraphTrackerImpl implements LDGraphTracker {
-  private _summary: LDAIGraphMetricSummary = {};
+  private _summary: Partial<LDAIGraphMetricSummary> = {};
 
   constructor(
     private readonly _ldClient: LDClientMin,
@@ -67,7 +67,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
     };
   }
 
-  getSummary(): LDAIGraphMetricSummary {
+  getSummary(): Partial<LDAIGraphMetricSummary> {
     return { ...this._summary };
   }
 

--- a/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
+++ b/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
@@ -33,9 +33,13 @@ export interface LDGraphTracker {
   };
 
   /**
-   * Returns a snapshot of all graph-level metrics tracked so far.
+   * Returns a snapshot of all graph-level metrics tracked so far. Fields
+   * populate incrementally as `track*` methods are called, so the result is
+   * a `Partial<LDAIGraphMetricSummary>`. Once the graph invocation has
+   * completed via `ManagedAgentGraph.run()`, prefer `ManagedGraphResult.metrics`
+   * which is fully populated.
    */
-  getSummary(): LDAIGraphMetricSummary;
+  getSummary(): Partial<LDAIGraphMetricSummary>;
 
   /**
    * A URL-safe Base64-encoded (RFC 4648, no padding) token encoding the tracker's

--- a/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
+++ b/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
@@ -5,7 +5,7 @@ import { LDAIMetricSummary } from '../model/types';
 import { LDJudgeResult } from '../judge/types';
 import { AgentGraphDefinition } from './AgentGraphDefinition';
 import { LDGraphTracker } from './LDGraphTracker';
-import { AgentGraphRunnerResult, GraphMetricSummary, ManagedGraphResult } from './types';
+import { AgentGraphRunnerResult, LDAIGraphMetricSummary, ManagedGraphResult } from './types';
 
 /**
  * ManagedAgentGraph wraps an AgentGraphDefinition and provides a managed run()
@@ -13,7 +13,7 @@ import { AgentGraphRunnerResult, GraphMetricSummary, ManagedGraphResult } from '
  *
  * The runner function is responsible for executing the graph and returning
  * an AgentGraphRunnerResult. ManagedAgentGraph builds the managed result from
- * the runner result, including GraphMetricSummary with the graphTracker's
+ * the runner result, including LDAIGraphMetricSummary with the graphTracker's
  * resumptionToken.
  */
 export class ManagedAgentGraph {
@@ -31,7 +31,7 @@ export class ManagedAgentGraph {
    * run() returns before ManagedGraphResult.evaluations resolves.
    *
    * @param runner Async function that executes the graph and returns AgentGraphRunnerResult.
-   * @returns ManagedGraphResult with GraphMetricSummary and evaluations promise.
+   * @returns ManagedGraphResult with LDAIGraphMetricSummary and evaluations promise.
    */
   async run(
     runner: (
@@ -43,7 +43,7 @@ export class ManagedAgentGraph {
 
     const runnerResult = await runner(this._graphDefinition, graphTracker);
 
-    const metrics: GraphMetricSummary = {
+    const metrics: LDAIGraphMetricSummary = {
       success: runnerResult.metrics.success,
       path: runnerResult.metrics.path,
       durationMs: runnerResult.metrics.durationMs,

--- a/packages/sdk/server-ai/src/api/graph/types.ts
+++ b/packages/sdk/server-ai/src/api/graph/types.ts
@@ -40,28 +40,38 @@ export interface LDAgentGraphFlagValue {
 }
 
 /**
- * Accumulated graph-level metrics collected by an LDGraphTracker.
+ * Summarized graph-level metrics for a completed graph invocation, as
+ * returned by {@link ManagedAgentGraph.run} via {@link ManagedGraphResult.metrics}.
+ *
+ * For the tracker-layer incremental view (where fields populate as tracking
+ * calls arrive), see {@link LDGraphTracker.getSummary}, which returns a
+ * `Partial<LDAIGraphMetricSummary>`.
  */
 export interface LDAIGraphMetricSummary {
   /**
-   * Whether the graph invocation succeeded. Absent if not yet tracked.
+   * Whether the graph invocation succeeded.
    */
-  success?: boolean;
+  success: boolean;
 
   /**
-   * Total graph execution duration in milliseconds. Absent if not yet tracked.
+   * Execution path through the graph as an ordered array of config keys.
+   */
+  path: string[];
+
+  /**
+   * Per-node metric summaries keyed by agent config key.
+   */
+  nodeMetrics: Record<string, LDAIMetricSummary>;
+
+  /**
+   * Total graph execution duration in milliseconds, if tracked.
    */
   durationMs?: number;
 
   /**
-   * Aggregate token usage across the entire graph invocation. Absent if not yet tracked.
+   * Aggregate token usage across the entire graph invocation, if available.
    */
   tokens?: LDTokenUsage;
-
-  /**
-   * Execution path through the graph as an array of config keys. Absent if not yet tracked.
-   */
-  path?: string[];
 
   /**
    * Resumption token for deferred feedback association.
@@ -126,42 +136,6 @@ export interface AgentGraphRunnerResult {
 // ============================================================================
 
 /**
- * Graph metric summary returned in ManagedGraphResult.
- * Includes per-node metrics and a resumption token.
- */
-export interface GraphMetricSummary {
-  /**
-   * Whether the graph invocation succeeded.
-   */
-  success: boolean;
-
-  /**
-   * Execution path through the graph as an ordered array of config keys.
-   */
-  path: string[];
-
-  /**
-   * Total graph execution duration in milliseconds, if tracked.
-   */
-  durationMs?: number;
-
-  /**
-   * Aggregate token usage across the entire graph invocation, if available.
-   */
-  tokens?: LDTokenUsage;
-
-  /**
-   * Per-node metric summaries keyed by agent config key.
-   */
-  nodeMetrics: Record<string, LDAIMetricSummary>;
-
-  /**
-   * Resumption token for deferred feedback association.
-   */
-  resumptionToken?: string;
-}
-
-/**
  * The result returned by a managed graph invocation (ManagedAgentGraph.run()).
  */
 export interface ManagedGraphResult {
@@ -173,7 +147,7 @@ export interface ManagedGraphResult {
   /**
    * Summarized metrics for this graph invocation.
    */
-  metrics: GraphMetricSummary;
+  metrics: LDAIGraphMetricSummary;
 
   /**
    * The raw response object from the provider, if available.


### PR DESCRIPTION
## Summary

JS already had two duplicate graph-metric-summary interfaces:

- `LDAIGraphMetricSummary` (tracker-layer) — used by `LDGraphTracker.getSummary()`. All fields optional. Missing `nodeMetrics`.
- `AIGraphMetricSummary` (managed-layer, introduced in #1335) — used by `ManagedGraphResult.metrics` / `ManagedAgentGraph`. Required `success`/`path`/`nodeMetrics`. Includes `nodeMetrics`.

Both describe the same spec concept (`AIGraphMetricSummary` in AIRUNNER §2.5). This PR consolidates them into the single `LDAIGraphMetricSummary` (JS LD-prefix convention used by all sibling types like `LDAIMetrics`, `LDAIMetricSummary`, `LDAIGraphMetrics`) and adds the missing `nodeMetrics` field.

## Required vs. optional fields

The consolidated type's optionality matches the actual runtime contract — preserving the type precision the old `AIGraphMetricSummary` provided:

- **Required**: `success`, `path`, `nodeMetrics`. The managed layer sources these from `LDAIGraphMetrics` where they are required, so consumers of `ManagedGraphResult.metrics` can rely on them being present.
- **Optional**: `durationMs`, `tokens`, `resumptionToken`. Genuinely may not be tracked depending on runner.

For the tracker's incremental view, `LDGraphTracker.getSummary()` now returns `Partial<LDAIGraphMetricSummary>` to express that fields populate as tracking calls arrive. `LDGraphTrackerImpl._summary` is similarly typed.

## Coordination

This is one of three coordinated PRs renaming/aligning the graph metric summary types:

- Spec PR: launchdarkly/sdk-specs#162 (draft, base `main`) — canonical spec rename to `AIGraphMetricSummary`.
- Python PR: launchdarkly/python-server-sdk-ai#173 (draft, base `main`) — adopts `AIGraphMetricSummary` (Python doesn't use the LD prefix).
- This PR: js-core (draft, base `feat/next-ai-release`) — JS keeps the LD prefix and consolidates the duplicate.

## Files changed

- `packages/sdk/server-ai/src/api/graph/types.ts` — added `nodeMetrics` to `LDAIGraphMetricSummary`; tightened `success`/`path`/`nodeMetrics` to required; removed the duplicate `AIGraphMetricSummary` interface; updated `ManagedGraphResult.metrics` to `LDAIGraphMetricSummary`.
- `packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts` — `getSummary()` returns `Partial<LDAIGraphMetricSummary>`.
- `packages/sdk/server-ai/src/LDGraphTrackerImpl.ts` — `_summary` field and `getSummary()` return are `Partial<LDAIGraphMetricSummary>`.
- `packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts` — switched to `LDAIGraphMetricSummary`.

## Breaking changes

- `AIGraphMetricSummary` is removed. Consumers should import `LDAIGraphMetricSummary` from `@launchdarkly/server-sdk-ai`.
- `LDAIGraphMetricSummary.success`, `path`, and `nodeMetrics` are now required (previously optional). Consumers of `ManagedGraphResult.metrics` benefit; consumers who built `LDAIGraphMetricSummary` literals from the tracker should switch to `Partial<LDAIGraphMetricSummary>`.
- `LDGraphTracker.getSummary()` now returns `Partial<LDAIGraphMetricSummary>` instead of `LDAIGraphMetricSummary` to reflect the incremental population. Consumers reading `getSummary().success` etc. were already getting `boolean | undefined` at runtime; the change just makes the type honest.

## Test plan

- [x] `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/server-sdk-ai' run build` passes
- [x] `yarn workspace @launchdarkly/server-sdk-ai test` passes (230/230)
- [x] `yarn workspace @launchdarkly/server-sdk-ai lint` clean
- [ ] Reviewer confirms naming choice (LD-prefix consolidation vs spec's bare `AIGraphMetricSummary`)