### PR TITLE
docs: expand browser contract-test README (Playwright, headless, adapter bind-on-connect, suppressions)

### DIFF
--- a/packages/sdk/browser/contract-tests/README.md
+++ b/packages/sdk/browser/contract-tests/README.md
@@ -7,9 +7,9 @@ This directory contains the contract test implementation for the LaunchDarkly Br
 The browser contract tests consist of three components:
 
 1. **Adapter**: The `npx sdk-testharness-server adapter` CLI from `@launchdarkly/js-contract-test-utils`. The adapter:
-   - Exposes a REST API on port 8000 for the test harness
    - Runs a WebSocket server on port 8001 for browser communication
    - Translates REST commands to WebSocket messages
+   - Exposes a REST API on port 8000 for the test harness. **Note:** the REST server (8000) is only started once a browser entity connects over the WebSocket (8001), and it is torn down and recreated on every (re)connection. A browser must therefore be connected before the harness can reach port 8000.
 
 2. **Entity** (`entity/`): A browser application (Vite app) that:
    - Connects to the adapter via WebSocket
@@ -26,28 +26,60 @@ The browser contract tests consist of three components:
 
 - Node.js 18 or later
 - Yarn
-- A modern browser (for manual testing)
+- Chromium for Playwright (used for headless runs). Install it once with:
 
-### Quick Start
+  ```bash
+  yarn workspace @launchdarkly/browser-contract-test-service run install-playwright-browsers
+  ```
+
+  If you later hit a Playwright error like `Executable doesn't exist at .../chrome-headless-shell-<version>`, the bundled Playwright was updated and now expects a newer Chromium build — just re-run the command above (or `npx playwright install chromium` from `entity/`).
+
+### Quick Start (opens your default browser)
 
 ```bash
 # From the repository root
 ./packages/sdk/browser/contract-tests/run-test-service.sh
 ```
 
-This script will:
-1. Start the adapter (WebSocket bridge)
-2. Start the entity (browser app with Vite dev server)
-3. Open the browser app in your default browser
+This starts the adapter and the entity (Vite dev server) and opens the entity in your **default browser**.
 
 The services will be available at:
 - Adapter REST API: http://localhost:8000
 - Adapter WebSocket: ws://localhost:8001
 - Browser App: http://localhost:5173
 
-You then run the `sdk-test-harness`. More information is available here: https://github.com/launchdarkly/sdk-test-harness
+> **Important:** the adapter's REST API (8000) only starts listening once a browser entity has connected over the WebSocket (8001) — see the Architecture note above. If `http://localhost:8000` is not responding, make sure a browser (a real tab, or the headless instance below) is loaded and connected.
 
-Example with local clone of the test harness:
+### Headless (no GUI / CI)
+
+For CI or a headless machine, start the pieces separately and drive the entity with a headless Chromium via Playwright. `open-browser.mjs` loads the entity, keeps it open, and streams the browser console (`[Browser Console]` / `[Browser Error]`) to stdout — handy for debugging the front-end:
+
 ```bash
-go run . --url http://localhost:8123 -skip-from path-to-your-js-core-clone/packages/sdk/browser/contract-tests/suppressions.txt
+# 1. Adapter (WebSocket bridge + REST)
+yarn workspace @launchdarkly/browser-contract-test-service run start:adapter &
+
+# 2. Entity Vite dev server, WITHOUT auto-opening a browser
+yarn workspace @launchdarkly/browser-contract-test-service run start:headless &
+
+# 3. Headless browser that loads the entity and connects to the adapter
+node packages/sdk/browser/contract-tests/entity/open-browser.mjs http://localhost:5173 &
 ```
+
+Once the headless browser connects, the adapter logs `Listening on port 8000` and the REST API becomes available.
+
+### Running the test harness
+
+Point the [sdk-test-harness](https://github.com/launchdarkly/sdk-test-harness) at the adapter's REST API (port **8000**), skipping the tests listed in one of the suppression files:
+
+```bash
+# from your local sdk-test-harness clone
+go run . --url http://localhost:8000 \
+  -skip-from path-to-your-js-core-clone/packages/sdk/browser/contract-tests/suppressions.txt
+```
+
+#### Suppression files
+
+Two skip-lists live alongside this README; pass the appropriate one to `-skip-from`:
+
+- **`suppressions.txt`** — the standard skip list for the Browser SDK contract tests.
+- **`suppressions_datamode_changes.txt`** — a broader skip list used when running against the FDv2 (data system / "data mode") client-side work. In addition to the standard skips, it excludes request tests that are not expected to pass in that configuration yet (the HTTP `REPORT` streaming/polling request variants and the `tags` streaming/polling request tests), giving a clean baseline on that branch.


### PR DESCRIPTION
## Summary

Documents setup details for running the Browser SDK contract tests that weren't captured anywhere (no skill/memory/CLAUDE.md covered them), based on getting the harness running end-to-end. Docs-only — no code changes.

- **Playwright** — adds the Chromium install prerequisite (`yarn workspace @launchdarkly/browser-contract-test-service run install-playwright-browsers`) and how to recover from the `Executable doesn't exist at …chrome-headless-shell-<version>` mismatch after a Playwright bump.
- **Headless / CI** — a new section: run `start:adapter` + `start:headless` (no auto-open) + `entity/open-browser.mjs`, which loads the entity in headless Chromium and streams the browser console (`[Browser Console]` / `[Browser Error]`) to stdout.
- **Adapter bind-on-connect** — calls out that the adapter's REST API (8000) only starts listening once a browser entity connects over the WebSocket (8001), and is torn down/recreated on every (re)connection — so a browser must be connected before the harness can reach 8000.
- **Suppression files** — documents the two skip-lists: `suppressions.txt` (standard) vs `suppressions_datamode_changes.txt` (broader, for the FDv2 client-side work).
- **Fix** — corrects the harness example URL from `http://localhost:8123` to `http://localhost:8000`.

## Scope

README-only (`packages/sdk/browser/contract-tests/README.md`). No source, adapter, or entity changes in this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the contract-tests README; no runtime, adapter, or entity behavior is modified.
> 
> **Overview**
> Expands **`packages/sdk/browser/contract-tests/README.md`** so Browser SDK contract-test setup matches how the harness is actually run end-to-end—**docs only**, no code changes.
> 
> The **Architecture** section now states that the adapter REST API on port **8000** only listens after a browser entity connects on WebSocket **8001**, and that the REST server is torn down and recreated on each (re)connection.
> 
> **Prerequisites** add Playwright Chromium install via `install-playwright-browsers` and recovery steps when `chrome-headless-shell` is missing after a Playwright upgrade. **Quick Start** is retitled and clarified; a callout explains why **8000** may be down until a browser is connected.
> 
> A new **Headless (no GUI / CI)** section documents `start:adapter`, `start:headless`, and `open-browser.mjs` (console streaming). **Running the test harness** fixes the example URL from **8123** to **8000** and documents **`suppressions.txt`** vs **`suppressions_datamode_changes.txt`** for FDv2/data-mode baselines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aae04ebda1c2d1c56f1e631edb1b8fe90b6b129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->