### PR TITLE
ci: fixing electron ci breaking

### DIFF
--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -19,8 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Node versions to run on.
-        version: [24]
+        # NOTE: we need to pin this particular version for electron because
+        # 24.16 introduce some breaking changes affecting electron installation.
+        # We should monitor if NodeJS patches anything on that minor version before
+        # putting this back to latest LTS.
+        version: [24.15]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -80,7 +83,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.15
       - uses: ./actions/run-example
         with:
           workspace_name: '@launchdarkly/electron-example'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only Node version pin with no application or security logic changes.
> 
> **Overview**
> Pins Node.js to **24.15** in the Electron GitHub Actions workflow (`build-test-electron` matrix and `run-example`) instead of floating **24** / latest 24.x.
> 
> Comments document that **Node 24.16** introduces breaking changes that break Electron installation in CI, with a note to revisit once upstream fixes land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48bc8fa55f99aa76e46a34c245dcafc362328be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->