### PR TITLE
fix: explicit return types and TS6 source compatibility fixes

### DIFF
--- a/packages/sdk/fastly/src/api/createOptions.ts
+++ b/packages/sdk/fastly/src/api/createOptions.ts
@@ -8,7 +8,7 @@ export const defaultOptions: LDOptions = {
   logger: BasicLogger.get(),
 };
 
-const createOptions = (options: LDOptions) => {
+const createOptions = (options: LDOptions): LDOptions => {
   const finalOptions = { ...defaultOptions, ...options };
 
   // The Fastly SDK does not poll LaunchDarkly for updates, so a custom baseUri does not make sense. However, we need

--- a/packages/sdk/shopify-oxygen/src/utils/createOptions.ts
+++ b/packages/sdk/shopify-oxygen/src/utils/createOptions.ts
@@ -26,7 +26,7 @@ export const defaultOptions: LDOptions & OxygenLDOptions = {
   },
 };
 
-export const createOptions = (options: LDOptions & OxygenLDOptions = {}) => {
+export const createOptions = (options: LDOptions & OxygenLDOptions = {}): LDOptions & OxygenLDOptions => {
   const finalOptions = {
     ...defaultOptions,
     ...options,

--- a/packages/shared/akamai-edgeworker-sdk/src/utils/createOptions.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/utils/createOptions.ts
@@ -8,7 +8,7 @@ export const defaultOptions: LDOptions = {
   logger: BasicLogger.get(),
 };
 
-export const createOptions = (options: LDOptions) => {
+export const createOptions = (options: LDOptions): LDOptions => {
   const finalOptions = { ...defaultOptions, ...options };
   finalOptions.logger?.debug(`Using LD options: ${JSON.stringify(finalOptions)}`);
   return finalOptions;

--- a/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
+++ b/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
@@ -50,6 +50,7 @@ const mockSendEventData = jest.fn();
 jest.useFakeTimers();
 
 jest.mock('../../../src/internal/events/EventSender', () => ({
+  __esModule: true,
   default: jest.fn(() => ({
     sendEventData: mockSendEventData,
   })),

--- a/packages/shared/sdk-server-edge/src/api/createOptions.ts
+++ b/packages/shared/sdk-server-edge/src/api/createOptions.ts
@@ -8,6 +8,6 @@ export const defaultOptions: LDOptions = {
   logger: BasicLogger.get(),
 };
 
-const createOptions = (options: LDOptions) => ({ ...defaultOptions, ...options });
+const createOptions = (options: LDOptions): LDOptions => ({ ...defaultOptions, ...options });
 
 export default createOptions;

--- a/packages/shared/sdk-server/src/store/sortDataSet.ts
+++ b/packages/shared/sdk-server/src/store/sortDataSet.ts
@@ -51,7 +51,7 @@ function topologicalSort(
 
   while (unvisitedItems.size > 0) {
     // Visit the next item, the order we visit doesn't matter.
-    const key = unvisitedItems.values().next().value;
+    const key = unvisitedItems.values().next().value!;
     visit(key);
   }
   return sortedItems;


### PR DESCRIPTION
This PR will tighten some type declarations to prepare this repo's upgrade to typescript 6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only and test-mock changes with no security or data-path logic altered.
> 
> **Overview**
> Adds **explicit return types** to `createOptions` in the Fastly, Shopify Oxygen, Akamai Edgeworker, and server-edge SDKs (`LDOptions` or `LDOptions & OxygenLDOptions`), so merged options are typed consistently under stricter TypeScript inference.
> 
> For TS 6 / module interop, the **EventProcessor** test mock for `EventSender` now sets `__esModule: true`. In **sortDataSet**, the topological-sort loop uses a **non-null assertion** on `unvisitedItems.values().next().value` when the set is known to be non-empty.
> 
> No intended runtime behavior changes—typing and test compatibility only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0d9dc9c8c473064e80b91c8a5aa6f598cf90a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->