### PR TITLE
fix: Remove pre-release caution note from server-ai README

### DIFF
--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -6,12 +6,6 @@
 [![NPM][server-ai-sdk-dm-badge]][server-ai-sdk-npm-link]
 [![NPM][server-ai-sdk-dt-badge]][server-ai-sdk-npm-link]
 
-> [!CAUTION]
-> This SDK is in pre-release and not subject to backwards compatibility
-> guarantees. The API may change based on feedback.
->
-> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
-
 ## LaunchDarkly overview
 
 [LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!


### PR DESCRIPTION
Tracking internally as: AIC-1655

Removes the pre-release caution banner from `@launchdarkly/server-sdk-ai` now that the SDK has hit 1.0. Provider package READMEs retain the note as those packages are still pre-release.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes the pre-release warning from `@launchdarkly/server-sdk-ai` README; no runtime or API behavior is affected.
> 
> **Overview**
> Removes the *pre-release* `[!CAUTION]` banner and upgrade guidance from `packages/sdk/server-ai/README.md`, presenting `@launchdarkly/server-sdk-ai` as generally available in its primary documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947dbd056acd39785ceaa26bcbe81b374d4086ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->