### PR TITLE
chore: remove FDv2 pre-release warnings from server-side packages

### DIFF
--- a/packages/shared/common/src/api/subsystem/DataSystem/DataSource.ts
+++ b/packages/shared/common/src/api/subsystem/DataSystem/DataSource.ts
@@ -1,9 +1,4 @@
 // TODO: refactor client-sdk to use this enum
-/**
- * @experimental
- * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
- * versioning.  It is not suitable for production usage.
- */
 export enum DataSourceState {
   // Positive confirmation of connection/data receipt
   Valid,
@@ -15,11 +10,6 @@ export enum DataSourceState {
   Closed,
 }
 
-/**
- * @experimental
- * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
- * versioning.  It is not suitable for production usage.
- */
 export interface DataSource {
   /**
    * May be called any number of times, if already started, has no effect
@@ -40,9 +30,4 @@ export interface DataSource {
   stop(): void;
 }
 
-/**
- * @experimental
- * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
- * versioning.  It is not suitable for production usage.
- */
 export type LDDataSourceFactory = () => DataSource;

--- a/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
+++ b/packages/shared/sdk-server/src/api/options/LDDataSystemOptions.ts
@@ -3,10 +3,6 @@ import { LDClientContext } from '@launchdarkly/js-sdk-common';
 import { LDFeatureStore } from '../subsystems';
 
 /**
- * @experimental
- * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
- * versioning.  It is not suitable for production usage.
- *
  * Configuration options for the Data System that the SDK uses to get and maintain flags and other
  * data from LaunchDarkly and other sources.
  *
@@ -186,10 +182,7 @@ export type SynchronizerDataSource =
   | StreamingDataSourceConfiguration;
 
 /**
- * @experimental
  * This data source will allow developers to define their own composite data source.
- * This is a free-form option and is not subject to any backwards compatibility guarantees or semantic
- * versioning.
  *
  * The following example is roughly equivilent to using the {@link StandardDataSourceOptions} with the default values.
  * @example

--- a/packages/shared/sdk-server/src/api/options/LDOptions.ts
+++ b/packages/shared/sdk-server/src/api/options/LDOptions.ts
@@ -74,10 +74,6 @@ export interface LDOptions {
   featureStore?: LDFeatureStore | ((clientContext: LDClientContext) => LDFeatureStore);
 
   /**
-   * @experimental
-   * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
-   * versioning.  It is not suitable for production usage.
-   *
    * Configuration options for the Data System that the SDK uses to get and maintain flags and other
    * data from LaunchDarkly and other sources.
    *

--- a/packages/shared/sdk-server/src/api/subsystems/LDTransactionalFeatureStore.ts
+++ b/packages/shared/sdk-server/src/api/subsystems/LDTransactionalFeatureStore.ts
@@ -5,10 +5,6 @@ import { LDFeatureStore, LDFeatureStoreDataStorage } from './LDFeatureStore';
 type InitMetadata = internal.InitMetadata;
 
 /**
- * @experimental
- * This feature is not stable and not subject to any backwards compatibility guarantees or semantic
- * versioning.  It is not suitable for production usage.
- *
  * Transactional version of {@link LDFeatureStore} with support for {@link applyChanges}
  */
 export interface LDTransactionalFeatureStore extends LDFeatureStore {


### PR DESCRIPTION
## Summary

- FDv2 / data-saving mode is going GA on server-side SDKs per the [SDK Release Standards spec](https://github.com/launchdarkly/sdk-specs/tree/main/specs/RELEASE-sdk-release-standards).
- Removes the pre-release warning prose ("not stable and not subject to any backwards compatibility guarantees", "not suitable for production usage") and `@experimental` tags from TSDoc on server-side FDv2 types.
- **Scoped to server-side:** `@launchdarkly/js-server-sdk-common`, plus the shared `DataSourceState` / `DataSource` / `LDDataSourceFactory` types in `@launchdarkly/js-sdk-common`. Client-side packages (`sdk-client`, `browser`, `react-native`) are out of scope -- the data-saving-mode docs only list server SDKs as GA.

Tracking: [SDK-2349](https://launchdarkly.atlassian.net/browse/SDK-2349)

## Test plan

- [x] `yarn workspace @launchdarkly/js-sdk-common build` clean
- [x] `yarn workspace @launchdarkly/js-server-sdk-common build` clean
- [x] `yarn workspace @launchdarkly/node-server-sdk build` clean
- [ ] CI green

[SDK-2349]: https://launchdarkly.atlassian.net/browse/SDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only TSDoc comment changes that remove experimental/unstable warnings; no runtime behavior or type shapes are modified.
> 
> **Overview**
> Removes `@experimental` tags and pre-release warning language from TSDoc on FDv2/data-system public types, including `DataSourceState`/`DataSource`/`LDDataSourceFactory`, `LDOptions#dataSystem`, `LDDataSystemOptions`, and `LDTransactionalFeatureStore`.
> 
> This effectively marks the server-side data system APIs as GA without changing any implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4043874ca7017a73d9ffb7d4b3a10a2937b7a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->