### PR TITLE
chore: Clarify trackJudgeResult guidance in create-judge example

### DIFF
--- a/packages/sdk/server-ai/examples/features/create-judge/src/index.ts
+++ b/packages/sdk/server-ai/examples/features/create-judge/src/index.ts
@@ -77,9 +77,10 @@ async function main() {
 
     const judgeResult = await judge.evaluate(inputText, outputText);
 
-    // Track the judge evaluation scores on the tracker for the aiConfig you
-    // are evaluating. Example:
-    //   aiConfig.createTracker().trackJudgeResult(judgeResult);
+    // If the output you're judging came from another AI Config, track the
+    // result on that config's tracker so the metric is attributed to the
+    // right config:
+    // aiConfig.createTracker().trackJudgeResult(judgeResult);
 
     console.log('\nJudge result:');
     console.log(`- judge_config_key: ${judgeKey}`);


### PR DESCRIPTION
## Summary

Rewords the comment in the create-judge example that points at `aiConfig.createTracker().trackJudgeResult(judgeResult)` to explain *why* — when the output you're judging came from another AI Config, the score should be attributed to that config's tracker, not the judge's. Also drops the triple-space code-block inset to match the rest of the comment block.

No code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in an example file; no runtime behavior or API usage is modified.
> 
> **Overview**
> Clarifies the comment in the `create-judge` example to explain that `trackJudgeResult` should be sent to the *evaluated* AI Config’s tracker (when judging output from another config) so metrics are attributed correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ef10a90b77789ce870caa3e811d47894d95425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->