### PR TITLE
chore: adding bootstrap example for react sdk

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -112,3 +112,18 @@ jobs:
           workspace_name: '@launchdarkly/react-sdk-example-react-server'
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           before_test: 'yarn workspace @launchdarkly/react-sdk-example-react-server playwright install --with-deps chromium'
+
+  run-bootstrap-example:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - uses: ./actions/run-example
+        with:
+          workspace_name: '@launchdarkly/react-sdk-example-bootstrap'
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          before_test: 'yarn workspace @launchdarkly/react-sdk-example-bootstrap playwright install --with-deps chromium'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "packages/sdk/fastly/example",
     "packages/sdk/react",
     "packages/sdk/react/contract-tests",
+    "packages/sdk/react/examples/features/bootstrap",
     "packages/sdk/react/examples/hello-react",
     "packages/sdk/react/examples/react-server-example",
     "packages/sdk/react/examples/vercel-edge",

--- a/packages/sdk/react/examples/README.md
+++ b/packages/sdk/react/examples/README.md
@@ -5,5 +5,6 @@ This directory contains example applications demonstrating the LaunchDarkly Reac
 | Example | Description |
 |---------|-------------|
 | [hello-react](./hello-react/) | Minimal Vite + React app that evaluates a boolean feature flag and displays the result with real-time updates. This is the recommended starting point. |
+| [features/bootstrap](./features/bootstrap/) | Vite SPA + Express server demonstrating the standalone `bootstrap` option on `LDReactProviderOptions`. The Node Server SDK pre-evaluates flags so the client renders bootstrapped values on first paint without a flag-fetch round-trip. |
 | [react-server-example](./react-server-example/) | Next.js App Router example demonstrating server-side flag evaluation with React Server Components. |
 | [vercel-edge](./vercel-edge/) | Next.js App Router example using the Vercel Edge SDK to evaluate flags from Vercel Edge Config, with server-to-client bootstrap via `LDIsomorphicProvider`. |

--- a/packages/sdk/react/examples/features/bootstrap/.env.example
+++ b/packages/sdk/react/examples/features/bootstrap/.env.example
@@ -1,0 +1,7 @@
+# Set when running yarn start (e.g. LAUNCHDARKLY_SDK_KEY=xxx LAUNCHDARKLY_CLIENT_SIDE_ID=yyy yarn start).
+
+LAUNCHDARKLY_SDK_KEY=
+LAUNCHDARKLY_CLIENT_SIDE_ID=
+
+# Optional: override the boolean flag key the example evaluates. Defaults to "sample-feature".
+# LAUNCHDARKLY_FLAG_KEY=

--- a/packages/sdk/react/examples/features/bootstrap/.gitignore
+++ b/packages/sdk/react/examples/features/bootstrap/.gitignore
@@ -1,0 +1,24 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/dist
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+test-results/

--- a/packages/sdk/react/examples/features/bootstrap/README.md
+++ b/packages/sdk/react/examples/features/bootstrap/README.md
@@ -12,26 +12,35 @@ This demo requires Node.js v20 or later.
 
 ## What this example adds on top of [`hello-react`](../../hello-react/)
 
-* A small Express server (`server/index.ts`) initializes `@launchdarkly/node-server-sdk`,
-  evaluates the client-side flags for the example context with
-  `allFlagsState(context, { clientSideOnly: true })`, and exposes the result at
-  `GET /api/bootstrap`.
-* `src/index.tsx` `await`s that endpoint before mounting the app and passes the response to
+* A small Express server (`server/index.ts`) initializes `@launchdarkly/node-server-sdk` and,
+  on every request to `/`, evaluates the client-side flags for the example context with
+  `allFlagsState(context, { clientSideOnly: true })`.
+* The server renders an EJS template (`views/index.ejs`) that injects the evaluated payload
+  into the page as a `<script>` blob:
+
+  ```html
+  <script>
+    window.__LD_BOOTSTRAP__ = <%- bootstrap %>;
+    window.__LD_CLIENT_SIDE_ID__ = <%- clientSideId %>;
+    window.__LD_CONTEXT__ = <%- context %>;
+  </script>
+  ```
+
+* `src/index.tsx` reads those values synchronously and hands the bootstrap payload to
   `LDReactProviderOptions.bootstrap`:
 
   ```ts
-  const bootstrap = await fetchBootstrap();
-  const LDReactProvider = createLDReactProvider(clientSideId, context, { bootstrap });
+  const options: LDReactProviderOptions = { bootstrap: window.__LD_BOOTSTRAP__ };
+  const LDReactProvider = createLDReactProvider(clientSideId, context, options);
   ```
 
