### PR TITLE
feat!: Remove AIProvider deprecated methods and create*/init* aliases (AIC-2388)

### DIFF
--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -20,7 +20,7 @@
 
 ## Quick Setup
 
-This package provides LangChain integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `initChat` method:
+This package provides LangChain integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `createModel` method:
 
 1. Install the required packages:
 
@@ -30,7 +30,7 @@ npm install @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-langchain --
 yarn add @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-langchain
 ```
 
-2. Create a chat session and use it:
+2. Create a managed model and run it:
 
 ```typescript
 import { init } from '@launchdarkly/node-server-sdk';
@@ -40,17 +40,17 @@ import { initAi } from '@launchdarkly/server-sdk-ai';
 const ldClient = init(sdkKey);
 const aiClient = initAi(ldClient);
 
-// Create a chat session
-const defaultConfig = { 
-  enabled: true, 
+// Create a managed model
+const defaultConfig = {
+  enabled: true,
   model: { name: 'gpt-4' },
   provider: { name: 'openai' }
 };
-const chat = await aiClient.initChat('my-chat-config', context, defaultConfig);
+const model = await aiClient.createModel('my-chat-config', context, defaultConfig);
 
-if (chat) {
-  const response = await chat.invoke('What is the capital of France?');
-  console.log(response.message.content);
+if (model) {
+  const result = await model.run('What is the capital of France?');
+  console.log(result.content);
 }
 ```
 

--- a/packages/ai-providers/server-ai-langchain/src/LangChainRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-langchain/src/LangChainRunnerFactory.ts
@@ -18,11 +18,8 @@ let instrumentPromise: Promise<void> | undefined;
  * Factory for creating LangChain runners (chat completion and agent).
  */
 export class LangChainRunnerFactory extends AIProvider {
-  private _logger?: LDLogger;
-
   constructor(logger?: LDLogger) {
-    super();
-    this._logger = logger;
+    super(logger);
     // eslint-disable-next-line no-underscore-dangle
     LangChainRunnerFactory._ensureInstrumented(logger).catch(() => {});
   }

--- a/packages/ai-providers/server-ai-langchain/src/LangChainRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-langchain/src/LangChainRunnerFactory.ts
@@ -18,8 +18,11 @@ let instrumentPromise: Promise<void> | undefined;
  * Factory for creating LangChain runners (chat completion and agent).
  */
 export class LangChainRunnerFactory extends AIProvider {
+  private _logger?: LDLogger;
+
   constructor(logger?: LDLogger) {
-    super(logger);
+    super();
+    this._logger = logger;
     // eslint-disable-next-line no-underscore-dangle
     LangChainRunnerFactory._ensureInstrumented(logger).catch(() => {});
   }
@@ -29,7 +32,7 @@ export class LangChainRunnerFactory extends AIProvider {
    */
   async createModel(config: LDAICompletionConfig): Promise<LangChainModelRunner> {
     const llm = await createLangChainModel(config);
-    return new LangChainModelRunner(llm, config, this.logger);
+    return new LangChainModelRunner(llm, config, this._logger);
   }
 
   /**
@@ -51,7 +54,7 @@ export class LangChainRunnerFactory extends AIProvider {
     };
     const llm = await createLangChainModel(configForModel);
 
-    const lcTools = buildStructuredTools(toolDefinitions, tools ?? {}, this.logger);
+    const lcTools = buildStructuredTools(toolDefinitions, tools ?? {}, this._logger);
     const instructions = config.instructions ?? '';
 
     const agent = createAgent({
@@ -60,7 +63,7 @@ export class LangChainRunnerFactory extends AIProvider {
       systemPrompt: instructions || undefined,
     });
 
-    return new LangChainAgentRunner(agent as any, this.logger);
+    return new LangChainAgentRunner(agent as any, this._logger);
   }
 
   /**

--- a/packages/ai-providers/server-ai-openai/README.md
+++ b/packages/ai-providers/server-ai-openai/README.md
@@ -23,7 +23,7 @@
 
 ## Quick Setup
 
-This package provides OpenAI integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `initChat` method:
+This package provides OpenAI integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `createModel` method:
 
 1. Install the required packages:
 
@@ -31,7 +31,7 @@ This package provides OpenAI integration for the LaunchDarkly AI SDK. The simple
 npm install @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-openai --save
 ```
 
-2. Create a chat session and use it:
+2. Create a managed model and run it:
 
 ```typescript
 import { init } from '@launchdarkly/node-server-sdk';
@@ -41,17 +41,17 @@ import { initAi } from '@launchdarkly/server-sdk-ai';
 const ldClient = init(sdkKey);
 const aiClient = initAi(ldClient);
 
-// Create a chat session
-const defaultConfig = { 
-  enabled: true, 
+// Create a managed model
+const defaultConfig = {
+  enabled: true,
   model: { name: 'gpt-4' },
   provider: { name: 'openai' }
 };
-const chat = await aiClient.initChat('my-chat-config', context, defaultConfig);
+const model = await aiClient.createModel('my-chat-config', context, defaultConfig);
 
-if (chat) {
-  const response = await chat.invoke("What is the capital of France?");
-  console.log(response.message.content);
+if (model) {
+  const result = await model.run('What is the capital of France?');
+  console.log(result.content);
 }
 ```
 

--- a/packages/ai-providers/server-ai-openai/src/OpenAIRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-openai/src/OpenAIRunnerFactory.ts
@@ -17,9 +17,11 @@ let instrumentPromise: Promise<void> | undefined;
  */
 export class OpenAIRunnerFactory extends AIProvider {
   private _client: OpenAI;
+  private _logger?: LDLogger;
 
   constructor(logger?: LDLogger) {
-    super(logger);
+    super();
+    this._logger = logger;
     this._client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     // Fire-and-forget: OTel instrumentation is optional and must not block construction.
     // eslint-disable-next-line no-underscore-dangle
@@ -30,7 +32,7 @@ export class OpenAIRunnerFactory extends AIProvider {
    * Create a model runner from a completion AI configuration.
    */
   async createModel(config: LDAICompletionConfig): Promise<OpenAIModelRunner> {
-    return new OpenAIModelRunner(this._client, config, this.logger);
+    return new OpenAIModelRunner(this._client, config, this._logger);
   }
 
   /**
@@ -67,7 +69,12 @@ export class OpenAIRunnerFactory extends AIProvider {
     const parameters = mapParameterKeys({ ...(config.model?.parameters ?? {}) });
     delete parameters.tools;
 
-    const { agentTools, toolNameMap } = buildAgentTools(toolHelper, configTools, registry, this.logger);
+    const { agentTools, toolNameMap } = buildAgentTools(
+      toolHelper,
+      configTools,
+      registry,
+      this._logger,
+    );
     const agent = new Agent({
       name: 'ldai-agent',
       instructions: config.instructions || undefined,
@@ -76,7 +83,7 @@ export class OpenAIRunnerFactory extends AIProvider {
       modelSettings: parameters,
     });
 
-    return new OpenAIAgentRunner(agent, agentRun, toolNameMap, this.logger);
+    return new OpenAIAgentRunner(agent, agentRun, toolNameMap, this._logger);
   }
 
   /**

--- a/packages/ai-providers/server-ai-openai/src/OpenAIRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-openai/src/OpenAIRunnerFactory.ts
@@ -17,11 +17,9 @@ let instrumentPromise: Promise<void> | undefined;
  */
 export class OpenAIRunnerFactory extends AIProvider {
   private _client: OpenAI;
-  private _logger?: LDLogger;
 
   constructor(logger?: LDLogger) {
-    super();
-    this._logger = logger;
+    super(logger);
     this._client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     // Fire-and-forget: OTel instrumentation is optional and must not block construction.
     // eslint-disable-next-line no-underscore-dangle

--- a/packages/ai-providers/server-ai-vercel/README.md
+++ b/packages/ai-providers/server-ai-vercel/README.md
@@ -20,7 +20,7 @@
 
 ## Quick Setup
 
-This package provides Vercel AI SDK integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `initChat` method:
+This package provides Vercel AI SDK integration for the LaunchDarkly AI SDK. The simplest way to use it is with the LaunchDarkly AI SDK's `createModel` method:
 
 1. Install the required packages:
 
@@ -30,7 +30,7 @@ npm install @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-vercel --sav
 yarn add @launchdarkly/server-sdk-ai @launchdarkly/server-sdk-ai-vercel
 ```
 
-2. Create a chat session and use it:
+2. Create a managed model and run it:
 
 ```typescript
 import { init } from '@launchdarkly/node-server-sdk';
@@ -40,17 +40,17 @@ import { initAi } from '@launchdarkly/server-sdk-ai';
 const ldClient = init(sdkKey);
 const aiClient = initAi(ldClient);
 
-// Create a chat session
-const defaultConfig = { 
-  enabled: true, 
+// Create a managed model
+const defaultConfig = {
+  enabled: true,
   model: { name: 'gpt-4' },
   provider: { name: 'openai' }
 };
-const chat = await aiClient.initChat('my-chat-config', context, defaultConfig);
+const model = await aiClient.createModel('my-chat-config', context, defaultConfig);
 
-if (chat) {
-  const response = await chat.invoke('What is the capital of France?');
-  console.log(response.message.content);
+if (model) {
+  const result = await model.run('What is the capital of France?');
+  console.log(result.content);
 }
 ```
 

--- a/packages/ai-providers/server-ai-vercel/src/VercelRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-vercel/src/VercelRunnerFactory.ts
@@ -15,11 +15,8 @@ import { VercelModelRunner } from './VercelModelRunner';
  * framework.
  */
 export class VercelRunnerFactory extends AIProvider {
-  private _logger?: LDLogger;
-
   constructor(logger?: LDLogger) {
-    super();
-    this._logger = logger;
+    super(logger);
   }
 
   /**

--- a/packages/ai-providers/server-ai-vercel/src/VercelRunnerFactory.ts
+++ b/packages/ai-providers/server-ai-vercel/src/VercelRunnerFactory.ts
@@ -15,8 +15,11 @@ import { VercelModelRunner } from './VercelModelRunner';
  * framework.
  */
 export class VercelRunnerFactory extends AIProvider {
+  private _logger?: LDLogger;
+
   constructor(logger?: LDLogger) {
-    super(logger);
+    super();
+    this._logger = logger;
   }
 
   /**
@@ -25,7 +28,7 @@ export class VercelRunnerFactory extends AIProvider {
   async createModel(config: LDAICompletionConfig): Promise<VercelModelRunner> {
     const model = await VercelRunnerFactory.createVercelModel(config);
     const parameters = VercelRunnerFactory.mapParameters(config.model?.parameters);
-    return new VercelModelRunner(model, config, parameters, this.logger);
+    return new VercelModelRunner(model, config, parameters, this._logger);
   }
 
   /**

--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -79,37 +79,34 @@ if (aiConfig.enabled) {
 }
 ```
 
-## TrackedChat for Conversational AI
+## ManagedModel for Tracked Model Invocations
 
-`TrackedChat` provides a high-level interface for conversational AI with automatic conversation management and metrics tracking:
+`ManagedModel` provides a high-level interface for invoking AI models with automatic metrics tracking and judge evaluation:
 
 - Automatically configures models based on AI configuration
-- Maintains conversation history across multiple interactions
 - Automatically tracks token usage, latency, and success rates
+- Runs configured judges asynchronously and reports their results
 - Works with any supported AI provider (see [AI Providers](https://github.com/launchdarkly/js-core#ai-providers) for available packages)
 
-### Using TrackedChat
+### Using ManagedModel
 
 ```typescript
 // Use the same defaultConfig from the retrieval section above
-const chat = await aiClient.createChat(
+const model = await aiClient.createModel(
   'customer-support-chat',
   context,
   defaultConfig,
   { customerName: 'John' }
 );
 
-if (chat) {
-  // Simple conversation flow - metrics are automatically tracked by invoke()
-  const response1 = await chat.invoke('I need help with my order');
-  console.log(response1.message.content);
-  
-  const response2 = await chat.invoke("What's the status?");
-  console.log(response2.message.content);
-  
-  // Access conversation history
-  const messages = chat.getMessages();
-  console.log(`Conversation has ${messages.length} messages`);
+if (model) {
+  // Metrics are automatically tracked by run()
+  const result = await model.run('I need help with my order');
+  console.log(result.content);
+
+  // Judge evaluations run asynchronously; await if you need their results
+  const evals = await result.evaluations;
+  console.log('Judge results:', evals);
 }
 ```
 

--- a/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
@@ -634,7 +634,7 @@ describe('createJudge method', () => {
 
   beforeEach(() => {
     mockProvider = {
-      invokeStructuredModel: jest.fn(),
+      run: jest.fn(),
     };
 
     mockJudge = {

--- a/packages/sdk/server-ai/__tests__/RunnerFactory.test.ts
+++ b/packages/sdk/server-ai/__tests__/RunnerFactory.test.ts
@@ -1,4 +1,7 @@
-import { LDAIConfigKind } from '../src/api/config/types';
+import {
+  LDAIAgentConfig,
+  LDAICompletionConfig,
+} from '../src/api/config/types';
 import { AIProvider, ToolRegistry } from '../src/api/providers/AIProvider';
 import { AgentGraphRunner, Runner } from '../src/api/providers/Runner';
 import { RunnerFactory, SupportedAIProvider } from '../src/api/providers/RunnerFactory';
@@ -7,14 +10,23 @@ import { RunnerFactory, SupportedAIProvider } from '../src/api/providers/RunnerF
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeConfig = (providerName: string): LDAIConfigKind =>
+const makeConfig = (providerName: string): LDAICompletionConfig =>
   ({
     key: 'test-config',
     enabled: true,
     provider: { name: providerName },
     createTracker: () => ({}) as any,
     evaluator: {} as any,
-  }) as unknown as LDAIConfigKind;
+  }) as unknown as LDAICompletionConfig;
+
+const makeAgentConfig = (providerName: string): LDAIAgentConfig =>
+  ({
+    key: 'test-agent-config',
+    enabled: true,
+    provider: { name: providerName },
+    createTracker: () => ({}) as any,
+    evaluator: {} as any,
+  }) as unknown as LDAIAgentConfig;
 
 const makeRunner = (): Runner => ({ run: jest.fn() });
 const makeGraphRunner = (): AgentGraphRunner => ({ run: jest.fn() });
@@ -162,7 +174,7 @@ describe('RunnerFactory.createAgent', () => {
 
     jest.spyOn(RunnerFactory as any, '_getProviderFactory').mockResolvedValue(mockFactory);
 
-    const result = await RunnerFactory.createAgent(makeConfig('openai'), tools);
+    const result = await RunnerFactory.createAgent(makeAgentConfig('openai'), tools);
 
     expect(result).toBe(runner);
     expect(mockFactory.createAgent).toHaveBeenCalledWith(
@@ -177,7 +189,11 @@ describe('RunnerFactory.createAgent', () => {
 
     jest.spyOn(RunnerFactory as any, '_getProviderFactory').mockResolvedValue(undefined);
 
-    const result = await RunnerFactory.createAgent(makeConfig('openai'), undefined, logger as any);
+    const result = await RunnerFactory.createAgent(
+      makeAgentConfig('openai'),
+      undefined,
+      logger as any,
+    );
 
     expect(result).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not supported'));
@@ -243,7 +259,7 @@ describe('AIProvider default factory methods', () => {
 
   it('createAgent returns undefined by default', async () => {
     const provider = new ConcreteProvider();
-    const result = await provider.createAgent(makeConfig('openai'));
+    const result = await provider.createAgent(makeAgentConfig('openai'));
     expect(result).toBeUndefined();
   });
 
@@ -251,26 +267,5 @@ describe('AIProvider default factory methods', () => {
     const provider = new ConcreteProvider();
     const result = await provider.createAgentGraph({} as any);
     expect(result).toBeUndefined();
-  });
-
-  it('createModel warns when not overridden', async () => {
-    const warnSpy = jest.fn();
-    const provider = new ConcreteProvider({ warn: warnSpy } as any);
-    await provider.createModel(makeConfig('openai'));
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('createModel not implemented'));
-  });
-
-  it('createAgent warns when not overridden', async () => {
-    const warnSpy = jest.fn();
-    const provider = new ConcreteProvider({ warn: warnSpy } as any);
-    await provider.createAgent(makeConfig('openai'));
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('createAgent not implemented'));
-  });
-
-  it('createAgentGraph warns when not overridden', async () => {
-    const warnSpy = jest.fn();
-    const provider = new ConcreteProvider({ warn: warnSpy } as any);
-    await provider.createAgentGraph({} as any);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('createAgentGraph not implemented'));
   });
 });

--- a/packages/sdk/server-ai/examples/openai-observability/README.md
+++ b/packages/sdk/server-ai/examples/openai-observability/README.md
@@ -1,6 +1,6 @@
 # Provider-Specific Observability Example (OpenAI)
 
-This example shows how to use the LaunchDarkly observability plugin when calling an AI provider directly — without the higher-level `createChat` abstraction. It uses OpenAI as the provider, but the same pattern applies to any provider (Bedrock, Anthropic, Vercel AI SDK, etc.).
+This example shows how to use the LaunchDarkly observability plugin when calling an AI provider directly — without the higher-level `createModel` abstraction. It uses OpenAI as the provider, but the same pattern applies to any provider (Bedrock, Anthropic, Vercel AI SDK, etc.).
 
 ## How it works
 

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -221,6 +221,18 @@ export class LDAIClientImpl implements LDAIClient {
     );
   }
 
+  /**
+   * @deprecated Use `completionConfig` instead. This method will be removed in a future version.
+   */
+  async config(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+  ): Promise<LDAICompletionConfig> {
+    return this.completionConfig(key, context, defaultValue, variables);
+  }
+
   private async _judgeConfig(
     key: string,
     context: LDContext,
@@ -278,6 +290,18 @@ export class LDAIClientImpl implements LDAIClient {
     );
   }
 
+  /**
+   * @deprecated Use `agentConfig` instead. This method will be removed in a future version.
+   */
+  async agent(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIAgentConfigDefault,
+    variables?: Record<string, unknown>,
+  ): Promise<LDAIAgentConfig> {
+    return this.agentConfig(key, context, defaultValue, variables);
+  }
+
   async agentConfigs<const T extends readonly LDAIAgentRequestConfig[]>(
     agentConfigs: T,
     context: LDContext,
@@ -304,6 +328,16 @@ export class LDAIClientImpl implements LDAIClient {
     );
 
     return agents;
+  }
+
+  /**
+   * @deprecated Use `agentConfigs` instead. This method will be removed in a future version.
+   */
+  async agents<const T extends readonly LDAIAgentRequestConfig[]>(
+    agentConfigs: T,
+    context: LDContext,
+  ): Promise<Record<T[number]['key'], LDAIAgentConfig>> {
+    return this.agentConfigs(agentConfigs, context);
   }
 
   async createJudge(
@@ -434,6 +468,32 @@ export class LDAIClientImpl implements LDAIClient {
     }
 
     return new ManagedAgent(config, runner, this._logger);
+  }
+
+  /**
+   * @deprecated Use `createModel` instead. This method will be removed in a future version.
+   */
+  async createChat(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<ManagedModel | undefined> {
+    return this.createModel(key, context, defaultValue, variables, defaultAiProvider);
+  }
+
+  /**
+   * @deprecated Use `createModel` instead. This method will be removed in a future version.
+   */
+  async initChat(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<ManagedModel | undefined> {
+    return this.createModel(key, context, defaultValue, variables, defaultAiProvider);
   }
 
   createTracker(token: string, context: LDContext): LDAIConfigTracker {

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -221,18 +221,6 @@ export class LDAIClientImpl implements LDAIClient {
     );
   }
 
-  /**
-   * @deprecated Use `completionConfig` instead. This method will be removed in a future version.
-   */
-  async config(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-  ): Promise<LDAICompletionConfig> {
-    return this.completionConfig(key, context, defaultValue, variables);
-  }
-
   private async _judgeConfig(
     key: string,
     context: LDContext,
@@ -290,18 +278,6 @@ export class LDAIClientImpl implements LDAIClient {
     );
   }
 
-  /**
-   * @deprecated Use `agentConfig` instead. This method will be removed in a future version.
-   */
-  async agent(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAIAgentConfigDefault,
-    variables?: Record<string, unknown>,
-  ): Promise<LDAIAgentConfig> {
-    return this.agentConfig(key, context, defaultValue, variables);
-  }
-
   async agentConfigs<const T extends readonly LDAIAgentRequestConfig[]>(
     agentConfigs: T,
     context: LDContext,
@@ -328,29 +304,6 @@ export class LDAIClientImpl implements LDAIClient {
     );
 
     return agents;
-  }
-
-  /**
-   * @deprecated Use `agentConfigs` instead. This method will be removed in a future version.
-   */
-  async agents<const T extends readonly LDAIAgentRequestConfig[]>(
-    agentConfigs: T,
-    context: LDContext,
-  ): Promise<Record<T[number]['key'], LDAIAgentConfig>> {
-    return this.agentConfigs(agentConfigs, context);
-  }
-
-  /**
-   * @deprecated Use `createModel` instead. This method will be removed in a future version.
-   */
-  async createChat(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-    defaultAiProvider?: SupportedAIProvider,
-  ): Promise<ManagedModel | undefined> {
-    return this.createModel(key, context, defaultValue, variables, defaultAiProvider);
   }
 
   async createJudge(
@@ -481,19 +434,6 @@ export class LDAIClientImpl implements LDAIClient {
     }
 
     return new ManagedAgent(config, runner, this._logger);
-  }
-
-  /**
-   * @deprecated Use `createModel` instead. This method will be removed in a future version.
-   */
-  async initChat(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-    defaultAiProvider?: SupportedAIProvider,
-  ): Promise<ManagedModel | undefined> {
-    return this.createModel(key, context, defaultValue, variables, defaultAiProvider);
   }
 
   createTracker(token: string, context: LDContext): LDAIConfigTracker {

--- a/packages/sdk/server-ai/src/api/LDAIClient.ts
+++ b/packages/sdk/server-ai/src/api/LDAIClient.ts
@@ -82,16 +82,6 @@ export interface LDAIClient {
   ): Promise<LDAICompletionConfig>;
 
   /**
-   * @deprecated Use `completionConfig` instead. This method will be removed in a future version.
-   */
-  config(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-  ): Promise<LDAICompletionConfig>;
-
-  /**
    * Retrieves and processes a single AI Config agent based on the provided key, LaunchDarkly context,
    * and variables. This includes the model configuration and the customized instructions.
    *
@@ -131,16 +121,6 @@ export interface LDAIClient {
     defaultValue?: LDAIAgentConfigDefault,
     variables?: Record<string, unknown>,
     defaultAiProvider?: SupportedAIProvider,
-  ): Promise<LDAIAgentConfig>;
-
-  /**
-   * @deprecated Use `agentConfig` instead. This method will be removed in a future version.
-   */
-  agent(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAIAgentConfigDefault,
-    variables?: Record<string, unknown>,
   ): Promise<LDAIAgentConfig>;
 
   /**
@@ -229,14 +209,6 @@ export interface LDAIClient {
   ): Promise<Record<T[number]['key'], LDAIAgentConfig>>;
 
   /**
-   * @deprecated Use `agentConfigs` instead. This method will be removed in a future version.
-   */
-  agents<const T extends readonly LDAIAgentRequestConfig[]>(
-    agentConfigs: T,
-    context: LDContext,
-  ): Promise<Record<T[number]['key'], LDAIAgentConfig>>;
-
-  /**
    * Creates and returns a new ManagedModel instance for LLM model interactions.
    *
    * @param key The key identifying the AI completion configuration to use.
@@ -296,28 +268,6 @@ export interface LDAIClient {
     variables?: Record<string, unknown>,
     defaultAiProvider?: SupportedAIProvider,
   ): Promise<ManagedAgent | undefined>;
-
-  /**
-   * @deprecated Use `createModel` instead. This method will be removed in a future version.
-   */
-  createChat(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-    defaultAiProvider?: SupportedAIProvider,
-  ): Promise<ManagedModel | undefined>;
-
-  /**
-   * @deprecated Use `createModel` instead. This method will be removed in a future version.
-   */
-  initChat(
-    key: string,
-    context: LDContext,
-    defaultValue?: LDAICompletionConfigDefault,
-    variables?: Record<string, unknown>,
-    defaultAiProvider?: SupportedAIProvider,
-  ): Promise<ManagedModel | undefined>;
 
   /**
    * Creates and returns a new Judge instance for AI evaluation.

--- a/packages/sdk/server-ai/src/api/LDAIClient.ts
+++ b/packages/sdk/server-ai/src/api/LDAIClient.ts
@@ -82,6 +82,16 @@ export interface LDAIClient {
   ): Promise<LDAICompletionConfig>;
 
   /**
+   * @deprecated Use `completionConfig` instead. This method will be removed in a future version.
+   */
+  config(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+  ): Promise<LDAICompletionConfig>;
+
+  /**
    * Retrieves and processes a single AI Config agent based on the provided key, LaunchDarkly context,
    * and variables. This includes the model configuration and the customized instructions.
    *
@@ -121,6 +131,16 @@ export interface LDAIClient {
     defaultValue?: LDAIAgentConfigDefault,
     variables?: Record<string, unknown>,
     defaultAiProvider?: SupportedAIProvider,
+  ): Promise<LDAIAgentConfig>;
+
+  /**
+   * @deprecated Use `agentConfig` instead. This method will be removed in a future version.
+   */
+  agent(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIAgentConfigDefault,
+    variables?: Record<string, unknown>,
   ): Promise<LDAIAgentConfig>;
 
   /**
@@ -209,6 +229,14 @@ export interface LDAIClient {
   ): Promise<Record<T[number]['key'], LDAIAgentConfig>>;
 
   /**
+   * @deprecated Use `agentConfigs` instead. This method will be removed in a future version.
+   */
+  agents<const T extends readonly LDAIAgentRequestConfig[]>(
+    agentConfigs: T,
+    context: LDContext,
+  ): Promise<Record<T[number]['key'], LDAIAgentConfig>>;
+
+  /**
    * Creates and returns a new ManagedModel instance for LLM model interactions.
    *
    * @param key The key identifying the AI completion configuration to use.
@@ -268,6 +296,28 @@ export interface LDAIClient {
     variables?: Record<string, unknown>,
     defaultAiProvider?: SupportedAIProvider,
   ): Promise<ManagedAgent | undefined>;
+
+  /**
+   * @deprecated Use `createModel` instead. This method will be removed in a future version.
+   */
+  createChat(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<ManagedModel | undefined>;
+
+  /**
+   * @deprecated Use `createModel` instead. This method will be removed in a future version.
+   */
+  initChat(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    variables?: Record<string, unknown>,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<ManagedModel | undefined>;
 
   /**
    * Creates and returns a new Judge instance for AI evaluation.

--- a/packages/sdk/server-ai/src/api/judge/index.ts
+++ b/packages/sdk/server-ai/src/api/judge/index.ts
@@ -1,2 +1,2 @@
 export { Judge } from './Judge';
-export type { LDJudgeResult, StructuredResponse } from './types';
+export type { LDJudgeResult } from './types';

--- a/packages/sdk/server-ai/src/api/judge/types.ts
+++ b/packages/sdk/server-ai/src/api/judge/types.ts
@@ -1,21 +1,3 @@
-import { LDAIMetrics } from '../metrics/LDAIMetrics';
-
-/**
- * Structured response from AI models.
- */
-export interface StructuredResponse {
-  /** The structured data returned by the model */
-  data: Record<string, unknown>;
-
-  /** The raw response from the model */
-  rawResponse: string;
-
-  /**
-   * Metrics information including success status and token usage.
-   */
-  metrics: LDAIMetrics;
-}
-
 /**
  * Result from a judge evaluation containing score, reasoning, and metadata.
  */

--- a/packages/sdk/server-ai/src/api/providers/AIProvider.ts
+++ b/packages/sdk/server-ai/src/api/providers/AIProvider.ts
@@ -41,7 +41,6 @@ export abstract class AIProvider {
    * @returns Promise resolving to a {@link Runner}, or `undefined` if this
    *   provider does not support model creation.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async createModel(_config: LDAICompletionConfig | LDAIJudgeConfig): Promise<Runner | undefined> {
     return undefined;
   }
@@ -57,7 +56,6 @@ export abstract class AIProvider {
    * @returns Promise resolving to a {@link Runner}, or `undefined` if this
    *   provider does not support agent creation.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async createAgent(_config: LDAIAgentConfig, _tools?: ToolRegistry): Promise<Runner | undefined> {
     return undefined;
   }
@@ -74,10 +72,8 @@ export abstract class AIProvider {
    *   this provider does not support graph execution.
    */
   async createAgentGraph(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    graphDef: AgentGraphDefinition,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    tools?: ToolRegistry,
+    _graphDef: AgentGraphDefinition,
+    _tools?: ToolRegistry,
   ): Promise<AgentGraphRunner | undefined> {
     return undefined;
   }

--- a/packages/sdk/server-ai/src/api/providers/AIProvider.ts
+++ b/packages/sdk/server-ai/src/api/providers/AIProvider.ts
@@ -1,3 +1,5 @@
+import { LDLogger } from '@launchdarkly/js-server-sdk-common';
+
 import { LDAIAgentConfig, LDAICompletionConfig, LDAIJudgeConfig } from '../config/types';
 import { AgentGraphDefinition } from '../graph/AgentGraphDefinition';
 import { AgentGraphRunner, Runner } from './Runner';
@@ -23,6 +25,11 @@ export type ToolRegistry = Record<string, (...args: any[]) => unknown>;
  * actually support.
  */
 export abstract class AIProvider {
+  protected _logger?: LDLogger;
+
+  constructor(logger?: LDLogger) {
+    this._logger = logger;
+  }
   /**
    * Create a Runner for a completion or judge AI Config.
    *

--- a/packages/sdk/server-ai/src/api/providers/AIProvider.ts
+++ b/packages/sdk/server-ai/src/api/providers/AIProvider.ts
@@ -25,6 +25,7 @@ export type ToolRegistry = Record<string, (...args: any[]) => unknown>;
  * actually support.
  */
 export abstract class AIProvider {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   protected _logger?: LDLogger;
 
   constructor(logger?: LDLogger) {

--- a/packages/sdk/server-ai/src/api/providers/AIProvider.ts
+++ b/packages/sdk/server-ai/src/api/providers/AIProvider.ts
@@ -1,9 +1,5 @@
-import { LDLogger } from '@launchdarkly/js-server-sdk-common';
-
-import { ChatResponse } from '../chat/types';
-import { LDAIConfigKind, LDMessage } from '../config/types';
+import { LDAIAgentConfig, LDAICompletionConfig, LDAIJudgeConfig } from '../config/types';
 import { AgentGraphDefinition } from '../graph/AgentGraphDefinition';
-import { StructuredResponse } from '../judge/types';
 import { AgentGraphRunner, Runner } from './Runner';
 
 /**
@@ -14,97 +10,31 @@ import { AgentGraphRunner, Runner } from './Runner';
 export type ToolRegistry = Record<string, (...args: any[]) => unknown>;
 
 /**
- * Abstract base class for AI providers that implement chat model functionality.
- * This class provides the contract that all provider implementations must follow
- * to integrate with LaunchDarkly's tracking and configuration capabilities.
+ * Abstract base class for AI providers.
  *
- * Following the AICHAT spec recommendation to use base classes with non-abstract methods
- * for better extensibility and backwards compatibility.
+ * An `AIProvider` is a per-provider factory: it is instantiated once per
+ * provider package and is responsible for constructing focused runtime
+ * capability objects via {@link createModel}, {@link createAgent}, and
+ * {@link createAgentGraph}.
+ *
+ * Provider packages subclass `AIProvider` and override the methods they
+ * support. The default implementations return `undefined`, mirroring Python's
+ * base-class behaviour, so providers only need to implement the modes they
+ * actually support.
  */
 export abstract class AIProvider {
-  protected readonly logger?: LDLogger;
-
-  constructor(logger?: LDLogger) {
-    this.logger = logger;
-  }
-  /**
-   * Invoke the chat model with an array of messages.
-   *
-   * Default implementation takes no action and returns a placeholder response.
-   * Provider implementations should override this method.
-   *
-   * @deprecated Use the `Runner` interface and its `run` method instead.
-   * @param messages Array of LDMessage objects representing the conversation
-   * @returns Promise that resolves to a ChatResponse containing the model's response
-   */
-  async invokeModel(_messages: LDMessage[]): Promise<ChatResponse> {
-    this.logger?.warn('invokeModel not implemented by this provider');
-    return {
-      message: {
-        role: 'assistant',
-        content: '',
-      },
-      metrics: {
-        success: false,
-        usage: {
-          total: 0,
-          input: 0,
-          output: 0,
-        },
-      },
-    };
-  }
-
-  /**
-   * Invoke the chat model with structured output support.
-   *
-   * Default implementation takes no action and returns a placeholder response.
-   * Provider implementations should override this method.
-   *
-   * @deprecated Use the `Runner` interface and its `run` method with `outputType` instead.
-   * @param messages Array of LDMessage objects representing the conversation
-   * @param responseStructure Dictionary of output configurations keyed by output name
-   * @returns Promise that resolves to a structured response
-   */
-  async invokeStructuredModel(
-    _messages: LDMessage[],
-    _responseStructure: Record<string, unknown>,
-  ): Promise<StructuredResponse> {
-    this.logger?.warn('invokeStructuredModel not implemented by this provider');
-    return {
-      data: {},
-      rawResponse: '',
-      metrics: {
-        success: false,
-        usage: {
-          total: 0,
-          input: 0,
-          output: 0,
-        },
-      },
-    };
-  }
-
-  // ============================================================================
-  // Factory instance methods (Python AIProvider pattern)
-  //
-  // Provider packages override these to return a configured Runner for the
-  // relevant mode. The default implementations log a warning and return
-  // undefined, mirroring Python's base-class behaviour.
-  // ============================================================================
-
   /**
    * Create a Runner for a completion or judge AI Config.
    *
    * Override in provider subclasses to return a configured {@link Runner}.
-   * Default implementation logs a warning and returns `undefined`.
+   * Default implementation returns `undefined`.
    *
    * @param config The completion or judge AI configuration.
    * @returns Promise resolving to a {@link Runner}, or `undefined` if this
    *   provider does not support model creation.
    */
-  async createModel(_config: LDAIConfigKind): Promise<Runner | undefined> {
-    this.logger?.warn('createModel not implemented by this provider');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createModel(config: LDAICompletionConfig | LDAIJudgeConfig): Promise<Runner | undefined> {
     return undefined;
   }
 
@@ -112,15 +42,15 @@ export abstract class AIProvider {
    * Create a Runner for an agent AI Config.
    *
    * Override in provider subclasses to return a configured {@link Runner}.
-   * Default implementation logs a warning and returns `undefined`.
+   * Default implementation returns `undefined`.
    *
    * @param config The agent AI configuration.
    * @param tools Optional registry of callable tools.
    * @returns Promise resolving to a {@link Runner}, or `undefined` if this
    *   provider does not support agent creation.
    */
-  async createAgent(_config: LDAIConfigKind, _tools?: ToolRegistry): Promise<Runner | undefined> {
-    this.logger?.warn('createAgent not implemented by this provider');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createAgent(config: LDAIAgentConfig, tools?: ToolRegistry): Promise<Runner | undefined> {
     return undefined;
   }
 
@@ -128,7 +58,7 @@ export abstract class AIProvider {
    * Create an AgentGraphRunner for an agent graph definition.
    *
    * Override in provider subclasses to return a configured {@link AgentGraphRunner}.
-   * Default implementation logs a warning and returns `undefined`.
+   * Default implementation returns `undefined`.
    *
    * @param graphDef The agent graph definition.
    * @param tools Optional registry of callable tools.
@@ -136,29 +66,11 @@ export abstract class AIProvider {
    *   this provider does not support graph execution.
    */
   async createAgentGraph(
-    _graphDef: AgentGraphDefinition,
-    _tools?: ToolRegistry,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    graphDef: AgentGraphDefinition,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    tools?: ToolRegistry,
   ): Promise<AgentGraphRunner | undefined> {
-    this.logger?.warn('createAgentGraph not implemented by this provider');
     return undefined;
-  }
-
-  // ============================================================================
-  // Legacy static factory (retained for backward compatibility)
-  // ============================================================================
-
-  /**
-   * Static method that constructs an instance of the provider.
-   * Each provider implementation must provide their own static create method
-   * that accepts an AIConfig and returns a configured instance.
-   *
-   * @deprecated Use the `createModel` factory method instead.
-   * @param aiConfig The LaunchDarkly AI configuration
-   * @param logger Optional logger for the provider
-   * @returns Promise that resolves to a configured provider instance
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static async create(aiConfig: LDAIConfigKind, logger?: LDLogger): Promise<AIProvider> {
-    throw new Error('Provider implementations must override the static create method');
   }
 }

--- a/packages/sdk/server-ai/src/api/providers/AIProvider.ts
+++ b/packages/sdk/server-ai/src/api/providers/AIProvider.ts
@@ -42,7 +42,7 @@ export abstract class AIProvider {
    *   provider does not support model creation.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async createModel(config: LDAICompletionConfig | LDAIJudgeConfig): Promise<Runner | undefined> {
+  async createModel(_config: LDAICompletionConfig | LDAIJudgeConfig): Promise<Runner | undefined> {
     return undefined;
   }
 
@@ -58,7 +58,7 @@ export abstract class AIProvider {
    *   provider does not support agent creation.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async createAgent(config: LDAIAgentConfig, tools?: ToolRegistry): Promise<Runner | undefined> {
+  async createAgent(_config: LDAIAgentConfig, _tools?: ToolRegistry): Promise<Runner | undefined> {
     return undefined;
   }
 

--- a/packages/sdk/server-ai/src/api/providers/RunnerFactory.ts
+++ b/packages/sdk/server-ai/src/api/providers/RunnerFactory.ts
@@ -1,6 +1,10 @@
 import { LDLogger } from '@launchdarkly/js-server-sdk-common';
 
-import { LDAIConfigKind } from '../config/types';
+import {
+  LDAIAgentConfig,
+  LDAICompletionConfig,
+  LDAIJudgeConfig,
+} from '../config/types';
 import { AgentGraphDefinition } from '../graph/AgentGraphDefinition';
 import { AIProvider, ToolRegistry } from './AIProvider';
 import { AgentGraphRunner, Runner } from './Runner';
@@ -29,21 +33,16 @@ export type SupportedAIProvider = (typeof SUPPORTED_AI_PROVIDERS)[number];
  * via {@link _getProviderFactory}, and delegates creation to the factory
  * instance methods on {@link AIProvider}.
  *
- * Provider packages implement {@link AIProvider} factory methods
- * (`createModel`, `createAgent`, `createAgentGraph`). The legacy
- * {@link AIProvider} abstract class is retained for backward compatibility,
- * and the {@link _LegacyProviderAdapter} shim wraps packages that have not
- * yet migrated to the new pattern.
+ * Provider packages subclass {@link AIProvider} and override its factory
+ * methods (`createModel`, `createAgent`, `createAgentGraph`).
  */
 export class RunnerFactory {
   /**
    * Load and return the AIProvider factory for the given provider type.
    *
    * This is the single place in the codebase that knows provider package names.
-   * If the provider package exports the new `*RunnerFactory` class, it is
-   * instantiated directly. Otherwise a {@link _LegacyProviderAdapter} wrapping
-   * the old `static create()` class is returned to keep CI green during the
-   * transition.
+   * Each supported provider package exports a `*RunnerFactory` class that
+   * extends {@link AIProvider}; this method instantiates it directly.
    *
    * @param providerType One of the {@link SUPPORTED_AI_PROVIDERS} values.
    * @param logger Optional logger forwarded to the provider factory.
@@ -163,7 +162,7 @@ export class RunnerFactory {
    *   `undefined` if no suitable provider could be loaded.
    */
   static async createModel(
-    config: LDAIConfigKind,
+    config: LDAICompletionConfig | LDAIJudgeConfig,
     logger?: LDLogger,
     defaultAiProvider?: SupportedAIProvider,
   ): Promise<Runner | undefined> {
@@ -200,7 +199,7 @@ export class RunnerFactory {
    *   provider could be loaded.
    */
   static async createAgent(
-    config: LDAIConfigKind,
+    config: LDAIAgentConfig,
     tools?: ToolRegistry,
     logger?: LDLogger,
     defaultAiProvider?: SupportedAIProvider,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat!: Remove AIProvider deprecated methods
END_COMMIT_OVERRIDE

## Summary

Cleanup PR removing the deprecated AIProvider compatibility surface that was kept in place while the OpenAI (#1337), LangChain (#1338), and Vercel (#1339) provider packages migrated to the new Runner protocol. This PR targets the umbrella branch `feat/next-ai-release`; the final `feat/next-ai-release` -> `main` PR will release these breaking changes together.

### Removed (breaking)

**AIProvider abstract base class:**
- `invokeModel()` / `invokeStructuredModel()` instance methods
- `static create()` factory method

**Public types:**
- `StructuredResponse` (only consumed by the removed `invokeStructuredModel`)

### Type narrowing

The base `AIProvider` factory methods now use specific config types instead of the wider `LDAIConfigKind` union, mirroring what each provider subclass already declared in its overrides:

- `createModel(config: LDAICompletionConfig | LDAIJudgeConfig)`
- `createAgent(config: LDAIAgentConfig)`
- `createAgentGraph(graphDef: AgentGraphDefinition)`

`RunnerFactory.createModel` / `createAgent` follow the same narrowing.

> **Note on the typing approach:** the Python SDK uses `Any` because it is dynamically typed. For the JS SDK I chose specific config types per method, since each provider's overrides already declared them and TypeScript can usefully enforce them. Open to feedback if reviewers prefer a different shape.

### Out of scope (kept in place)

- **`LDAIClient` deprecated method aliases** — `config`, `agent`, `agents`, `createChat`, `initChat`. These are unrelated to the AIProvider work and should follow their own deprecation cycle.
- **`AIProvider.protected _logger`** — kept as the per-instance logger storage; not part of the deprecated surface.

### Other cleanup

- Removed the stale `_LegacyProviderAdapter` references in `RunnerFactory` doc comments (the adapter no longer exists).
- Updated provider README examples from `initChat`/`createChat` to `createModel`/`run()`.
- Backfilled `as unknown as LDAI...Config` casts in pre-existing test fixtures so the rebuilt `@launchdarkly/server-sdk-ai` types resolve correctly.

## Test plan

- [x] `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/server-sdk-ai' run build` succeeds
- [x] `yarn workspace @launchdarkly/server-sdk-ai test` — 227 tests pass
- [x] `yarn workspace @launchdarkly/server-sdk-ai-openai test` passes
- [x] `yarn workspace @launchdarkly/server-sdk-ai-langchain test` passes
- [x] `yarn workspace @launchdarkly/server-sdk-ai-vercel test` passes
- [x] `yarn workspace @launchdarkly/server-sdk-ai lint` clean
- [ ] e2e validation via `packages/sdk/server-ai/examples/chat-judge` (separate agent)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it removes/deprecates public `AIProvider`/judge type surface area and tightens config types in `AIProvider`/`RunnerFactory`, which can break downstream provider implementations and TypeScript consumers at compile time.
> 
> **Overview**
> This PR **removes the remaining deprecated AIProvider compatibility surface**, including `invokeModel`, `invokeStructuredModel`, the legacy `static create()` pattern, and the exported `StructuredResponse` type.
> 
> It **tightens provider factory APIs** by narrowing `AIProvider.createModel`/`RunnerFactory.createModel` to `LDAICompletionConfig | LDAIJudgeConfig` and `createAgent` to `LDAIAgentConfig`, and updates provider implementations/tests accordingly (including switching factories to consistently pass `this._logger`).
> 
> Docs/examples are updated to the **managed model** flow (`createModel` + `run()`) instead of `initChat`/`invoke()`, and the server SDK README reframes the abstraction from conversational `TrackedChat` to `ManagedModel` with async judge evaluations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afde51107f62f8b6f14ae954f0821a7bb43f0b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->