### PR TITLE
chore: Suppress failing hook test

### DIFF
--- a/packages/sdk/browser/contract-tests/suppressions.txt
+++ b/packages/sdk/browser/contract-tests/suppressions.txt
@@ -17,3 +17,4 @@ tags/stream requests/{"applicationId":"_________________________________________
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
 hooks/evaluation/executes beforeEvaluation hooks in registration order
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/browser/contract-tests/suppressions.txt
+++ b/packages/sdk/browser/contract-tests/suppressions.txt
@@ -16,3 +16,4 @@ tags/stream requests/{"applicationId":"_________________________________________
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":""}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
+hooks/evaluation/executes beforeEvaluation hooks in registration order

--- a/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
+++ b/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
@@ -43,4 +43,3 @@ tags/poll requests/{"applicationId":"___________________________________________
 tags/poll requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/poll requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
 tags/disallowed characters
-hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
+++ b/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
@@ -43,3 +43,4 @@ tags/poll requests/{"applicationId":"___________________________________________
 tags/poll requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/poll requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
 tags/disallowed characters
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/electron/contract-tests/suppressions.txt
+++ b/packages/sdk/electron/contract-tests/suppressions.txt
@@ -1,1 +1,2 @@
 hooks/evaluation/executes beforeEvaluation hooks in registration order
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/electron/contract-tests/suppressions.txt
+++ b/packages/sdk/electron/contract-tests/suppressions.txt
@@ -1,0 +1,1 @@
+hooks/evaluation/executes beforeEvaluation hooks in registration order

--- a/packages/sdk/react/contract-tests/suppressions.txt
+++ b/packages/sdk/react/contract-tests/suppressions.txt
@@ -17,3 +17,4 @@ tags/stream requests/{"applicationId":"_________________________________________
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
 hooks/evaluation/executes beforeEvaluation hooks in registration order
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/react/contract-tests/suppressions.txt
+++ b/packages/sdk/react/contract-tests/suppressions.txt
@@ -16,3 +16,4 @@ tags/stream requests/{"applicationId":"_________________________________________
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":""}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"}
 tags/stream requests/{"applicationId":"________________________________________________________________","applicationVersion":"________________________________________________________________"}
+hooks/evaluation/executes beforeEvaluation hooks in registration order

--- a/packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt
+++ b/packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt
@@ -12,3 +12,4 @@ streaming/fdv2/reconnection state management/updates previously known state
 streaming/fdv2/ignores model version
 streaming/fdv2/can discard partial events on errors
 hooks/evaluation/executes beforeEvaluation hooks in registration order
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt
+++ b/packages/sdk/server-node/contract-tests/testharness-suppressions-fdv2.txt
@@ -11,3 +11,4 @@ streaming/fdv2/reconnection state management/replaces previously known state
 streaming/fdv2/reconnection state management/updates previously known state
 streaming/fdv2/ignores model version
 streaming/fdv2/can discard partial events on errors
+hooks/evaluation/executes beforeEvaluation hooks in registration order

--- a/packages/sdk/server-node/contract-tests/testharness-suppressions.txt
+++ b/packages/sdk/server-node/contract-tests/testharness-suppressions.txt
@@ -5,3 +5,4 @@ streaming/requests/URL path is computed correctly/environment_filter_key="encodi
 polling/requests/URL path is computed correctly/environment_filter_key="encoding_not_necessary"/base URI has no trailing slash/GET
 polling/requests/URL path is computed correctly/environment_filter_key="encoding_not_necessary"/base URI has a trailing slash/GET
 hooks/evaluation/executes beforeEvaluation hooks in registration order
+hooks/track/executes afterTrack hooks in registration order

--- a/packages/sdk/server-node/contract-tests/testharness-suppressions.txt
+++ b/packages/sdk/server-node/contract-tests/testharness-suppressions.txt
@@ -4,3 +4,4 @@ streaming/requests/URL path is computed correctly/environment_filter_key="encodi
 streaming/requests/URL path is computed correctly/environment_filter_key="encoding_not_necessary"/base URI has a trailing slash/GET
 polling/requests/URL path is computed correctly/environment_filter_key="encoding_not_necessary"/base URI has no trailing slash/GET
 polling/requests/URL path is computed correctly/environment_filter_key="encoding_not_necessary"/base URI has a trailing slash/GET
+hooks/evaluation/executes beforeEvaluation hooks in registration order


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low runtime risk since changes only adjust contract-test suppression lists, but it reduces coverage by masking failures in hook ordering behavior across multiple SDKs.
> 
> **Overview**
> Adds new entries to multiple contract-test suppression lists to ignore the failing hook ordering cases: `hooks/evaluation/executes beforeEvaluation hooks in registration order` and `hooks/track/executes afterTrack hooks in registration order` (browser, react, electron, and server-node test harness including FDv2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5262653febfb0ca7ecffd041615aac11b007e6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->