### PR TITLE
ci: remove npm force resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,7 @@
     "typescript": "5.1.6"
   },
   "packageManager": "yarn@4.15.0",
-  "//": "Pin jsonc-parser because v3.3.0 breaks rollup-plugin-esbuild",
   "resolutions": {
-    "jsonc-parser": "3.2.0",
-    "parse5": "7.2.1",
     "@types/node": "24.1.0"
   }
 }


### PR DESCRIPTION
This PR removes some workarounds to package resolutions and see if yarn 4 can handle this better.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Root-level dependency pinning only; risk is limited to install/build breakage if a previously avoided transitive version regresses.
> 
> **Overview**
> Removes Yarn **resolutions** that previously pinned **`jsonc-parser`** to `3.2.0` (with a note that `3.3.0` broke `rollup-plugin-esbuild`) and **`parse5`** to `7.2.1`, plus the explanatory `//` comment in `package.json`.
> 
> The only remaining resolution is **`@types/node`** at `24.1.0`. Transitive versions of those packages will now follow what Yarn 4 resolves from the lockfile and dependency tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6df5e80b7ecdc1e4c810154d1f15fb2a63485f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->