### PR TITLE
chore: scaffold vue

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,6 +64,7 @@ on:
           - packages/sdk/electron
           - packages/sdk/react
           - packages/sdk/openfeature-node-server
+          - packages/sdk/vue
       prerelease:
         description: 'Is this a prerelease. If so, then the latest tag will not be updated in npm.'
         type: boolean
@@ -109,6 +110,7 @@ jobs:
       package-sdk-react-released: ${{ steps.release.outputs['packages/sdk/react--release_created'] }}
       package-sdk-openfeature-node-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-node-server--release_created'] }}
       package-tooling-client-testing-plugin-released: ${{ steps.release.outputs['packages/tooling/client-testing-plugin--release_created'] }}
+      package-sdk-vue-released: ${{ steps.release.outputs['packages/sdk/vue--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0
         id: release
@@ -555,6 +557,24 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/sdk/openfeature-node-server
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-vue:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-browser']
+    permissions:
+      id-token: write
+      contents: write
+    # if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-vue-released == 'true'}}
+    # TODO: Uncomment this when the package is ready to be released.
+    if: false
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - id: release-vue
+        name: Full release of packages/sdk/vue
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/sdk/vue
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   manual-publish:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -1,0 +1,28 @@
+name: sdk/vue
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-vue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./actions/setup-yarn
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/vue-client-sdk'
+          workspace_path: packages/sdk/vue
+          should_build_docs: false
+
+  # TODO(scaffold): run-example job arrives when examples/getting-started lands
+  # TODO(scaffold): contract-tests job arrives when contract-tests land

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -26,5 +26,6 @@
   "packages/tooling/client-testing-plugin": "0.1.1",
   "packages/sdk/shopify-oxygen": "0.1.13",
   "packages/sdk/react": "4.1.2",
-  "packages/sdk/openfeature-node-server": "1.2.3"
+  "packages/sdk/openfeature-node-server": "1.2.3",
+  "packages/sdk/vue": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "packages/sdk/browser/example",
     "packages/sdk/browser/example-fdv2",
     "packages/sdk/openfeature-node-server",
-    "packages/sdk/openfeature-node-server/examples/getting-started"
+    "packages/sdk/openfeature-node-server/examples/getting-started",
+    "packages/sdk/vue"
   ],
   "private": true,
   "scripts": {

--- a/packages/sdk/vue/.gitignore
+++ b/packages/sdk/vue/.gitignore
@@ -1,0 +1,4 @@
+dist/
+docs/
+node_modules/
+*.tsbuildinfo

--- a/packages/sdk/vue/CHANGELOG.md
+++ b/packages/sdk/vue/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to `@launchdarkly/vue-client-sdk` will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).

--- a/packages/sdk/vue/LICENSE
+++ b/packages/sdk/vue/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2026 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/sdk/vue/README.md
+++ b/packages/sdk/vue/README.md
@@ -1,0 +1,50 @@
+# LaunchDarkly Vue SDK
+
+[![Actions Status][vue-sdk-ci-badge]][vue-sdk-ci]
+<!-- Badges below are commented out until the package is published to npm and docs are deployed.
+[![NPM][vue-sdk-npm-badge]][vue-sdk-npm-link]
+[![Documentation][vue-sdk-ghp-badge]][vue-sdk-ghp-link]
+[![NPM][vue-sdk-dm-badge]][vue-sdk-npm-link]
+[![NPM][vue-sdk-dt-badge]][vue-sdk-npm-link]
+-->
+
+> [!CAUTION]
+> This SDK is experimental and should NOT be considered ready for production use.
+> It may change or be removed without notice and is not subject to backwards
+> compatibility guarantees.
+>
+> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
+
+## Getting started
+
+Refer to the [SDK documentation](https://launchdarkly.com/docs/sdk/client-side/vue) for instructions on getting started with using the SDK.
+
+## Verifying SDK build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages. To learn more, see the [provenance guide](../../../PROVENANCE.md).
+
+## About LaunchDarkly
+
+- LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard. With LaunchDarkly, you can:
+  - Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
+  - Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
+  - Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
+  - Grant access to certain features based on user attributes, like payment plan (eg: users on the 'gold' plan get access to more features than users in the 'silver' plan).
+  - Disable parts of your application to facilitate maintenance, without taking everything offline.
+- LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Read [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
+- Explore LaunchDarkly
+  - [launchdarkly.com](https://www.launchdarkly.com/ 'LaunchDarkly Main Website') for more information
+  - [docs.launchdarkly.com](https://docs.launchdarkly.com/ 'LaunchDarkly Documentation') for our documentation and SDK reference guides
+  - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
+  - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
+
+[vue-sdk-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml/badge.svg
+[vue-sdk-ci]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml
+<!-- Badge link definitions below are commented out until the package is published.
+[vue-sdk-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/vue-client-sdk.svg?style=flat-square
+[vue-sdk-npm-link]: https://www.npmjs.com/package/@launchdarkly/vue-client-sdk
+[vue-sdk-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[vue-sdk-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/vue/docs/
+[vue-sdk-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/vue-client-sdk.svg?style=flat-square
+[vue-sdk-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/vue-client-sdk.svg?style=flat-square
+-->

--- a/packages/sdk/vue/jest.config.json
+++ b/packages/sdk/vue/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "transform": { "^.+\\.tsx?$": ["ts-jest", { "tsconfig": { "esModuleInterop": true } }] },
+  "testMatch": ["**/*.test.ts?(x)"],
+  "testPathIgnorePatterns": ["node_modules", "example", "contract-tests", "dist"],
+  "modulePathIgnorePatterns": ["dist"],
+  "testEnvironment": "node",
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+  "collectCoverageFrom": ["src/**/*.ts?(x)"]
+}

--- a/packages/sdk/vue/package.json
+++ b/packages/sdk/vue/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@launchdarkly/vue-client-sdk",
+  "version": "0.1.0",
+  "description": "LaunchDarkly Client-side SDK for Vue",
+  "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/sdk/vue",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/js-core.git"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "launchdarkly",
+    "vue",
+    "vuejs"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "tsup",
+    "lint": "eslint .",
+    "test": "npx jest --ci --passWithNoTests",
+    "coverage": "yarn test --coverage",
+    "check": "yarn lint && yarn build && yarn test"
+  },
+  "peerDependencies": {
+    "vue": "^3.3.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^9.0.0",
+    "eslint-import-resolver-typescript": "^4.0.0",
+    "eslint-plugin-import-x": "^4.0.0",
+    "eslint-plugin-jest": "^28.0.0",
+    "globals": "^16.0.0",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.5",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.5.1",
+    "typedoc": "0.25.0",
+    "typescript": "5.1.6",
+    "typescript-eslint": "^8.0.0",
+    "vue": "^3.4.0"
+  }
+}

--- a/packages/sdk/vue/src/index.ts
+++ b/packages/sdk/vue/src/index.ts
@@ -1,0 +1,2 @@
+// TODO(scaffold): full implementation arrives in the next PR
+export {};

--- a/packages/sdk/vue/tsconfig.eslint.json
+++ b/packages/sdk/vue/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/sdk/vue/tsconfig.json
+++ b/packages/sdk/vue/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "lib": ["es2017", "dom", "dom.iterable"],
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noImplicitOverride": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "stripInternal": true,
+    "target": "ES2017",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "dist", "node_modules", "__tests__", "example", "contract-tests"]
+}

--- a/packages/sdk/vue/tsconfig.ref.json
+++ b/packages/sdk/vue/tsconfig.ref.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "package.json"],
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/sdk/vue/tsup.config.js
+++ b/packages/sdk/vue/tsup.config.js
@@ -1,0 +1,26 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  minify: true,
+  format: ['esm', 'cjs'],
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  external: ['vue'],
+  noExternal: [
+    '@launchdarkly/js-sdk-common',
+    '@launchdarkly/js-client-sdk-common',
+    '@launchdarkly/js-client-sdk',
+  ],
+  dts: true,
+  metafile: true,
+  esbuildOptions(opts) {
+    // This would normally be `^_(?!meta|_)`, but go doesn't support negative look-ahead assertions,
+    // so we need to craft something that works without it.
+    // So start of line followed by a character that isn't followed by m or underscore, but we
+    // want other things that do start with m, so we need to progressively handle more characters
+    // of meta with exclusions.
+    opts.mangleProps = /^_([^m|_]|m[^e]|me[^t]|met[^a])/;
+  },
+});

--- a/packages/sdk/vue/typedoc.json
+++ b/packages/sdk/vue/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -387,6 +387,9 @@
           "jsonpath": "$.dependencies['@launchdarkly/openfeature-node-server']"
         }
       ]
+    },
+    "packages/sdk/vue": {
+      "bump-minor-pre-major": true
     }
   },
   "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,9 @@
       "path": "./packages/sdk/svelte/tsconfig.ref.json"
     },
     {
+      "path": "./packages/sdk/vue/tsconfig.ref.json"
+    },
+    {
       "path": "./packages/store/node-server-sdk-redis/tsconfig.ref.json"
     },
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Infrastructure-only scaffold with no runtime SDK surface; automated npm release for Vue remains disabled.
> 
> **Overview**
> Adds **`@launchdarkly/vue-client-sdk`** (`packages/sdk/vue`) at **0.1.0** as an experimental Vue 3 client SDK scaffold. The public entry is a placeholder (`export {}`); **tsup**, Jest, TypeDoc, and README/changelog/license** mirror other client packages, with **Vue** as a peer and LaunchDarkly JS client packages configured for bundling in `tsup.config.js`.
> 
> Wires the package into the monorepo (**yarn workspace**, root **tsconfig** reference) and **release-please** (manifest + config). A new **`vue.yml`** CI job runs shared build/lint/test; **`release-vue`** is added but **`if: false`** until publish is enabled (same pattern as electron/openfeature). Manual publish dropdown includes `packages/sdk/vue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5944ea2f4bead9201a86d7e2ba97193f50ddd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->