### PR TITLE
chore: Drop unnecessary createTracker non-null assertions in getting-started examples

### DIFF
--- a/packages/sdk/server-ai/examples/getting-started/bedrock/converse/src/index.ts
+++ b/packages/sdk/server-ai/examples/getting-started/bedrock/converse/src/index.ts
@@ -80,7 +80,7 @@ async function main() {
       return;
     }
 
-    const tracker = aiConfig.createTracker!();
+    const tracker = aiConfig.createTracker();
 
     const chatMessages = mapPromptToConversation(aiConfig.messages ?? []);
     const systemMessages =

--- a/packages/sdk/server-ai/examples/getting-started/openai/chat-completions/src/index.ts
+++ b/packages/sdk/server-ai/examples/getting-started/openai/chat-completions/src/index.ts
@@ -70,7 +70,7 @@ async function main() {
       return;
     }
 
-    const tracker = aiConfig.createTracker!();
+    const tracker = aiConfig.createTracker();
 
     const sampleQuestion = 'What can you help me with?';
     const messages = [

--- a/packages/sdk/server-ai/examples/getting-started/vercel-ai/generate-text/src/index.ts
+++ b/packages/sdk/server-ai/examples/getting-started/vercel-ai/generate-text/src/index.ts
@@ -69,7 +69,7 @@ async function main() {
       return;
     }
 
-    const tracker = aiConfig.createTracker!();
+    const tracker = aiConfig.createTracker();
     const model = openai(aiConfig.model?.name ?? 'gpt-4');
     const parameters = VercelRunnerFactory.mapParameters(aiConfig.model?.parameters);
 


### PR DESCRIPTION
## Summary

`LDAIConfig.createTracker` is declared non-optional in `packages/sdk/server-ai/src/api/config/types.ts`, so the `!` non-null assertion is unnecessary. Drop it across the three `getting-started/` examples that still had it.

Affected files:
- `packages/sdk/server-ai/examples/getting-started/bedrock/converse/src/index.ts`
- `packages/sdk/server-ai/examples/getting-started/openai/chat-completions/src/index.ts`
- `packages/sdk/server-ai/examples/getting-started/vercel-ai/generate-text/src/index.ts`

## Background

This PR was originally scoped against the pre-#1379 examples layout (with `examples/openai/`, `examples/bedrock/`, `examples/openai-observability/`, `examples/direct-judge/`, etc.). PR #1379 ("Align server-ai examples with EXAM-SDK-example spec") restructured the examples into `features/` and `getting-started/` subdirectories and absorbed most of the issues this PR originally targeted — including the `OpenAIProvider` class removal, `aiConfig.tracker` property usage, `LDAIMetrics(usage:)` literal, and `trackSuccess({...})` arg bug. Three `createTracker!()` occurrences remain in the new `getting-started/` examples; those are what this PR now fixes.

Refs AIC-2383. This PR is part of the AI Configs docs/example modernization sweep tracked in \`python-agent-work/all-docs-review.md\`.

## Test plan
- [x] Final grep sweep returns zero hits for \`createTracker!()\` under \`packages/sdk/server-ai/examples/\`
- [ ] \`yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/server-sdk-ai' run build\` succeeds with the three affected example workspaces
- [ ] Spot-run the three examples to confirm no runtime change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to TypeScript getting-started examples and only remove `!` non-null assertions from `aiConfig.createTracker`, with no runtime behavior change expected.
> 
> **Overview**
> Cleans up the `server-ai` getting-started examples to call `aiConfig.createTracker()` directly (without the `!` non-null assertion) in the Bedrock converse, OpenAI chat-completions, and Vercel AI generate-text samples.
> 
> This aligns the examples with the SDK typings where `createTracker` is non-optional and avoids masking potential type issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ff6bae7ff644fa0a23ea130b24a9978702bdf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->