-  With `bootstrap` set, the React SDK returns the seeded values from `useBoolVariation` (and the
-  other variation hooks) on the very first render -- no flag-fetch waterfall, no flicker between
-  the default and the evaluated value.
+  Because the bootstrap script runs inline before the React bundle, the SDK has the evaluated
+  values cached the moment the very first React render runs.
 
 ## Build instructions
 
 1. Set `LAUNCHDARKLY_SDK_KEY` to your server-side SDK key (used by the Express server) and
-   `LAUNCHDARKLY_CLIENT_SIDE_ID` to your client-side ID (read at build time by Vite):
+   `LAUNCHDARKLY_CLIENT_SIDE_ID` to your client-side ID:
 
    ```bash
    export LAUNCHDARKLY_SDK_KEY="my-server-side-sdk-key"

--- a/packages/sdk/react/examples/features/bootstrap/README.md
+++ b/packages/sdk/react/examples/features/bootstrap/README.md
@@ -1,0 +1,59 @@
+# LaunchDarkly sample React application with bootstrap
+
+We've built a simple Vite + React application that demonstrates how to seed the LaunchDarkly
+React SDK with `bootstrap` data so the first paint reflects evaluated flag values without
+waiting for the initial flag fetch.
+
+Below, you'll find the build procedure. For more comprehensive instructions, you can visit your
+[Quickstart page](https://app.launchdarkly.com/quickstart#/) or the
+[React SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/react/react-web).
+
+This demo requires Node.js v20 or later.
+
+## What this example adds on top of [`hello-react`](../../hello-react/)
+
+* A small Express server (`server/index.ts`) initializes `@launchdarkly/node-server-sdk`,
+  evaluates the client-side flags for the example context with
+  `allFlagsState(context, { clientSideOnly: true })`, and exposes the result at
+  `GET /api/bootstrap`.
+* `src/index.tsx` `await`s that endpoint before mounting the app and passes the response to
+  `LDReactProviderOptions.bootstrap`:
+
+  ```ts
+  const bootstrap = await fetchBootstrap();
+  const LDReactProvider = createLDReactProvider(clientSideId, context, { bootstrap });
+  ```
+
+  With `bootstrap` set, the React SDK returns the seeded values from `useBoolVariation` (and the
+  other variation hooks) on the very first render -- no flag-fetch waterfall, no flicker between
+  the default and the evaluated value.
+
+## Build instructions
+
+1. Set `LAUNCHDARKLY_SDK_KEY` to your server-side SDK key (used by the Express server) and
+   `LAUNCHDARKLY_CLIENT_SIDE_ID` to your client-side ID (read at build time by Vite):
+
+   ```bash
+   export LAUNCHDARKLY_SDK_KEY="my-server-side-sdk-key"
+   export LAUNCHDARKLY_CLIENT_SIDE_ID="my-client-side-id"
+   ```
+
+   Alternatively, copy `.env.example` to `.env` and set them there.
+
+2. If there is an existing boolean feature flag in your LaunchDarkly project that you want to
+   evaluate, set `LAUNCHDARKLY_FLAG_KEY` to the flag key:
+
+   ```bash
+   export LAUNCHDARKLY_FLAG_KEY="my-flag-key"
+   ```
+
+   Otherwise, `sample-feature` will be used by default.
+
+3. On the command line, run:
+
+   ```bash
+   yarn && yarn start
+   ```
+
+   Then open [http://localhost:3001](http://localhost:3001). The page renders the bootstrapped
+   flag value immediately; you should not see an "initializing" flash.

--- a/packages/sdk/react/examples/features/bootstrap/e2e/verify.spec.ts
+++ b/packages/sdk/react/examples/features/bootstrap/e2e/verify.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@playwright/test';
+
+test('bootstrapped feature flag value renders on first paint', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByTestId('flag-value')).toHaveText(
+    /feature flag evaluates to (true|false)\./,
+    { timeout: 5000 },
+  );
+});

--- a/packages/sdk/react/examples/features/bootstrap/e2e/verify.spec.ts
+++ b/packages/sdk/react/examples/features/bootstrap/e2e/verify.spec.ts
@@ -1,10 +1,13 @@
 import { expect, test } from '@playwright/test';
 
-test('bootstrapped feature flag value renders on first paint', async ({ page }) => {
+test('renders the bootstrapped flag value without LaunchDarkly network access', async ({ page }) => {
+  // Block every LaunchDarkly request so the browser SDK cannot fetch flags on its own.
+  // The only way the page can render the real flag value is via the server-provided bootstrap payload.
+  await page.route(/launchdarkly\.(com|us)/, (route) => route.abort());
+
   await page.goto('/');
 
-  await expect(page.getByTestId('flag-value')).toHaveText(
-    /feature flag evaluates to (true|false)\./,
-    { timeout: 5000 },
-  );
+  await expect(page.getByText('feature flag evaluates to true', { exact: false })).toBeVisible({
+    timeout: 10_000,
+  });
 });

--- a/packages/sdk/react/examples/features/bootstrap/index.html
+++ b/packages/sdk/react/examples/features/bootstrap/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LaunchDarkly React SDK Bootstrap Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/sdk/react/examples/features/bootstrap/package.json
+++ b/packages/sdk/react/examples/features/bootstrap/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@launchdarkly/node-server-sdk": "9.10.14",
     "@launchdarkly/react-sdk": "4.0.1",
+    "ejs": "^5.0.2",
     "express": "^4.21.0",
     "react": "^19",
     "react-dom": "^19"
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",
+    "@types/ejs": "^3.1.5",
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
     "@types/react": "^19",

--- a/packages/sdk/react/examples/features/bootstrap/package.json
+++ b/packages/sdk/react/examples/features/bootstrap/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^19"
   },
   "scripts": {
-    "start": "yarn build && tsx server/index.ts",
+    "start": "yarn build && tsx --env-file-if-exists=.env server/index.ts",
     "build": "vite build",
     "test": "playwright test",
     "tsc": "tsc"

--- a/packages/sdk/react/examples/features/bootstrap/package.json
+++ b/packages/sdk/react/examples/features/bootstrap/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@launchdarkly/react-sdk-example-bootstrap",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@launchdarkly/node-server-sdk": "9.10.14",
+    "@launchdarkly/react-sdk": "4.0.1",
+    "express": "^4.21.0",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "scripts": {
+    "start": "yarn build && tsx server/index.ts",
+    "build": "vite build",
+    "test": "playwright test",
+    "tsc": "tsc"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.0.0",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^6"
+  }
+}

--- a/packages/sdk/react/examples/features/bootstrap/playwright.config.ts
+++ b/packages/sdk/react/examples/features/bootstrap/playwright.config.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://localhost:3001',
+  },
+  webServer: {
+    command: 'yarn start',
+    port: 3001,
+    timeout: 60_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/packages/sdk/react/examples/features/bootstrap/server/index.ts
+++ b/packages/sdk/react/examples/features/bootstrap/server/index.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import express from 'express';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { init, LDContext } from '@launchdarkly/node-server-sdk';
+
+const sdkKey = process.env.LAUNCHDARKLY_SDK_KEY ?? '';
+const port = Number(process.env.PORT ?? 3001);
+
+if (!sdkKey) {
+  // eslint-disable-next-line no-console
+  console.error('LAUNCHDARKLY_SDK_KEY must be set. See .env.example.');
+  process.exit(1);
+}
+
+const context: LDContext = {
+  kind: 'user',
+  key: 'example-user-key',
+  name: 'Sandy',
+};
+
+const ldClient = init(sdkKey);
+
+async function main() {
+  await ldClient.waitForInitialization({ timeout: 10 });
+
+  const app = express();
+
+  app.get('/api/bootstrap', async (_req, res) => {
+    const state = await ldClient.allFlagsState(context, { clientSideOnly: true });
+    res.json(state.toJSON());
+  });
+
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const distDir = path.resolve(dir, '..', 'dist');
+  app.use(express.static(distDir));
+  app.get('*', (_req, res) => {
+    res.sendFile(path.join(distDir, 'index.html'));
+  });
+
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Bootstrap example server listening on http://localhost:${port}`);
+  });
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('Server failed to start:', err);
+  process.exit(1);
+});

