### PR TITLE
docs: Clarify runId purpose and per-method tracker semantics

### DIFF
--- a/packages/sdk/server-ai/__tests__/LDAIConfigTrackerImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIConfigTrackerImpl.test.ts
@@ -973,7 +973,7 @@ describe('at-most-once semantics', () => {
 
     expect(mockTrack).toHaveBeenCalledTimes(1);
     expect(mockWarn).toHaveBeenCalledTimes(1);
-    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('Duration'));
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('trackDuration'));
   });
 
   it('drops duplicate trackSuccess call with warning', () => {

--- a/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDGraphTrackerImpl.test.ts
@@ -151,7 +151,7 @@ it('drops second trackInvocationSuccess call and warns', () => {
   tracker.trackInvocationSuccess();
   expect(mockTrack).toHaveBeenCalledTimes(1);
   expect(mockWarn).toHaveBeenCalledWith(
-    expect.stringContaining('invocation success/failure already recorded for this run'),
+    expect.stringContaining('invocation result already recorded on this graph tracker'),
   );
 });
 
@@ -161,7 +161,7 @@ it('drops trackInvocationFailure after trackInvocationSuccess and warns', () => 
   tracker.trackInvocationFailure();
   expect(mockTrack).toHaveBeenCalledTimes(1);
   expect(mockWarn).toHaveBeenCalledWith(
-    expect.stringContaining('invocation success/failure already recorded for this run'),
+    expect.stringContaining('invocation result already recorded on this graph tracker'),
   );
 });
 

--- a/packages/sdk/server-ai/src/LDAIConfigTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIConfigTrackerImpl.ts
@@ -82,7 +82,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackDuration(duration: number): void {
     if (this._trackedMetrics.durationMs !== undefined) {
       this._ldClient.logger?.warn(
-        'Duration has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackDuration: duration already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }
@@ -106,7 +106,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackTimeToFirstToken(timeToFirstTokenMs: number) {
     if (this._trackedMetrics.timeToFirstTokenMs !== undefined) {
       this._ldClient.logger?.warn(
-        'Time to first token has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackTimeToFirstToken: time-to-first-token already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }
@@ -148,7 +148,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackFeedback(feedback: { kind: LDFeedbackKind }): void {
     if (this._trackedMetrics.feedback !== undefined) {
       this._ldClient.logger?.warn(
-        'Feedback has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackFeedback: feedback already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }
@@ -163,7 +163,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackSuccess(): void {
     if (this._trackedMetrics.success !== undefined) {
       this._ldClient.logger?.warn(
-        'Generation result has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackSuccess: success/error already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }
@@ -174,7 +174,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackError(): void {
     if (this._trackedMetrics.success !== undefined) {
       this._ldClient.logger?.warn(
-        'Generation result has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackError: success/error already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }
@@ -303,7 +303,7 @@ export class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   trackTokens(tokens: LDTokenUsage): void {
     if (this._trackedMetrics.tokens !== undefined) {
       this._ldClient.logger?.warn(
-        'Token usage has already been tracked for this execution. Use createTracker() for a new execution.',
+        'Skipping trackTokens: token usage already recorded on this tracker. Call createTracker on the AI Config for a new run.',
       );
       return;
     }

--- a/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
+++ b/packages/sdk/server-ai/src/LDGraphTrackerImpl.ts
@@ -89,7 +89,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
   trackInvocationSuccess(): void {
     if (this._summary.success !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: invocation success/failure already recorded for this run — dropping duplicate call.',
+        'Skipping trackInvocationSuccess: invocation result already recorded on this graph tracker. Call createTracker on the agent graph for a new run.',
       );
       return;
     }
@@ -100,7 +100,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
   trackInvocationFailure(): void {
     if (this._summary.success !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: invocation success/failure already recorded for this run — dropping duplicate call.',
+        'Skipping trackInvocationFailure: invocation result already recorded on this graph tracker. Call createTracker on the agent graph for a new run.',
       );
       return;
     }
@@ -111,7 +111,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
   trackDuration(durationMs: number): void {
     if (this._summary.durationMs !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: trackDuration already called for this run — dropping duplicate call.',
+        'Skipping trackDuration: duration already recorded on this graph tracker. Call createTracker on the agent graph for a new run.',
       );
       return;
     }
@@ -127,7 +127,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
   trackTotalTokens(tokens: LDTokenUsage): void {
     if (this._summary.tokens !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: trackTotalTokens already called for this run — dropping duplicate call.',
+        'Skipping trackTotalTokens: tokens already recorded on this graph tracker. Call createTracker on the agent graph for a new run.',
       );
       return;
     }
@@ -143,7 +143,7 @@ export class LDGraphTrackerImpl implements LDGraphTracker {
   trackPath(path: string[]): void {
     if (this._summary.path !== undefined) {
       this._ldClient.logger?.warn(
-        'LDGraphTracker: trackPath already called for this run — dropping duplicate call.',
+        'Skipping trackPath: path already recorded on this graph tracker. Call createTracker on the agent graph for a new run.',
       );
       return;
     }

--- a/packages/sdk/server-ai/src/api/LDAIClient.ts
+++ b/packages/sdk/server-ai/src/api/LDAIClient.ts
@@ -34,9 +34,11 @@ export interface LDAIClient {
    * the message content. The keys correspond to placeholders within the template, and the values
    * are the corresponding replacements.
    *
-   * @returns The AI `config`, customized `messages`, and a `tracker`. If the configuration cannot be accessed from
-   * LaunchDarkly, then the return value will include information from the `defaultValue`. The returned `tracker` can
-   * be used to track AI operation metrics (latency, token usage, etc.).
+   * @returns An {@link LDAICompletionConfig} with `enabled`, `model`, `provider`,
+   * `messages`, and a `createTracker()` factory. Call `createTracker()` on the
+   * returned config to obtain a tracker for each AI run. If the configuration
+   * cannot be accessed from LaunchDarkly, the return value will include
+   * information from the `defaultValue`.
    *
    * @example
    * ```
@@ -49,27 +51,11 @@ export interface LDAIClient {
    *  provider: { name: 'openai' },
    * };
    *
-   * const result = completionConfig(key, context, defaultValue, variables);
-   * // Output:
-   * {
-   *   enabled: true,
-   *   config: {
-   *     modelId: "gpt-4o",
-   *     temperature: 0.2,
-   *     maxTokens: 4096,
-   *     userDefinedKey: "myValue",
-   *   },
-   *   messages: [
-   *     {
-   *       role: "system",
-   *       content: "You are an amazing GPT."
-   *     },
-   *     {
-   *       role: "user",
-   *       content: "Explain how you're an amazing GPT."
-   *     }
-   *   ],
-   *   tracker: ...
+   * const completionConfig = await client.completionConfig(key, context, defaultValue, variables);
+   * if (completionConfig.enabled) {
+   *   const tracker = completionConfig.createTracker();
+   *   // Use completionConfig.messages and completionConfig.model with your LLM,
+   *   // then record metrics with tracker.trackSuccess(), tracker.trackTokens(), etc.
    * }
    * ```
    */
@@ -95,9 +81,11 @@ export interface LDAIClient {
    * the instructions. The keys correspond to placeholders within the template, and the values
    * are the corresponding replacements.
    *
-   * @returns An AI agent with customized `instructions` and a `tracker`. If the configuration
-   * cannot be accessed from LaunchDarkly, then the return value will include information from the
-   * `defaultValue`. The returned `tracker` can be used to track AI operation metrics (latency, token usage, etc.).
+   * @returns An {@link LDAIAgentConfig} with customized `instructions`, `model`,
+   * `provider`, and a `createTracker()` factory. Call `createTracker()` on the
+   * returned config to obtain a tracker for each AI run. If the configuration
+   * cannot be accessed from LaunchDarkly, the return value will include
+   * information from the `defaultValue`.
    *
    * @example
    * ```
@@ -111,8 +99,11 @@ export interface LDAIClient {
    *   instructions: 'You are a research assistant.',
    * }, variables);
    *
-   * const researchResult = agentConfig.instructions; // Interpolated instructions
-   * agentConfig.tracker.trackSuccess();
+   * if (agentConfig.enabled) {
+   *   const tracker = agentConfig.createTracker();
+   *   const researchResult = agentConfig.instructions; // Interpolated instructions
+   *   tracker.trackSuccess();
+   * }
    * ```
    */
   agentConfig(
@@ -134,7 +125,10 @@ export interface LDAIClient {
    * @param defaultValue Optional fallback when the configuration is not available from LaunchDarkly.
    * When omitted or null, a disabled default is used.
    * @param variables Optional variables for template interpolation in messages and instructions.
-   * @returns A promise that resolves to a tracked judge configuration.
+   * @returns A promise that resolves to an {@link LDAIJudgeConfig} with `enabled`,
+   * `model`, `provider`, `messages`, `evaluationMetricKey`, and a `createTracker()`
+   * factory. Call `createTracker()` on the returned config to obtain a tracker for
+   * each AI run.
    *
    * @example
    * ```typescript
@@ -146,8 +140,11 @@ export interface LDAIClient {
    *   messages: [{ role: 'system', content: 'You are a relevance judge.' }]
    * }, variables);
    *
-   * const config = judgeConf.config; // Interpolated configuration
-   * judgeConf.tracker.trackSuccess();
+   * if (judgeConf.enabled) {
+   *   const tracker = judgeConf.createTracker();
+   *   // Use judgeConf.messages and judgeConf.model with your LLM,
+   *   // then record metrics with tracker.trackSuccess(), tracker.trackJudgeResult(), etc.
+   * }
    * ```
    */
   judgeConfig(
@@ -167,10 +164,11 @@ export interface LDAIClient {
    * current environment, user, or session. This context may influence how the configuration is
    * processed or personalized.
    *
-   * @returns A map of agent keys to their respective AI agents with customized `instructions` and `tracker`.
-   * If a configuration cannot be accessed from LaunchDarkly, then the return value will include information
-   * from the respective `defaultValue`. The returned `tracker` can be used to track AI operation metrics
-   * (latency, token usage, etc.).
+   * @returns A map of agent keys to their respective {@link LDAIAgentConfig}s,
+   * each with customized `instructions` and a `createTracker()` factory. Call
+   * `createTracker()` on a returned config to obtain a tracker for each AI run.
+   * If a configuration cannot be accessed from LaunchDarkly, the return value
+   * will include information from the respective `defaultValue`.
    *
    * @example
    * ```
@@ -199,8 +197,11 @@ export interface LDAIClient {
    * const context = {...};
    *
    * const configs = await client.agentConfigs(agentConfigsList, context);
-   * const researchResult = configs["research_agent"].instructions; // Interpolated instructions
-   * configs["research_agent"].tracker.trackSuccess();
+   * if (configs["research_agent"].enabled) {
+   *   const tracker = configs["research_agent"].createTracker();
+   *   const researchResult = configs["research_agent"].instructions; // Interpolated instructions
+   *   tracker.trackSuccess();
+   * }
    * ```
    */
   agentConfigs<const T extends readonly LDAIAgentRequestConfig[]>(
@@ -316,7 +317,7 @@ export interface LDAIClient {
   /**
    * Reconstructs an AIConfigTracker from a resumption token string previously
    * obtained from a tracker's `resumptionToken` property. Use this to associate
-   * deferred events (such as user feedback) with the original invocation's runId.
+   * deferred events (such as user feedback) with the original run's runId.
    *
    * @param token A URL-safe Base64-encoded resumption token string.
    * @param context The evaluation context to use for subsequent track calls.

--- a/packages/sdk/server-ai/src/api/LDAIClient.ts
+++ b/packages/sdk/server-ai/src/api/LDAIClient.ts
@@ -317,7 +317,7 @@ export interface LDAIClient {
   /**
    * Reconstructs an AIConfigTracker from a resumption token string previously
    * obtained from a tracker's `resumptionToken` property. Use this to associate
-   * deferred events (such as user feedback) with the original run's runId.
+   * deferred events (such as user feedback) with the original tracker's runId.
    *
    * @param token A URL-safe Base64-encoded resumption token string.
    * @param context The evaluation context to use for subsequent track calls.

--- a/packages/sdk/server-ai/src/api/config/LDAIConfigTracker.ts
+++ b/packages/sdk/server-ai/src/api/config/LDAIConfigTracker.ts
@@ -3,7 +3,13 @@ import { LDAIMetrics, LDFeedbackKind, LDTokenUsage } from '../metrics';
 import { LDAIMetricSummary } from '../model/types';
 
 /**
- * The LDAIConfigTracker is used to track various details about AI operations.
+ * The LDAIConfigTracker records metrics for a single AI run.
+ *
+ * All events a tracker emits share a runId (a UUIDv4) so LaunchDarkly can
+ * correlate them in metrics views. See individual track methods for their
+ * specific semantics. Call `createTracker` on the AI Config to start a new
+ * run. A resumption token preserves the runId, so events emitted by a
+ * tracker reconstructed in another process correlate with the original run.
  */
 export interface LDAIConfigTracker {
   /**
@@ -23,66 +29,63 @@ export interface LDAIConfigTracker {
    * A URL-safe Base64-encoded token that encodes the tracker's runId, configKey,
    * variationKey, and version. Pass this to AIClient.createTracker() to reconstruct
    * the tracker across process boundaries (e.g. for associating deferred feedback
-   * with the original invocation).
+   * with the original AI run).
    */
   readonly resumptionToken: string;
 
   /**
    * Track the duration of generation.
    *
-   * At-most-once per execution: subsequent calls on the same tracker are dropped
-   * with a warning. Use createTracker() on the config result to obtain a fresh
-   * tracker for a new execution.
-   *
    * Ideally this would not include overhead time such as network communication.
    *
    * @param durationMs The duration in milliseconds.
+   *
+   * @remarks Records at most once per Tracker; further calls are ignored.
    */
   trackDuration(durationMs: number): void;
 
   /**
    * Track information about token usage.
    *
-   * At-most-once per execution: subsequent calls on the same tracker are dropped
-   * with a warning.
-   *
    * @param tokens Token usage information.
+   *
+   * @remarks Records at most once per Tracker; further calls are ignored.
    */
   trackTokens(tokens: LDTokenUsage): void;
 
   /**
    * Generation was successful.
    *
-   * At-most-once per execution: subsequent calls (including trackError) on the
-   * same tracker are dropped with a warning.
+   * @remarks Records at most once per Tracker. trackSuccess and trackError share
+   * state; only one of the two can record per Tracker, and subsequent calls are
+   * ignored.
    */
   trackSuccess(): void;
 
   /**
    * An error was encountered during generation.
    *
-   * At-most-once per execution: subsequent calls (including trackSuccess) on the
-   * same tracker are dropped with a warning.
+   * @remarks Records at most once per Tracker. trackSuccess and trackError share
+   * state; only one of the two can record per Tracker, and subsequent calls are
+   * ignored.
    */
   trackError(): void;
 
   /**
    * Track sentiment about the generation.
    *
-   * At-most-once per execution: subsequent calls on the same tracker are dropped
-   * with a warning.
-   *
    * @param feedback Feedback about the generation.
+   *
+   * @remarks Records at most once per Tracker; further calls are ignored.
    */
   trackFeedback(feedback: { kind: LDFeedbackKind }): void;
 
   /**
    * Track the time to first token for this generation.
    *
-   * At-most-once per execution: subsequent calls on the same tracker are dropped
-   * with a warning.
-   *
    * @param timeToFirstTokenMs The duration in milliseconds.
+   *
+   * @remarks Records at most once per Tracker; further calls are ignored.
    */
   trackTimeToFirstToken(timeToFirstTokenMs: number): void;
 
@@ -92,6 +95,9 @@ export interface LDAIConfigTracker {
    * No event is emitted when the result was not sampled (result.sampled is false).
    *
    * @param result Judge result containing score, reasoning, and metadata
+   *
+   * @remarks May be called multiple times per Tracker; each call records the
+   * scores from the given response.
    */
   trackJudgeResult(result: LDJudgeResult): void;
 
@@ -99,6 +105,9 @@ export interface LDAIConfigTracker {
    * Track a single tool invocation.
    *
    * @param toolKey The identifier of the tool that was invoked.
+   *
+   * @remarks May be called multiple times per Tracker; each call records the
+   * given tool call.
    */
   trackToolCall(toolKey: string): void;
 
@@ -106,11 +115,14 @@ export interface LDAIConfigTracker {
    * Track multiple tool invocations.
    *
    * @param toolKeys The identifiers of the tools that were invoked.
+   *
+   * @remarks May be called multiple times per Tracker; each call records the
+   * given tool calls.
    */
   trackToolCalls(toolKeys: string[]): void;
 
   /**
-   * Track the duration of execution of the provided function.
+   * Track the duration of the provided function.
    *
    * If the provided function throws, then this method will also throw.
    * In the case the provided function throws, this function will still record the duration.
@@ -119,22 +131,30 @@ export interface LDAIConfigTracker {
    *
    * @param func The function to track the duration of.
    * @returns The result of the function.
+   *
+   * @remarks Because each inner metric is at-most-once per Tracker, calling
+   * this twice on the same Tracker will run the inner function again but
+   * produce no additional metric events.
    */
   trackDurationOf(func: () => Promise<any>): Promise<any>;
 
   /**
    * Track metrics for a generic AI operation.
    *
-   * This function will track the duration of the operation, extract metrics using the provided
+   * This function will track the duration of the AI run, extract metrics using the provided
    * metrics extractor function, and track success or error status accordingly.
    *
    * If the provided function throws, then this method will also throw.
    * In the case the provided function throws, this function will record the duration and an error.
-   * A failed operation will not have any token usage data.
+   * A failed AI run will not have any token usage data.
    *
-   * @param metricsExtractor Function that extracts LDAIMetrics from the operation result
-   * @param func Function which executes the operation
-   * @returns The result of the operation
+   * @param metricsExtractor Function that extracts LDAIMetrics from the AI run result
+   * @param func Function which executes the AI run
+   * @returns The result of the AI run
+   *
+   * @remarks Because each inner metric is at-most-once per Tracker, calling
+   * this twice on the same Tracker will run the inner function again but
+   * produce no additional metric events.
    */
   trackMetricsOf<TRes>(
     metricsExtractor: (result: TRes) => LDAIMetrics,
@@ -144,10 +164,10 @@ export interface LDAIConfigTracker {
   /**
    * Track metrics for a streaming AI operation.
    *
-   * This function will track the duration of the operation, extract metrics using the provided
+   * This function will track the duration of the AI run, extract metrics using the provided
    * metrics extractor function, and track success or error status accordingly.
    *
-   * Unlike trackMetricsOf, this method is designed for streaming operations where:
+   * Unlike trackMetricsOf, this method is designed for streaming AI runs where:
    * - The stream is created and returned immediately (synchronously)
    * - Metrics are extracted asynchronously in the background once the stream completes
    * - Duration is tracked from stream creation to metrics extraction completion
@@ -161,6 +181,10 @@ export interface LDAIConfigTracker {
    * @param streamCreator Function that creates and returns the stream (synchronous)
    * @param metricsExtractor Function that asynchronously extracts metrics from the stream
    * @returns The stream result (returned immediately, not a Promise)
+   *
+   * @remarks Because each inner metric is at-most-once per Tracker, calling
+   * this twice on the same Tracker will run the inner function again but
+   * produce no additional metric events.
    */
   trackStreamMetricsOf<TStream>(
     streamCreator: () => TStream,
@@ -168,12 +192,15 @@ export interface LDAIConfigTracker {
   ): TStream;
 
   /**
-   * Track an operation which uses Bedrock.
+   * Track an AI run which uses Bedrock.
    *
-   * This function will track the duration of the operation, the token usage, and the success or error status.
+   * This function will track the duration of the AI run, the token usage, and the success or error status.
    *
    * @param res The result of the Bedrock operation.
    * @returns The input operation.
+   *
+   * @remarks Because each inner metric is at-most-once per Tracker, calling
+   * this twice on the same Tracker will produce no additional metric events.
    */
   trackBedrockConverseMetrics<
     TRes extends {

--- a/packages/sdk/server-ai/src/api/config/LDAIConfigUtils.ts
+++ b/packages/sdk/server-ai/src/api/config/LDAIConfigUtils.ts
@@ -87,7 +87,7 @@ export class LDAIConfigUtils {
    *
    * @param key The configuration key
    * @param flagValue The flag value from LaunchDarkly
-   * @param trackerFactory A factory function that creates a new tracker for each execution
+   * @param trackerFactory A factory function that creates a new tracker for each AI run
    * @param evaluator The evaluator to attach to completion and agent configs
    * @returns The appropriate AI configuration type
    */
@@ -117,7 +117,7 @@ export class LDAIConfigUtils {
    *
    * @param key The configuration key
    * @param mode The mode for the disabled config
-   * @param createTracker A factory function that creates a new tracker for each execution
+   * @param createTracker A factory function that creates a new tracker for each AI run
    * @param evaluator The evaluator to attach to completion and agent configs
    * @returns A disabled config of the appropriate type
    */
@@ -196,7 +196,7 @@ export class LDAIConfigUtils {
    *
    * @param key The configuration key
    * @param flagValue The flag value from LaunchDarkly
-   * @param trackerFactory A factory function that creates a new tracker for each execution
+   * @param trackerFactory A factory function that creates a new tracker for each AI run
    * @param evaluator The evaluator for this completion config
    * @returns A completion configuration
    */
@@ -221,7 +221,7 @@ export class LDAIConfigUtils {
    *
    * @param key The configuration key
    * @param flagValue The flag value from LaunchDarkly
-   * @param trackerFactory A factory function that creates a new tracker for each execution
+   * @param trackerFactory A factory function that creates a new tracker for each AI run
    * @param evaluator The evaluator for this agent config
    * @returns An agent configuration
    */
@@ -246,7 +246,7 @@ export class LDAIConfigUtils {
    *
    * @param key The configuration key
    * @param flagValue The flag value from LaunchDarkly
-   * @param trackerFactory A factory function that creates a new tracker for each execution
+   * @param trackerFactory A factory function that creates a new tracker for each AI run
    * @returns A judge configuration
    */
   static toJudgeConfig(

--- a/packages/sdk/server-ai/src/api/config/types.ts
+++ b/packages/sdk/server-ai/src/api/config/types.ts
@@ -122,9 +122,10 @@ export interface LDAIConfig extends Omit<LDAIConfigDefault, 'enabled'> {
   enabled: boolean;
 
   /**
-   * Creates a new tracker for this AI Config invocation. Each call returns a
-   * new tracker with a fresh runId. Use createTracker() at the start of each
-   * execution to obtain a tracker, then use it to record metrics for that run.
+   * Creates a new tracker for a fresh AI run. Each call mints a new runId (a
+   * UUIDv4) that LaunchDarkly uses to correlate the run's events in metrics
+   * views. Call this once per AI run; metrics from different runIds cannot be
+   * combined.
    */
   createTracker: () => LDAIConfigTracker;
 }

--- a/packages/sdk/server-ai/src/api/graph/AgentGraphDefinition.ts
+++ b/packages/sdk/server-ai/src/api/graph/AgentGraphDefinition.ts
@@ -113,10 +113,10 @@ export class AgentGraphDefinition {
   }
 
   /**
-   * Returns a new {@link LDGraphTracker} for this graph invocation.
+   * Returns a new {@link LDGraphTracker} for a fresh graph run.
    *
-   * Call this once per invocation. Each call produces a tracker with a fresh `runId`
-   * that groups all events for that invocation.
+   * Call this once per graph run. Each call produces a tracker with a fresh `runId`
+   * that groups all events for that run.
    */
   createTracker(): LDGraphTracker {
     return this._createTracker();

--- a/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
+++ b/packages/sdk/server-ai/src/api/graph/LDGraphTracker.ts
@@ -2,7 +2,13 @@ import type { LDTokenUsage } from '../metrics';
 import type { LDAIGraphMetricSummary } from './types';
 
 /**
- * Tracks graph-level and edge-level metrics for an agent graph invocation.
+ * The LDGraphTracker records metrics for a single AI run of an agent graph.
+ *
+ * All events a graph tracker emits share a runId (a UUIDv4) so LaunchDarkly
+ * can correlate them in metrics views. Call `createTracker` on the agent
+ * graph to start a new run. A resumption token preserves the runId, so events
+ * emitted by a tracker reconstructed in another process correlate with the
+ * original run.
  *
  * Graph-level methods enforce at-most-once semantics: calling the same method
  * twice on a tracker instance drops the second call and emits a warning.
@@ -35,7 +41,7 @@ export interface LDGraphTracker {
   /**
    * Returns a snapshot of all graph-level metrics tracked so far. Fields
    * populate incrementally as `track*` methods are called, so the result is
-   * a `Partial<LDAIGraphMetricSummary>`. Once the graph invocation has
+   * a `Partial<LDAIGraphMetricSummary>`. Once the graph run has
    * completed via `ManagedAgentGraph.run()`, prefer `ManagedGraphResult.metrics`
    * which is fully populated.
    */
@@ -57,21 +63,21 @@ export interface LDGraphTracker {
   // -------------------------------------------------------------------------
 
   /**
-   * Tracks a successful graph invocation.
+   * Tracks a successful graph run.
    * Emits event `$ld:ai:graph:invocation_success` with metric value `1`.
    * At-most-once: subsequent calls are dropped with a warning.
    */
   trackInvocationSuccess(): void;
 
   /**
-   * Tracks an unsuccessful graph invocation.
+   * Tracks an unsuccessful graph run.
    * Emits event `$ld:ai:graph:invocation_failure` with metric value `1`.
    * At-most-once: subsequent calls are dropped with a warning.
    */
   trackInvocationFailure(): void;
 
   /**
-   * Tracks the total duration of the graph execution in milliseconds.
+   * Tracks the total duration of the graph run in milliseconds.
    * Emits event `$ld:ai:graph:duration:total` with the duration as the metric value.
    * At-most-once: subsequent calls are dropped with a warning.
    *
@@ -80,7 +86,7 @@ export interface LDGraphTracker {
   trackDuration(durationMs: number): void;
 
   /**
-   * Tracks aggregate token usage across the entire graph invocation.
+   * Tracks aggregate token usage across the entire graph run.
    * Emits event `$ld:ai:graph:total_tokens` with the total token count as the metric value.
    * At-most-once: subsequent calls are dropped with a warning.
    *
@@ -89,12 +95,12 @@ export interface LDGraphTracker {
   trackTotalTokens(tokens: LDTokenUsage): void;
 
   /**
-   * Tracks the execution path through the graph.
+   * Tracks the path taken through the graph during this run.
    * Emits event `$ld:ai:graph:path` with metric value `1`.
    * The data payload includes the path array in addition to standard track data.
    * At-most-once: subsequent calls are dropped with a warning.
    *
-   * @param path An ordered array of agent config keys representing the execution path.
+   * @param path An ordered array of agent config keys representing the path taken.
    */
   trackPath(path: string[]): void;
 


### PR DESCRIPTION
## Summary

Follow-up to the recently-merged billing-spec alignment PR for js-core's `server-ai` package. Brings tracker docs and at-most-once warning strings in line with what just landed for the Go SDK in [launchdarkly/go-server-sdk#363](https://github.com/launchdarkly/go-server-sdk/pull/363).

- **`refactor:` commit**: Reword the at-most-once warning messages on `LDAIConfigTracker` and `LDGraphTracker` so each one names the method being skipped, what was already recorded, and the remedy (call `createTracker` on the AI Config / agent graph for a new run).
- **`docs:` commit**:
  - Expand class-level TSDoc on `LDAIConfigTracker` and `LDGraphTracker` to explain that the `runId` is what LaunchDarkly uses to correlate a tracker's events in metrics views, and that the resumption token preserves the `runId` across process boundaries.
  - Expand `LDAIConfig.createTracker` and `AgentGraphDefinition.createTracker` TSDoc with the same `runId` framing.
  - On each `track*` method, state at-most-once vs. multi-call semantics and what happens when the limit is hit. `trackSuccess` / `trackError` share state; the docstring on each says so. Wrapper methods (`trackDurationOf`, `trackMetricsOf`, `trackStreamMetricsOf`, `trackBedrockConverseMetrics`) note that calling the wrapper twice runs the inner function again but emits no additional metric events.
  - Fix stale `completionConfig` / `agentConfig` / `judgeConfig` / `agentConfigs` TSDoc and examples that still described a returned `{ config, messages, tracker }` shape. The actual return is the config object with a `createTracker()` factory; examples now reflect this.
  - Light terminology sweep in narrative TSDoc text: prefer "AI run" / "graph run" over "execution" / "invocation" when referring to a single tracker's lifetime. Public API names (methods, event keys, type names, parameter names like `executionContext`) are unchanged.

No behavior changes, no version / changelog edits.

## Test plan

- [ ] CI passes on this branch.
- [ ] `LDAIConfigTrackerImpl` and `LDGraphTrackerImpl` unit tests still pass (the two warning-text assertions were updated to match the new wording).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TSDoc/example updates and rewording warning log messages; no tracking behavior or event payloads change, but any consumers depending on exact warning text may be affected.
> 
> **Overview**
> Clarifies tracker semantics across `LDAIConfigTracker`/`LDGraphTracker` and related APIs by explicitly framing a tracker as *one AI/graph run* whose events share a `runId`, and documenting at-most-once vs multi-call behavior per `track*` method (including wrapper helpers).
> 
> Standardizes at-most-once warning messages in `LDAIConfigTrackerImpl` and `LDGraphTrackerImpl` to name the skipped method, what was already recorded, and the remedy (call `createTracker()` for a new run), and updates unit tests accordingly. Also refreshes `LDAIClient` doc examples to reflect the `createTracker()` factory on returned configs rather than a returned `tracker` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1407150dac6b8be96707e4a0e894833711285530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->