### PR TITLE
chore: Port openfeature-node-server provider implementation, tests, and CI

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -26,6 +26,7 @@ on:
           - packages/sdk/shopify-oxygen
           - packages/sdk/electron
           - packages/sdk/react
+          - packages/sdk/openfeature-node-server
 name: Publish Documentation
 jobs:
   build-publish:

--- a/.github/workflows/openfeature-node-server.yaml
+++ b/.github/workflows/openfeature-node-server.yaml
@@ -13,9 +13,18 @@ on:
 jobs:
   build-test-openfeature-node-server:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Node versions to run on.
+        version: [20, 22]
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.version }}
+          registry-url: 'https://registry.npmjs.org'
       - id: shared
         name: Shared CI Steps
         uses: ./actions/ci

--- a/.github/workflows/openfeature-node-server.yaml
+++ b/.github/workflows/openfeature-node-server.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: ./actions/setup-yarn
         with:
           node-version: ${{ matrix.version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/openfeature-node-server.yaml
+++ b/.github/workflows/openfeature-node-server.yaml
@@ -1,0 +1,25 @@
+name: sdk/openfeature-node-server
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-openfeature-node-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/openfeature-node-server'
+          workspace_path: packages/sdk/openfeature-node-server
+      # TODO: Add contract tests

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,6 +62,7 @@ on:
           - packages/sdk/shopify-oxygen
           - packages/sdk/electron
           - packages/sdk/react
+          - packages/sdk/openfeature-node-server
       prerelease:
         description: 'Is this a prerelease. If so, then the latest tag will not be updated in npm.'
         type: boolean
@@ -105,6 +106,7 @@ jobs:
       package-sdk-shopify-oxygen-released: ${{ steps.release.outputs['packages/sdk/shopify-oxygen--release_created'] }}
       package-sdk-electron-released: ${{ steps.release.outputs['packages/sdk/electron--release_created'] }}
       package-sdk-react-released: ${{ steps.release.outputs['packages/sdk/react--release_created'] }}
+      package-sdk-openfeature-node-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-node-server--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0
         id: release
@@ -517,6 +519,24 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/sdk/react
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-openfeature-node-server:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-server-node']
+    permissions:
+      id-token: write
+      contents: write
+    # if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-openfeature-node-server-released == 'true'}}
+    # TODO: Uncomment this when the package is ready to be released.
+    if: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: release-openfeature-node-server
+        name: Full release of packages/sdk/openfeature-node-server
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/sdk/openfeature-node-server
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   manual-publish:

--- a/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
+++ b/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
@@ -1,0 +1,413 @@
+import {
+  Client,
+  ErrorCode,
+  OpenFeature,
+  ProviderEvents,
+  ProviderStatus,
+} from '@openfeature/server-sdk';
+
+import { integrations, LDClient, LDClientContext } from '@launchdarkly/node-server-sdk';
+import { translateContext } from '@launchdarkly/openfeature-js-server-common';
+
+import { LaunchDarklyProvider } from '../src';
+import TestLogger from './TestLogger';
+
+const basicContext = { targetingKey: 'the-key' };
+const testFlagKey = 'a-key';
+
+it('can be initialized', async () => {
+  const ldProvider = new LaunchDarklyProvider('sdk-key', { offline: true });
+  await ldProvider.initialize({});
+
+  await OpenFeature.setProviderAndWait(ldProvider);
+
+  const ofClient = OpenFeature.getClient();
+
+  expect(ofClient.providerStatus).toEqual(ProviderStatus.READY);
+  await ldProvider.onClose();
+});
+
+it('can fail to initialize client', async () => {
+  const ldProvider = new LaunchDarklyProvider('sdk-key', {
+    updateProcessor: (
+      clientContext: LDClientContext,
+      dataSourceUpdates: any,
+      initSuccessHandler: VoidFunction,
+      errorHandler?: (e: Error) => void,
+    ) => ({
+      start: () => {
+        setTimeout(() => errorHandler?.({ code: 401 } as any), 20);
+      },
+      close: () => {},
+    }),
+    sendEvents: false,
+  });
+  try {
+    await OpenFeature.setProviderAndWait(ldProvider);
+  } catch (e) {
+    expect((e as Error).message).toEqual('Authentication failed. Double check your SDK key.');
+  }
+  const ofClient = OpenFeature.getClient();
+  expect(ofClient.providerStatus).toEqual(ProviderStatus.ERROR);
+});
+
+it('emits events for flag changes', async () => {
+  const td = new integrations.TestData();
+  const ldProvider = new LaunchDarklyProvider('sdk-key', {
+    updateProcessor: td.getFactory(),
+    sendEvents: false,
+  });
+  let count = 0;
+  ldProvider.events.addHandler(ProviderEvents.ConfigurationChanged, (eventDetail) => {
+    expect(eventDetail?.flagsChanged).toEqual(['flagA']);
+    count += 1;
+  });
+  td.update(td.flag('flagA').valueForAll('B'));
+  expect(await ldProvider.getClient().stringVariation('flagA', { key: 'test-key' }, 'A')).toEqual(
+    'B',
+  );
+  expect(count).toEqual(1);
+  await ldProvider.onClose();
+});
+
+describe('given a mock LaunchDarkly client', () => {
+  let ldClient: LDClient;
+  let ofClient: Client;
+  let ldProvider: LaunchDarklyProvider;
+  const logger: TestLogger = new TestLogger();
+
+  beforeEach(async () => {
+    ldProvider = new LaunchDarklyProvider('sdk-key', { logger, offline: true });
+    ldClient = ldProvider.getClient();
+    await OpenFeature.setProviderAndWait(ldProvider);
+
+    ofClient = OpenFeature.getClient();
+    logger.reset();
+  });
+
+  afterEach(async () => {
+    await ldProvider.onClose();
+    jest.restoreAllMocks();
+  });
+
+  it('calls the client correctly for boolean variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: true,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    await ofClient.getBooleanDetails(testFlagKey, false, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      false,
+    );
+    jest.clearAllMocks();
+    await ofClient.getBooleanValue(testFlagKey, false, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      false,
+    );
+  });
+
+  it('handles correct return types for boolean variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: true,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getBooleanDetails(testFlagKey, false, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: true,
+      reason: 'OFF',
+    });
+  });
+
+  it('handles incorrect return types for boolean variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 'badness',
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getBooleanDetails(testFlagKey, false, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: false,
+      reason: 'ERROR',
+      errorCode: 'TYPE_MISMATCH',
+    });
+  });
+
+  it('calls the client correctly for string variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 'test',
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    await ofClient.getStringDetails(testFlagKey, 'default', basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      'default',
+    );
+    jest.clearAllMocks();
+    await ofClient.getStringValue(testFlagKey, 'default', basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      'default',
+    );
+  });
+
+  it('handles correct return types for string variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 'good',
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getStringDetails(testFlagKey, 'default', basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: 'good',
+      reason: 'OFF',
+    });
+  });
+
+  it('handles incorrect return types for string variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: true,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getStringDetails(testFlagKey, 'default', basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: 'default',
+      reason: 'ERROR',
+      errorCode: 'TYPE_MISMATCH',
+    });
+  });
+
+  it('calls the client correctly for numeric variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 8,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    await ofClient.getNumberDetails(testFlagKey, 0, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      0,
+    );
+    jest.clearAllMocks();
+    await ofClient.getNumberValue(testFlagKey, 0, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      0,
+    );
+  });
+
+  it('handles correct return types for numeric variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 17,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getNumberDetails(testFlagKey, 0, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: 17,
+      reason: 'OFF',
+    });
+  });
+
+  it('handles incorrect return types for numeric variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: true,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getNumberDetails(testFlagKey, 0, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: 0,
+      reason: 'ERROR',
+      errorCode: 'TYPE_MISMATCH',
+    });
+  });
+
+  it('calls the client correctly for object variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: { yes: 'no' },
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      {},
+    );
+    jest.clearAllMocks();
+    await ofClient.getObjectValue(testFlagKey, {}, basicContext);
+    expect(ldClient.variationDetail).toHaveBeenCalledWith(
+      testFlagKey,
+      translateContext(logger, basicContext),
+      {},
+    );
+  });
+
+  it('handles correct return types for object variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: { some: 'value' },
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: { some: 'value' },
+      reason: 'OFF',
+    });
+  });
+
+  it('handles incorrect return types for object variations', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: 22,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: {},
+      reason: 'ERROR',
+      errorCode: 'TYPE_MISMATCH',
+    });
+  });
+
+  it.each([
+    ['CLIENT_NOT_READY', ErrorCode.PROVIDER_NOT_READY],
+    ['MALFORMED_FLAG', ErrorCode.PARSE_ERROR],
+    ['FLAG_NOT_FOUND', ErrorCode.FLAG_NOT_FOUND],
+    ['USER_NOT_SPECIFIED', ErrorCode.TARGETING_KEY_MISSING],
+    ['UNSPECIFIED', ErrorCode.GENERAL],
+    [undefined, ErrorCode.GENERAL],
+  ])('handles errors from the client', async (ldError, ofError) => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: { yes: 'no' },
+      reason: {
+        kind: 'ERROR',
+        errorKind: ldError,
+      },
+    }));
+    const res = await ofClient.getObjectDetails(testFlagKey, { yes: 'no' }, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: { yes: 'no' },
+      reason: 'ERROR',
+      errorCode: ofError,
+    });
+  });
+
+  it('includes the variant', async () => {
+    ldClient.variationDetail = jest.fn(async () => ({
+      value: { yes: 'no' },
+      variationIndex: 22,
+      reason: {
+        kind: 'OFF',
+      },
+    }));
+    const res = await ofClient.getObjectDetails(testFlagKey, {}, basicContext);
+    expect(res).toMatchObject({
+      flagKey: testFlagKey,
+      value: { yes: 'no' },
+      variant: '22',
+      reason: 'OFF',
+    });
+  });
+
+  it('logs information about missing keys', async () => {
+    await ofClient.getObjectDetails(testFlagKey, {}, {});
+    expect(logger.logs[0]).toEqual(
+      "The EvaluationContext must contain either a 'targetingKey' " +
+        "or a 'key' and the type must be a string.",
+    );
+  });
+
+  it('logs information about double keys', async () => {
+    await ofClient.getObjectDetails(testFlagKey, {}, { targetingKey: '1', key: '2' });
+    expect(logger.logs[0]).toEqual(
+      "The EvaluationContext contained both a 'targetingKey' and a" +
+        " 'key' attribute. The 'key' attribute will be discarded.",
+    );
+  });
+
+  it('handles tracking with invalid context', () => {
+    ofClient.track('test-event', {});
+    expect(logger.logs[0]).toEqual(
+      "The EvaluationContext must contain either a 'targetingKey' " +
+        "or a 'key' and the type must be a string.",
+    );
+  });
+
+  it('handles tracking with no data or metricValue', () => {
+    ldClient.track = jest.fn();
+    ofClient.track('test-event', basicContext);
+    expect(ldClient.track).toHaveBeenCalledWith(
+      'test-event',
+      translateContext(logger, basicContext),
+      undefined,
+      undefined,
+    );
+  });
+
+  it('handles tracking with only metricValue', () => {
+    ldClient.track = jest.fn();
+    ofClient.track('test-event', basicContext, { value: 12345 });
+    expect(ldClient.track).toHaveBeenCalledWith(
+      'test-event',
+      translateContext(logger, basicContext),
+      undefined,
+      12345,
+    );
+  });
+
+  it('handles tracking with data but no metricValue', () => {
+    ldClient.track = jest.fn();
+    ofClient.track('test-event', basicContext, { key1: 'val1' });
+    expect(ldClient.track).toHaveBeenCalledWith(
+      'test-event',
+      translateContext(logger, basicContext),
+      { key1: 'val1' },
+      undefined,
+    );
+  });
+
+  it('handles tracking with data and metricValue', () => {
+    ldClient.track = jest.fn();
+    ofClient.track('test-event', basicContext, { value: 12345, key1: 'val1' });
+    expect(ldClient.track).toHaveBeenCalledWith(
+      'test-event',
+      translateContext(logger, basicContext),
+      { key1: 'val1' },
+      12345,
+    );
+  });
+});