--- a/packages/sdk/react/examples/features/bootstrap/server/index.ts
+++ b/packages/sdk/react/examples/features/bootstrap/server/index.ts
@@ -8,11 +8,14 @@ import express from 'express';
 import { init, LDContext } from '@launchdarkly/node-server-sdk';
 
 const sdkKey = process.env.LAUNCHDARKLY_SDK_KEY ?? '';
+const clientSideId = process.env.LAUNCHDARKLY_CLIENT_SIDE_ID ?? '';
 const port = Number(process.env.PORT ?? 3001);
 
-if (!sdkKey) {
+if (!sdkKey || !clientSideId) {
   // eslint-disable-next-line no-console
-  console.error('LAUNCHDARKLY_SDK_KEY must be set. See .env.example.');
+  console.error(
+    'LAUNCHDARKLY_SDK_KEY and LAUNCHDARKLY_CLIENT_SIDE_ID must be set. See .env.example.',
+  );
   process.exit(1);
 }
 
@@ -22,23 +25,33 @@ const context: LDContext = {
   name: 'Sandy',
 };
 
+// JSON-encode for embedding inside a `<script>` tag. Escape `<` so the value can never close
+// the script tag, even if a flag value happens to contain `</script>`.
+function jsonForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
 const ldClient = init(sdkKey);
 
 async function main() {
   await ldClient.waitForInitialization({ timeout: 10 });
 
   const app = express();
-
-  app.get('/api/bootstrap', async (_req, res) => {
-    const state = await ldClient.allFlagsState(context, { clientSideOnly: true });
-    res.json(state.toJSON());
-  });
-
   const dir = path.dirname(fileURLToPath(import.meta.url));
   const distDir = path.resolve(dir, '..', 'dist');
-  app.use(express.static(distDir));
-  app.get('*', (_req, res) => {
-    res.sendFile(path.join(distDir, 'index.html'));
+
+  app.set('view engine', 'ejs');
+  app.set('views', path.resolve(dir, '..', 'views'));
+
+  app.use('/assets', express.static(path.join(distDir, 'assets')));
+
+  app.get('/', async (_req, res) => {
+    const state = await ldClient.allFlagsState(context, { clientSideOnly: true });
+    res.render('index', {
+      bootstrap: jsonForScript(state.toJSON()),
+      clientSideId: jsonForScript(clientSideId),
+      context: jsonForScript(context),
+    });
   });
 
   app.listen(port, () => {

--- a/packages/sdk/react/examples/features/bootstrap/src/App.css
+++ b/packages/sdk/react/examples/features/bootstrap/src/App.css
@@ -1,0 +1,23 @@
+.App {
+  text-align: center;
+}
+
+.App-header {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+.error {
+  padding: 2rem;
+  font-family: sans-serif;
+  color: #b00020;
+}

--- a/packages/sdk/react/examples/features/bootstrap/src/App.tsx
+++ b/packages/sdk/react/examples/features/bootstrap/src/App.tsx
@@ -1,0 +1,26 @@
+import { useBoolVariation, useInitializationStatus } from '@launchdarkly/react-sdk';
+
+import './App.css';
+
+// Set FLAG_KEY to the feature flag key you want to evaluate.
+const FLAG_KEY = import.meta.env.LAUNCHDARKLY_FLAG_KEY ?? 'sample-feature';
+
+function App() {
+  const { status } = useInitializationStatus();
+  const flagValue = useBoolVariation(FLAG_KEY, false);
+
+  const headerBgColor = flagValue ? '#00844B' : '#373841';
+
+  return (
+    <div className="App">
+      <header className="App-header" style={{ backgroundColor: headerBgColor }}>
+        <p data-testid="flag-value">
+          {`The ${FLAG_KEY} feature flag evaluates to ${flagValue}.`}
+        </p>
+        <p data-testid="status">SDK status: {status}</p>
+      </header>
+    </div>
+  );
+}
+
+export default App;

--- a/packages/sdk/react/examples/features/bootstrap/src/index.css
+++ b/packages/sdk/react/examples/features/bootstrap/src/index.css
@@ -1,0 +1,12 @@
+body {
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}

--- a/packages/sdk/react/examples/features/bootstrap/src/index.tsx
+++ b/packages/sdk/react/examples/features/bootstrap/src/index.tsx
@@ -10,49 +10,38 @@ import {
 import App from './App';
 import './index.css';
 
-const LAUNCHDARKLY_CLIENT_SIDE_ID = import.meta.env.LAUNCHDARKLY_CLIENT_SIDE_ID ?? '';
-
-const context: LDContext = {
-  // Set up the evaluation context. This context should appear on your LaunchDarkly contexts dashboard soon after you run the demo.
-  kind: 'user',
-  key: 'example-user-key',
-  name: 'Sandy',
-};
-
-async function fetchBootstrap(): Promise<Record<string, unknown>> {
-  const res = await fetch('/api/bootstrap');
-  if (!res.ok) {
-    throw new Error(`Bootstrap request failed: ${res.status} ${res.statusText}`);
+declare global {
+  interface Window {
+    __LD_BOOTSTRAP__?: Record<string, unknown>;
+    __LD_CLIENT_SIDE_ID__?: string;
+    __LD_CONTEXT__?: LDContext;
   }
-  return res.json();
 }
 
-async function main() {
-  const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+// eslint-disable-next-line no-underscore-dangle
+const bootstrapData = window.__LD_BOOTSTRAP__;
+// eslint-disable-next-line no-underscore-dangle
+const clientSideId = window.__LD_CLIENT_SIDE_ID__ ?? '';
+// eslint-disable-next-line no-underscore-dangle
+const context = window.__LD_CONTEXT__;
 
-  let bootstrapData: Record<string, unknown>;
-  try {
-    bootstrapData = await fetchBootstrap();
-  } catch (err) {
-    root.render(
-      <div className="error">
-        <p>
-          Failed to load bootstrap data from the server. Make sure
-          <code> LAUNCHDARKLY_SDK_KEY </code> and <code>LAUNCHDARKLY_CLIENT_SIDE_ID</code> are set,
-          then restart the server.
-        </p>
-        <pre>{err instanceof Error ? err.message : String(err)}</pre>
-      </div>,
-    );
-    return;
-  }
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
+if (!bootstrapData || !context) {
+  root.render(
+    <div className="error">
+      <p>
+        Bootstrap data was not injected by the server. Make sure
+        <code> LAUNCHDARKLY_SDK_KEY </code> and <code>LAUNCHDARKLY_CLIENT_SIDE_ID</code> are set,
+        then restart the server.
+      </p>
+    </div>,
+  );
+} else {
   // Pass the server-evaluated payload as `bootstrap` so the client renders real flag values
   // on first paint instead of waiting for the SDK to fetch them.
-  const options: LDReactProviderOptions = {
-    bootstrap: bootstrapData,
-  };
-  const LDReactProvider = createLDReactProvider(LAUNCHDARKLY_CLIENT_SIDE_ID, context, options);
+  const options: LDReactProviderOptions = { bootstrap: bootstrapData };
+  const LDReactProvider = createLDReactProvider(clientSideId, context, options);
 
   root.render(
     <LDReactProvider>
@@ -60,5 +49,3 @@ async function main() {
     </LDReactProvider>,
   );
 }
-
-main();

--- a/packages/sdk/react/examples/features/bootstrap/src/index.tsx
+++ b/packages/sdk/react/examples/features/bootstrap/src/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import {
+  createLDReactProvider,
+  LDContext,
+  LDReactProviderOptions,
+} from '@launchdarkly/react-sdk';
+
+import App from './App';
+import './index.css';
+
+const LAUNCHDARKLY_CLIENT_SIDE_ID = import.meta.env.LAUNCHDARKLY_CLIENT_SIDE_ID ?? '';
+
+const context: LDContext = {
+  // Set up the evaluation context. This context should appear on your LaunchDarkly contexts dashboard soon after you run the demo.
+  kind: 'user',
+  key: 'example-user-key',
+  name: 'Sandy',
+};
+
+async function fetchBootstrap(): Promise<Record<string, unknown>> {
+  const res = await fetch('/api/bootstrap');
+  if (!res.ok) {
+    throw new Error(`Bootstrap request failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+
+  let bootstrapData: Record<string, unknown>;
+  try {
+    bootstrapData = await fetchBootstrap();
+  } catch (err) {
+    root.render(
+      <div className="error">
+        <p>
+          Failed to load bootstrap data from the server. Make sure
+          <code> LAUNCHDARKLY_SDK_KEY </code> and <code>LAUNCHDARKLY_CLIENT_SIDE_ID</code> are set,
+          then restart the server.
+        </p>
+        <pre>{err instanceof Error ? err.message : String(err)}</pre>
+      </div>,
+    );
+    return;
+  }
+
+  // Pass the server-evaluated payload as `bootstrap` so the client renders real flag values
+  // on first paint instead of waiting for the SDK to fetch them.
+  const options: LDReactProviderOptions = {
+    bootstrap: bootstrapData,
+  };
+  const LDReactProvider = createLDReactProvider(LAUNCHDARKLY_CLIENT_SIDE_ID, context, options);
+
+  root.render(
+    <LDReactProvider>
+      <App />
+    </LDReactProvider>,
+  );
+}
+
+main();

--- a/packages/sdk/react/examples/features/bootstrap/src/vite-env.d.ts
+++ b/packages/sdk/react/examples/features/bootstrap/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/sdk/react/examples/features/bootstrap/tsconfig.json
+++ b/packages/sdk/react/examples/features/bootstrap/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "server", "vite.config.ts", "playwright.config.ts"]
+}

--- a/packages/sdk/react/examples/features/bootstrap/views/index.ejs
+++ b/packages/sdk/react/examples/features/bootstrap/views/index.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LaunchDarkly React SDK Bootstrap Example</title>
+    <link rel="stylesheet" href="/assets/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      window.__LD_BOOTSTRAP__ = <%- bootstrap %>;
+      window.__LD_CLIENT_SIDE_ID__ = <%- clientSideId %>;
+      window.__LD_CONTEXT__ = <%- context %>;
+    </script>
+    <script type="module" src="/assets/index.js"></script>
+  </body>
+</html>

--- a/packages/sdk/react/examples/features/bootstrap/vite.config.ts
+++ b/packages/sdk/react/examples/features/bootstrap/vite.config.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import react from '@vitejs/plugin-react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  envPrefix: ['VITE_', 'LAUNCHDARKLY_'],
+});

--- a/packages/sdk/react/examples/features/bootstrap/vite.config.ts
+++ b/packages/sdk/react/examples/features/bootstrap/vite.config.ts
@@ -5,5 +5,16 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
-  envPrefix: ['VITE_', 'LAUNCHDARKLY_'],
+  // Only expose client-safe LaunchDarkly env vars. Do NOT add `LAUNCHDARKLY_` as a broad prefix --
+  // that would bake `LAUNCHDARKLY_SDK_KEY` (a server-side secret) into the client bundle.
+  envPrefix: ['VITE_', 'LAUNCHDARKLY_CLIENT_SIDE_ID', 'LAUNCHDARKLY_FLAG_KEY'],
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/index.js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name].[ext]',
+      },
+    },
+  },
 });

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -150,6 +150,11 @@
         "src/platform/NodeInfo.ts",
         {
           "type": "json",
+          "path": "/packages/sdk/react/examples/features/bootstrap/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/node-server-sdk']"
+        },
+        {
+          "type": "json",
           "path": "/packages/sdk/react/examples/react-server-example/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/node-server-sdk']"
         },
@@ -308,6 +313,11 @@
     "packages/sdk/react": {
       "extra-files": [
         "src/client/LDReactClient.tsx",
+        {
+          "type": "json",
+          "path": "examples/features/bootstrap/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/react-sdk']"
+        },
         {
           "type": "json",
           "path": "examples/hello-react/package.json",


### PR DESCRIPTION
This PR adds an example application to showcase bootstrapping a react sdk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new example app, docs, CI wiring) and do not modify SDK runtime behavior; main risk is CI/runtime flakiness or added pipeline time for the new Playwright-based example job.
> 
> **Overview**
> Adds a new `examples/features/bootstrap` Vite + React + Express example that server-evaluates flags via `@launchdarkly/node-server-sdk` and injects them into the page so the React SDK can initialize with `LDReactProviderOptions.bootstrap` on first paint.
> 
> Updates tooling to treat the new example as a workspace, documents it in the React examples index, adds a Playwright e2e test that verifies rendering works even when LaunchDarkly network requests are blocked, and extends CI (`react.yml`) plus `release-please-config.json` to run/version the new example alongside existing ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2254d62371a82b2f819dee392efdb1c67fa545e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->