### PR TITLE
docs: Clarify composite-tracker re-call wording

### DIFF
--- a/packages/sdk/server-ai/src/api/config/LDAIConfigTracker.ts
+++ b/packages/sdk/server-ai/src/api/config/LDAIConfigTracker.ts
@@ -152,9 +152,9 @@ export interface LDAIConfigTracker {
    * @param func Function which executes the AI run
    * @returns The result of the AI run
    *
-   * @remarks Because each inner metric is at-most-once per Tracker, calling
-   * this twice on the same Tracker will run the inner function again but
-   * produce no additional metric events.
+   * @remarks Subsequent calls re-run the inner function but emit only metrics
+   * not already recorded on this Tracker. Call createTracker on the AI Config
+   * to start a new run.
    */
   trackMetricsOf<TRes>(
     metricsExtractor: (result: TRes) => LDAIMetrics,
@@ -182,9 +182,9 @@ export interface LDAIConfigTracker {
    * @param metricsExtractor Function that asynchronously extracts metrics from the stream
    * @returns The stream result (returned immediately, not a Promise)
    *
-   * @remarks Because each inner metric is at-most-once per Tracker, calling
-   * this twice on the same Tracker will run the inner function again but
-   * produce no additional metric events.
+   * @remarks Subsequent calls re-run the inner function but emit only metrics
+   * not already recorded on this Tracker. Call createTracker on the AI Config
+   * to start a new run.
    */
   trackStreamMetricsOf<TStream>(
     streamCreator: () => TStream,
@@ -199,8 +199,8 @@ export interface LDAIConfigTracker {
    * @param res The result of the Bedrock operation.
    * @returns The input operation.
    *
-   * @remarks Because each inner metric is at-most-once per Tracker, calling
-   * this twice on the same Tracker will produce no additional metric events.
+   * @remarks Subsequent calls emit only metrics not already recorded on this
+   * Tracker. Call createTracker on the AI Config to start a new run.
    */
   trackBedrockConverseMetrics<
     TRes extends {


### PR DESCRIPTION
## Summary

Small accuracy fix to the per-method `@remarks` doc blocks added to `LDAIConfigTracker` in #1378.

The wording on the composite-tracker wrapper methods (`trackMetricsOf`, `trackStreamMetricsOf`, `trackBedrockConverseMetrics`) claimed that calling a wrapper twice on the same `Tracker` would emit no additional metric events. That overpromises: if the first call recorded only some of the inner metrics (for example, the inner function threw after duration was recorded but before tokens were extracted), a later successful call CAN still emit the metrics that were never recorded the first time. The new wording reflects this.

`trackDurationOf` is intentionally left as-is — it only records a single metric (duration), so the partial-failure leak doesn't apply.

Mirrors the equivalent doc fix being made for Go.

## Test plan

- [ ] CI passes (this is doc-only, no runtime behavior change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only changes that clarify metric emission behavior on repeated wrapper calls; no runtime logic is modified.
> 
> **Overview**
> Updates the `@remarks` documentation on `LDAIConfigTracker` wrapper methods (`trackMetricsOf`, `trackStreamMetricsOf`, `trackBedrockConverseMetrics`) to clarify that repeated calls may still emit *previously unrecorded* metrics on the same Tracker (e.g., after a partial failure), and recommends using `createTracker` to start a new run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0df53c9de3853bdd9de1a54b01a54e24393b55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->