--- a/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
+++ b/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
@@ -32,7 +32,7 @@ it('can fail to initialize client', async () => {
     updateProcessor: (
       clientContext: LDClientContext,
       dataSourceUpdates: any,
-      initSuccessHandler: VoidFunction,
+      initSuccessHandler: () => void,
       errorHandler?: (e: Error) => void,
     ) => ({
       start: () => {

--- a/packages/sdk/openfeature-node-server/__tests__/TestLogger.ts
+++ b/packages/sdk/openfeature-node-server/__tests__/TestLogger.ts
@@ -1,0 +1,25 @@
+import type { LDLogger } from '@launchdarkly/node-server-sdk';
+
+export default class TestLogger implements LDLogger {
+  public logs: string[] = [];
+
+  error(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  warn(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  info(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  debug(...args: any[]): void {
+    this.logs.push(args.join(' '));
+  }
+
+  reset() {
+    this.logs = [];
+  }
+}

--- a/packages/sdk/openfeature-node-server/__tests__/scaffold.test.ts
+++ b/packages/sdk/openfeature-node-server/__tests__/scaffold.test.ts
@@ -1,3 +1,0 @@
-it('package scaffolding builds and registers in the workspace', () => {
-  expect(true).toEqual(true);
-});

--- a/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
+++ b/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
@@ -1,0 +1,42 @@
+import type { LDClient, LDOptions } from '@launchdarkly/node-server-sdk';
+import { basicLogger, init } from '@launchdarkly/node-server-sdk';
+import { BaseOpenFeatureProvider } from '@launchdarkly/openfeature-js-server-common';
+
+/**
+ * An OpenFeature provider for the LaunchDarkly Server-Side SDK for Node.js.
+ */
+export default class LaunchDarklyProvider extends BaseOpenFeatureProvider<LDClient> {
+  /**
+   * Construct a {@link LaunchDarklyProvider}.
+   * @param sdkKey The SDK key.
+   * @param options Any options for the SDK.
+   * @param initTimeoutSeconds The default amount of time to wait for initialization in seconds.
+   * Defaults to 10 seconds.
+   */
+  constructor(sdkKey: string, options: LDOptions = {}, initTimeoutSeconds: number = 10) {
+    super({
+      logger: options.logger ?? basicLogger({ level: 'info' }),
+      providerName: 'launchdarkly-node-provider',
+      initTimeoutSeconds,
+    });
+
+    try {
+      const client = init(sdkKey, {
+        ...options,
+        wrapperName: 'open-feature-node-server',
+        // The wrapper version should be kept on its own line to allow easy updates using
+        // release-please.
+        wrapperVersion: '1.2.0', // x-release-please-version
+      });
+
+      this.setClient(client);
+
+      // Wire Node SDK update events to OpenFeature ConfigurationChanged events.
+      client.on('update', ({ key }: { key: string }) => {
+        this.emitConfigurationChanged(key);
+      });
+    } catch (e) {
+      this.setClientError(e);
+    }
+  }
+}

--- a/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
+++ b/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
@@ -26,7 +26,7 @@ export default class LaunchDarklyProvider extends BaseOpenFeatureProvider<LDClie
         wrapperName: 'open-feature-node-server',
         // The wrapper version should be kept on its own line to allow easy updates using
         // release-please.
-        wrapperVersion: '1.2.0', // x-release-please-version
+        wrapperVersion: '1.2.2', // x-release-please-version
       });
 
       this.setClient(client);

--- a/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
+++ b/packages/sdk/openfeature-node-server/src/LaunchDarklyProvider.ts
@@ -24,8 +24,6 @@ export default class LaunchDarklyProvider extends BaseOpenFeatureProvider<LDClie
       const client = init(sdkKey, {
         ...options,
         wrapperName: 'open-feature-node-server',
-        // The wrapper version should be kept on its own line to allow easy updates using
-        // release-please.
         wrapperVersion: '1.2.2', // x-release-please-version
       });
 

--- a/packages/sdk/openfeature-node-server/src/index.ts
+++ b/packages/sdk/openfeature-node-server/src/index.ts
@@ -1,9 +1,11 @@
 /**
- * This is the API reference for the LaunchDarkly OpenFeature provider for the
- * Node.js server SDK.
+ * This is the API reference for the LaunchDarkly OpenFeature provider for the Server-Side SDK for
+ * Node.js
  *
  * @module @launchdarkly/openfeature-node-server
  */
 
-// Provider implementation lands in a follow-up slice.
-export {};
+/* eslint-disable import/prefer-default-export */
+import LaunchDarklyProvider from './LaunchDarklyProvider';
+
+export { LaunchDarklyProvider };

--- a/packages/sdk/openfeature-node-server/typedoc.json
+++ b/packages/sdk/openfeature-node-server/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -345,7 +345,8 @@
       "prerelease": true
     },
     "packages/sdk/openfeature-node-server": {
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": ["src/LaunchDarklyProvider.ts"]
     }
   },
   "plugins": [


### PR DESCRIPTION
## Summary

Final code slice of the openfeature-node-server lateral move (SDK-2213). Lands
the actual provider behavior on top of the inert scaffold from SDK-2216
(PR #1356), wires CI gates around it, and ports the upstream test suite.

This combines the previously-planned CI and impl/tests slices per replan on
2026-05-08 -- the work was tightly coupled enough that splitting added review
overhead without much value.

- \`src/LaunchDarklyProvider.ts\` -- ports the upstream provider (~42 lines).
  Extends \`BaseOpenFeatureProvider\` from
  \`@launchdarkly/openfeature-js-server-common\`, wires Node SDK \`update\` events
  to OpenFeature \`ConfigurationChanged\` events, sets \`wrapperName\` /
  \`wrapperVersion\` for telemetry. Logger is passed through to the base; the
  base wraps with \`createSafeLogger\`, so no double-wrap.
- \`src/index.ts\` -- replaces the slice-2 stub with the real export.
- \`__tests__/LaunchDarklyProvider.test.ts\` (413 lines) + \`TestLogger.ts\` --
  full upstream test port. Provides end-to-end coverage by wiring
  \`OpenFeature.setProviderAndWait(ldProvider)\` against \`LaunchDarklyProvider\`
  whose \`LDClient\` uses \`integrations.TestData\` as the data source.
  Removes the slice-2 placeholder \`scaffold.test.ts\`.
- \`.github/workflows/openfeature-node-server.yaml\` -- new CI workflow
  mirroring \`akamai-base.yml\` via the shared \`actions/ci\` step.
- \`.github/workflows/release-please.yml\` -- adds the workspace_path option,
  the \`package-sdk-openfeature-node-server-released\` output, and a disabled
  \`release-openfeature-node-server\` job (\`if: false\` until post-GA).
- \`.github/workflows/manual-publish-docs.yml\` -- adds the new workspace path.

Resolves SDK-2325. Supersedes SDK-2217.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New flag-evaluation and event-tracking surface on the server path, but behavior is largely delegated to existing shared provider logic and covered by extensive tests; automated release remains off (`if: false`).
> 
> **Overview**
> Replaces the `openfeature-node-server` scaffold with a real **LaunchDarkly OpenFeature provider** for Node: `LaunchDarklyProvider` extends shared `BaseOpenFeatureProvider`, initializes the Node server SDK with wrapper telemetry, and maps SDK `update` events to OpenFeature `ConfigurationChanged`. The public API now exports `LaunchDarklyProvider` instead of an empty stub.
> 
> Adds a **ported Jest suite** (init/auth failure, flag-change events, typed evaluations, LD→OpenFeature error mapping, context logging, and `track` forwarding) plus a small `TestLogger`, and removes the placeholder scaffold test. **CI/release wiring** adds a dedicated workflow (Node 20/22 via shared `actions/ci`), registers the package in manual docs publish and release-please (including bumping `wrapperVersion` in `LaunchDarklyProvider.ts`), and introduces a **disabled** `release-openfeature-node-server` job until post-GA. TypeDoc config is added for the package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f3fc8149de921d9fb6f5de7e3d9e2eb099ea56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->