### PR TITLE
fix: Ensure FDv2 waits for network results instead of cached results.

### DIFF
--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -238,7 +238,7 @@ class BrowserClientImpl extends LDClientImpl {
     const options: LDBaseIdentifyOptions =
       identifyOptions?.sheddable === undefined
         ? { ...identifyOptions, sheddable: true }
-        : identifyOptions;
+        : { ...identifyOptions };
     // The browser only supports waiting for network results.
     options.waitForNetworkResults = true;
 

--- a/packages/sdk/browser/src/BrowserClient.ts
+++ b/packages/sdk/browser/src/BrowserClient.ts
@@ -235,10 +235,13 @@ class BrowserClientImpl extends LDClientImpl {
     context: LDContext,
     identifyOptions?: LDIdentifyOptions,
   ): Promise<LDIdentifyResult> {
-    const options =
+    const options: LDBaseIdentifyOptions =
       identifyOptions?.sheddable === undefined
         ? { ...identifyOptions, sheddable: true }
         : identifyOptions;
+    // The browser only supports waiting for network results.
+    options.waitForNetworkResults = true;
+
     const res = await super.identifyResult(context, options);
     // Ensure that we do not start the goal manager if start() is not called.
     if (this.startPromise) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-path behavior change in browser identify options; aligns with documented browser-only network semantics and does not touch auth or persistence.
> 
> **Overview**
> The browser client’s **`identifyResult`** path now always passes **`waitForNetworkResults: true`** into the shared identify flow so FDv2 **identify** completes on fresh network flag data instead of settling on cached results.
> 
> The identify options object is typed as **`LDBaseIdentifyOptions`**, and when **`sheddable`** is already provided the code copies options with a spread (same as the default branch) before setting **`waitForNetworkResults`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f086c74d6eb2acf8aee857b945862ea1220c291. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->