### PR TITLE
feat!: Rename LDAIMetrics.usage and LDAIGraphMetrics.usage to .tokens

### DIFF
--- a/packages/ai-providers/server-ai-langchain/__tests__/LangChainAgentRunner.test.ts
+++ b/packages/ai-providers/server-ai-langchain/__tests__/LangChainAgentRunner.test.ts
@@ -27,7 +27,7 @@ it('returns content with no toolCalls when the agent returns a simple response',
   expect(result.content).toBe('done');
   expect(result.metrics.success).toBe(true);
   expect(result.metrics.toolCalls).toBeUndefined();
-  expect(result.metrics.usage).toEqual({ total: 6, input: 4, output: 2 });
+  expect(result.metrics.tokens).toEqual({ total: 6, input: 4, output: 2 });
 });
 
 it('extracts tool calls and aggregates usage from multi-step agent messages', async () => {
@@ -56,7 +56,7 @@ it('extracts tool calls and aggregates usage from multi-step agent messages', as
 
   expect(result.content).toBe('Answer is 42.');
   expect(result.metrics.toolCalls).toEqual(['lookup']);
-  expect(result.metrics.usage).toEqual({ total: 28, input: 16, output: 12 });
+  expect(result.metrics.tokens).toEqual({ total: 28, input: 16, output: 12 });
 });
 
 it('returns success=false when the agent throws', async () => {
@@ -83,5 +83,5 @@ it('handles empty messages array gracefully', async () => {
   expect(result.content).toBe('');
   expect(result.metrics.success).toBe(true);
   expect(result.metrics.toolCalls).toBeUndefined();
-  expect(result.metrics.usage).toBeUndefined();
+  expect(result.metrics.tokens).toBeUndefined();
 });

--- a/packages/ai-providers/server-ai-langchain/__tests__/LangChainHelper.test.ts
+++ b/packages/ai-providers/server-ai-langchain/__tests__/LangChainHelper.test.ts
@@ -102,7 +102,7 @@ it('returns success=true with usage from the response', () => {
   message.usage_metadata = { total_tokens: 3, input_tokens: 1, output_tokens: 2 };
   expect(getAIMetricsFromResponse(message)).toEqual({
     success: true,
-    usage: { total: 3, input: 1, output: 2 },
+    tokens: { total: 3, input: 1, output: 2 },
   });
 });
 

--- a/packages/ai-providers/server-ai-langchain/__tests__/LangChainModelRunner.test.ts
+++ b/packages/ai-providers/server-ai-langchain/__tests__/LangChainModelRunner.test.ts
@@ -41,7 +41,7 @@ describe('LangChainModelRunner', () => {
     expect(result.content).toBe('hello');
     expect(result.metrics).toEqual({
       success: true,
-      usage: { total: 12, input: 7, output: 5 },
+      tokens: { total: 12, input: 7, output: 5 },
     });
     expect(result.raw).toBe(response);
   });

--- a/packages/ai-providers/server-ai-langchain/src/LangChainAgentRunner.ts
+++ b/packages/ai-providers/server-ai-langchain/src/LangChainAgentRunner.ts
@@ -61,7 +61,7 @@ export class LangChainAgentRunner implements Runner {
 
       const metrics: LDAIMetrics = {
         success: true,
-        usage: sumTokenUsageFromMessages(messages),
+        tokens: sumTokenUsageFromMessages(messages),
         toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       };
 

--- a/packages/ai-providers/server-ai-langchain/src/LangChainHelper.ts
+++ b/packages/ai-providers/server-ai-langchain/src/LangChainHelper.ts
@@ -80,7 +80,7 @@ export function getAIUsageFromResponse(response: AIMessage): LDTokenUsage | unde
 export function getAIMetricsFromResponse(response: AIMessage): LDAIMetrics {
   return {
     success: true,
-    usage: getAIUsageFromResponse(response),
+    tokens: getAIUsageFromResponse(response),
   };
 }
 

--- a/packages/ai-providers/server-ai-langchain/src/LangChainModelRunner.ts
+++ b/packages/ai-providers/server-ai-langchain/src/LangChainModelRunner.ts
@@ -96,7 +96,7 @@ export class LangChainModelRunner implements Runner {
 
       const metrics = {
         success: true,
-        usage: { total: 0, input: 0, output: 0 },
+        tokens: { total: 0, input: 0, output: 0 },
       };
 
       return {
@@ -111,7 +111,7 @@ export class LangChainModelRunner implements Runner {
         content: '',
         metrics: {
           success: false,
-          usage: { total: 0, input: 0, output: 0 },
+          tokens: { total: 0, input: 0, output: 0 },
         },
       };
     }

--- a/packages/ai-providers/server-ai-openai/__tests__/OpenAIAgentRunner.test.ts
+++ b/packages/ai-providers/server-ai-openai/__tests__/OpenAIAgentRunner.test.ts
@@ -32,7 +32,7 @@ describe('OpenAIAgentRunner', () => {
     expect(result.content).toBe('Done');
     expect(result.metrics.success).toBe(true);
     expect(result.metrics.toolCalls).toBeUndefined();
-    expect(result.metrics.usage).toEqual({ total: 12, input: 8, output: 4 });
+    expect(result.metrics.tokens).toEqual({ total: 12, input: 8, output: 4 });
   });
 
   it('reports tool calls from newItems with LD config name mapping', async () => {
@@ -55,7 +55,7 @@ describe('OpenAIAgentRunner', () => {
 
     expect(result.content).toBe('The answer is 42.');
     expect(result.metrics.toolCalls).toEqual(['lookup']);
-    expect(result.metrics.usage).toEqual({ total: 28, input: 16, output: 12 });
+    expect(result.metrics.tokens).toEqual({ total: 28, input: 16, output: 12 });
   });
 
   it('returns an unsuccessful RunnerResult when the agent run throws', async () => {

--- a/packages/ai-providers/server-ai-openai/__tests__/OpenAIHelper.test.ts
+++ b/packages/ai-providers/server-ai-openai/__tests__/OpenAIHelper.test.ts
@@ -41,7 +41,7 @@ it('returns success=true with usage extracted from the response', () => {
 
   expect(metrics).toEqual({
     success: true,
-    usage: { total: 3, input: 1, output: 2 },
+    tokens: { total: 3, input: 1, output: 2 },
   });
 });
 

--- a/packages/ai-providers/server-ai-openai/__tests__/OpenAIModelRunner.test.ts
+++ b/packages/ai-providers/server-ai-openai/__tests__/OpenAIModelRunner.test.ts
@@ -46,7 +46,7 @@ describe('OpenAIModelRunner', () => {
       expect(result.content).toBe('Hello there!');
       expect(result.metrics).toEqual({
         success: true,
-        usage: { total: 15, input: 10, output: 5 },
+        tokens: { total: 15, input: 10, output: 5 },
       });
       expect(result.raw).toBe(mockResponse);
       expect(result.parsed).toBeUndefined();

--- a/packages/ai-providers/server-ai-openai/src/OpenAIAgentRunner.ts
+++ b/packages/ai-providers/server-ai-openai/src/OpenAIAgentRunner.ts
@@ -61,10 +61,10 @@ export class OpenAIAgentRunner implements Runner {
         [],
       );
 
-      const usage: LDTokenUsage | undefined = getAIUsageFromAgentResult(result);
+      const tokens: LDTokenUsage | undefined = getAIUsageFromAgentResult(result);
       const metrics: LDAIMetrics = {
         success: true,
-        usage,
+        tokens,
         toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       };
 

--- a/packages/ai-providers/server-ai-openai/src/OpenAIHelper.ts
+++ b/packages/ai-providers/server-ai-openai/src/OpenAIHelper.ts
@@ -42,7 +42,7 @@ export function getAIUsageFromResponse(response: any): LDTokenUsage | undefined 
 export function getAIMetricsFromResponse(response: any): LDAIMetrics {
   return {
     success: true,
-    usage: getAIUsageFromResponse(response),
+    tokens: getAIUsageFromResponse(response),
   };
 }
 

--- a/packages/ai-providers/server-ai-vercel/__tests__/VercelHelper.test.ts
+++ b/packages/ai-providers/server-ai-vercel/__tests__/VercelHelper.test.ts
@@ -62,7 +62,7 @@ describe('getAIMetricsFromResponse', () => {
       getAIMetricsFromResponse({
         usage: { totalTokens: 5, promptTokens: 2, completionTokens: 3 },
       }),
-    ).toEqual({ success: true, usage: { total: 5, input: 2, output: 3 } });
+    ).toEqual({ success: true, tokens: { total: 5, input: 2, output: 3 } });
   });
 
   it('marks success=false when finishReason is "error"', () => {
@@ -83,7 +83,7 @@ describe('getAIMetricsFromStream', () => {
     });
     expect(result).toEqual({
       success: true,
-      usage: { total: 100, input: 49, output: 51 },
+      tokens: { total: 100, input: 49, output: 51 },
     });
   });
 

--- a/packages/ai-providers/server-ai-vercel/__tests__/VercelModelRunner.test.ts
+++ b/packages/ai-providers/server-ai-vercel/__tests__/VercelModelRunner.test.ts
@@ -51,7 +51,7 @@ describe('VercelModelRunner', () => {
       expect(out.content).toBe('Hi!');
       expect(out.metrics).toEqual({
         success: true,
-        usage: { total: 12, input: 7, output: 5 },
+        tokens: { total: 12, input: 7, output: 5 },
       });
       expect(out.raw).toBe(result);
     });
@@ -87,7 +87,7 @@ describe('VercelModelRunner', () => {
 
       const out = await runner.run('hello');
 
-      expect(out.metrics.usage).toEqual({ total: 100, input: 40, output: 60 });
+      expect(out.metrics.tokens).toEqual({ total: 100, input: 40, output: 60 });
     });
 
     it('returns success=false when generateText throws', async () => {

--- a/packages/ai-providers/server-ai-vercel/src/VercelHelper.ts
+++ b/packages/ai-providers/server-ai-vercel/src/VercelHelper.ts
@@ -44,16 +44,16 @@ export function mapUsageDataToLDTokenUsage(usageData: ModelUsageTokens): LDToken
 export function getAIMetricsFromResponse(response: TextResponse): LDAIMetrics {
   const finishReason = response?.finishReason ?? 'unknown';
 
-  let usage: LDTokenUsage | undefined;
+  let tokens: LDTokenUsage | undefined;
   if (response?.totalUsage) {
-    usage = mapUsageDataToLDTokenUsage(response.totalUsage);
+    tokens = mapUsageDataToLDTokenUsage(response.totalUsage);
   } else if (response?.usage) {
-    usage = mapUsageDataToLDTokenUsage(response.usage);
+    tokens = mapUsageDataToLDTokenUsage(response.usage);
   }
 
   return {
     success: finishReason !== 'error',
-    usage,
+    tokens,
   };
 }
 
@@ -66,24 +66,24 @@ export function getAIMetricsFromResponse(response: TextResponse): LDAIMetrics {
 export async function getAIMetricsFromStream(stream: StreamResponse): Promise<LDAIMetrics> {
   const finishReason = (await stream.finishReason?.catch(() => 'error')) ?? 'unknown';
 
-  let usage: LDTokenUsage | undefined;
+  let tokens: LDTokenUsage | undefined;
 
   if (stream.totalUsage) {
     const usageData = await stream.totalUsage.catch(() => undefined);
     if (usageData) {
-      usage = mapUsageDataToLDTokenUsage(usageData);
+      tokens = mapUsageDataToLDTokenUsage(usageData);
     }
   }
 
-  if (!usage && stream.usage) {
+  if (!tokens && stream.usage) {
     const usageData = await stream.usage.catch(() => undefined);
     if (usageData) {
-      usage = mapUsageDataToLDTokenUsage(usageData);
+      tokens = mapUsageDataToLDTokenUsage(usageData);
     }
   }
 
   return {
     success: finishReason !== 'error',
-    usage,
+    tokens,
   };
 }

--- a/packages/sdk/server-ai/__tests__/Judge.test.ts
+++ b/packages/sdk/server-ai/__tests__/Judge.test.ts
@@ -192,7 +192,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: {
+          tokens: {
             total: 100,
             input: 50,
             output: 50,
@@ -254,7 +254,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -283,7 +283,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -356,7 +356,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -391,7 +391,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -426,7 +426,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -462,7 +462,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -512,7 +512,7 @@ describe('Judge', () => {
         parsed: undefined,
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -538,7 +538,7 @@ describe('Judge', () => {
         parsed: {},
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -568,7 +568,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 
@@ -642,7 +642,7 @@ describe('Judge', () => {
         },
         metrics: {
           success: true,
-          usage: { total: 100, input: 50, output: 50 },
+          tokens: { total: 100, input: 50, output: 50 },
         },
       };
 

--- a/packages/sdk/server-ai/__tests__/LDAIConfigTrackerImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIConfigTrackerImpl.test.ts
@@ -723,7 +723,7 @@ describe('trackMetricsOf', () => {
     const mockResult = { response: 'test' };
     const mockMetrics = {
       success: true,
-      usage: { total: 100, input: 50, output: 50 },
+      tokens: { total: 100, input: 50, output: 50 },
     };
 
     const metricsExtractor = jest.fn().mockReturnValue(mockMetrics);

--- a/packages/sdk/server-ai/__tests__/ManagedAgentGraph.test.ts
+++ b/packages/sdk/server-ai/__tests__/ManagedAgentGraph.test.ts
@@ -68,10 +68,10 @@ describe('ManagedAgentGraph', () => {
         success: true,
         path: ['node-a', 'node-b'],
         durationMs: 1500,
-        usage: { total: 100, input: 50, output: 50 },
+        tokens: { total: 100, input: 50, output: 50 },
         nodeMetrics: {
-          'node-a': { success: true, usage: { total: 40, input: 20, output: 20 } },
-          'node-b': { success: true, usage: { total: 60, input: 30, output: 30 } },
+          'node-a': { success: true, tokens: { total: 40, input: 20, output: 20 } },
+          'node-b': { success: true, tokens: { total: 60, input: 30, output: 30 } },
         },
       },
     };
@@ -103,7 +103,7 @@ describe('ManagedAgentGraph', () => {
         nodeMetrics: {
           n1: {
             success: true,
-            usage: { total: 10, input: 5, output: 5 },
+            tokens: { total: 10, input: 5, output: 5 },
             durationMs: 200,
             toolCalls: ['tool-a'],
           },

--- a/packages/sdk/server-ai/__tests__/ManagedModel.test.ts
+++ b/packages/sdk/server-ai/__tests__/ManagedModel.test.ts
@@ -50,7 +50,7 @@ describe('ManagedModel', () => {
   it('passes the prompt directly to the runner without prepending config messages', async () => {
     const runnerResult: RunnerResult = {
       content: 'Response from model',
-      metrics: { success: true, usage: { total: 10, input: 4, output: 6 } },
+      metrics: { success: true, tokens: { total: 10, input: 4, output: 6 } },
     };
 
     mockTracker.trackMetricsOf.mockImplementation(async (_extractor, func) => func());
@@ -68,7 +68,7 @@ describe('ManagedModel', () => {
       content: 'Hi there',
       metrics: {
         success: true,
-        usage: { total: 12, input: 5, output: 7 },
+        tokens: { total: 12, input: 5, output: 7 },
         toolCalls: ['tool-1'],
         durationMs: 42,
       },
@@ -99,7 +99,7 @@ describe('ManagedModel', () => {
   it('forwards the runner result through tracker.trackMetricsOf', async () => {
     const runnerResult: RunnerResult = {
       content: 'tracked',
-      metrics: { success: true, usage: { total: 1, input: 1, output: 0 } },
+      metrics: { success: true, tokens: { total: 1, input: 1, output: 0 } },
     };
 
     mockTracker.trackMetricsOf.mockImplementation(async (_extractor, func) => func());
@@ -117,7 +117,7 @@ describe('ManagedModel', () => {
   it('does not retain conversation state across runs', async () => {
     const runnerResult: RunnerResult = {
       content: 'ok',
-      metrics: { success: true, usage: { total: 1, input: 1, output: 0 } },
+      metrics: { success: true, tokens: { total: 1, input: 1, output: 0 } },
     };
 
     mockTracker.trackMetricsOf.mockImplementation(async (_extractor, func) => func());

--- a/packages/sdk/server-ai/src/LDAIConfigTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIConfigTrackerImpl.ts
@@ -208,8 +208,8 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
     }
 
     // Track token usage if available
-    if (metrics.usage) {
-      this.trackTokens(metrics.usage);
+    if (metrics.tokens) {
+      this.trackTokens(metrics.tokens);
     }
 
     // Track tool calls if available
@@ -260,8 +260,8 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
       }
 
       // Track token usage if available
-      if (metrics.usage) {
-        this.trackTokens(metrics.usage);
+      if (metrics.tokens) {
+        this.trackTokens(metrics.tokens);
       }
 
       // Track tool calls if available

--- a/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
+++ b/packages/sdk/server-ai/src/api/graph/ManagedAgentGraph.ts
@@ -47,7 +47,7 @@ export class ManagedAgentGraph {
       success: runnerResult.metrics.success,
       path: runnerResult.metrics.path,
       durationMs: runnerResult.metrics.durationMs,
-      tokens: runnerResult.metrics.usage,
+      tokens: runnerResult.metrics.tokens,
       nodeMetrics: this._trackNodeMetrics(runnerResult.metrics.nodeMetrics),
       resumptionToken: graphTracker.resumptionToken,
     };
@@ -79,8 +79,8 @@ export class ManagedAgentGraph {
       }
 
       const tracker = node.getConfig().createTracker!();
-      if (metrics.usage) {
-        tracker.trackTokens(metrics.usage);
+      if (metrics.tokens) {
+        tracker.trackTokens(metrics.tokens);
       }
       if (metrics.durationMs !== undefined) {
         tracker.trackDuration(metrics.durationMs);

--- a/packages/sdk/server-ai/src/api/graph/types.ts
+++ b/packages/sdk/server-ai/src/api/graph/types.ts
@@ -102,7 +102,7 @@ export interface LDAIGraphMetrics {
   /**
    * Aggregate token usage across the entire graph invocation, if available.
    */
-  usage?: LDTokenUsage;
+  tokens?: LDTokenUsage;
 
   /**
    * Per-node metrics keyed by agent config key.

--- a/packages/sdk/server-ai/src/api/metrics/LDAIMetrics.ts
+++ b/packages/sdk/server-ai/src/api/metrics/LDAIMetrics.ts
@@ -14,7 +14,7 @@ export interface LDAIMetrics {
    * Token usage information for the operation.
    * This will be undefined if no token usage data is available.
    */
-  usage?: LDTokenUsage;
+  tokens?: LDTokenUsage;
 
   /**
    * List of tool call identifiers made during the operation.


### PR DESCRIPTION
## Summary

Standardize the runner-level metrics token-usage field on `tokens` to match the summary-level types. The summary types `LDAIMetricSummary` and `LDAIGraphMetricSummary` already use `tokens`; this PR aligns the runner-level `LDAIMetrics` and `LDAIGraphMetrics` with that convention.

This is one of three coordinated PRs that land together:
- spec: https://github.com/launchdarkly/sdk-specs/pull/163
- python-server-sdk-ai: (link to be added by sibling agent)
- this PR (js-core)

## Breaking change

The `usage` property on `LDAIMetrics` and `LDAIGraphMetrics` is renamed to `tokens`. The value type (`LDTokenUsage`) is unchanged. Consumers that construct or read these metrics directly must rename the field.

External provider response shapes (the `usage` property on OpenAI / Bedrock / Vercel response objects) and the LD-internal `$ld:ai:usage:*` event keys are unaffected — those are separate concepts that happen to share the English word.

## What's included

- `LDAIMetrics.usage` → `LDAIMetrics.tokens` (`packages/sdk/server-ai/src/api/metrics/LDAIMetrics.ts`)
- `LDAIGraphMetrics.usage` → `LDAIGraphMetrics.tokens` (`packages/sdk/server-ai/src/api/graph/types.ts`)
- All construction and read sites updated across:
  - `packages/sdk/server-ai`
  - `packages/ai-providers/server-ai-openai`
  - `packages/ai-providers/server-ai-langchain`
  - `packages/ai-providers/server-ai-vercel`
- Tests updated to match the new field name

## Verification

- `LDAIMetricSummary` (in `packages/sdk/server-ai/src/api/model/types.ts`) already uses `tokens` — no change needed
- `LDAIGraphMetricSummary` already uses `tokens` since #1362 — no change needed

## Test plan

- [x] `yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/server-sdk-ai' run build` (server-sdk-ai + ai-providers builds clean)
- [x] `yarn workspace @launchdarkly/server-sdk-ai test` (239 passed)
- [x] `yarn workspace @launchdarkly/server-sdk-ai-openai test` (39 passed)
- [x] `yarn workspace @launchdarkly/server-sdk-ai-langchain test` (38 passed)
- [x] `yarn workspace @launchdarkly/server-sdk-ai-vercel test` (20 passed)
- [x] `yarn workspace ... lint` for each touched package (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API rename from `metrics.usage` to `metrics.tokens` across runners/graphs; low logical risk but will break downstream consumers that read or construct these metrics.
> 
> **Overview**
> **Breaking change:** Standardizes runner-level token-usage metrics by renaming `LDAIMetrics.usage` to `LDAIMetrics.tokens`, and `LDAIGraphMetrics.usage` to `LDAIGraphMetrics.tokens`.
> 
> Updates all provider runners/helpers (LangChain, OpenAI, Vercel) plus managed-layer tracking (`LDAIConfigTrackerImpl`, `ManagedAgentGraph`) and test assertions to read/write the new `tokens` field while leaving underlying token values and provider response `usage` shapes unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6fc84584b50ecc58b7a7447f15fd457450e173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->