### PR TITLE
fix: Honor urlBuilder on React Native EventSource reconnect

### DIFF
--- a/packages/sdk/react-native/__tests__/fromExternal/react-native-sse/EventSource.test.ts
+++ b/packages/sdk/react-native/__tests__/fromExternal/react-native-sse/EventSource.test.ts
@@ -114,4 +114,25 @@ describe('EventSource', () => {
     expect(mockXhr.open).toHaveBeenCalledTimes(2);
     expect(eventSource.onclose).toHaveBeenCalledTimes(1);
   });
+
+  test('recomputes the connection URL via urlBuilder on each connection', () => {
+    let basis: string | undefined;
+    const urlBuilder = jest.fn(() => (basis ? `${uri}?basis=${basis}` : uri));
+    const es = new EventSource<EventName>(uri, { logger, urlBuilder });
+    es.onretrying = jest.fn();
+
+    // Initial connection asks the builder for the URL (no selector known yet).
+    jest.runAllTimers();
+    expect(urlBuilder).toHaveBeenCalled();
+    expect(mockXhr.open).toHaveBeenLastCalledWith('GET', uri, true);
+
+    // Once a selector is known, a reconnect must replay it (e.g. FDv2 basis)
+    // rather than reuse the original URL.
+    basis = 'initial';
+    // @ts-ignore - force a reconnect
+    es._tryConnect();
+    jest.runAllTimers();
+
+    expect(mockXhr.open).toHaveBeenLastCalledWith('GET', `${uri}?basis=initial`, true);
+  });
 });

--- a/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.ts
+++ b/packages/sdk/react-native/src/fromExternal/react-native-sse/EventSource.ts
@@ -68,6 +68,7 @@ export default class EventSource<E extends string = never> {
   private _initialRetryDelayMillis: number = 1000;
   private _retryCount: number = 0;
   private _logger?: any;
+  private _urlBuilder?: () => string;
 
   constructor(url: string, options?: EventSourceOptions) {
     const opts = {
@@ -84,6 +85,7 @@ export default class EventSource<E extends string = never> {
     this._retryAndHandleError = opts.retryAndHandleError;
     this._initialRetryDelayMillis = opts.initialRetryDelayMillis!;
     this._logger = opts.logger;
+    this._urlBuilder = opts.urlBuilder;
 
     this._tryConnect(true);
   }
@@ -116,6 +118,12 @@ export default class EventSource<E extends string = never> {
     try {
       this._lastIndexProcessed = 0;
       this._status = this.CONNECTING;
+      // Recompute the URL on each (re)connection so that reconnects pick up
+      // state that changes over the connection's lifetime (for example the
+      // FDv2 `basis` selector, which must be replayed on reconnect).
+      if (this._urlBuilder) {
+        this._url = this._urlBuilder();
+      }
       this._xhr.open(this._method, this._url, true);
 
       if (this._withCredentials) {

--- a/packages/sdk/react-native/src/fromExternal/react-native-sse/types.ts
+++ b/packages/sdk/react-native/src/fromExternal/react-native-sse/types.ts
@@ -54,6 +54,13 @@ export interface EventSourceOptions {
   retryAndHandleError?: (err: any) => boolean;
   initialRetryDelayMillis?: number;
   logger?: any;
+  /**
+   * Called before each (re)connection to compute the URL to connect to. When
+   * provided, this takes precedence over the static URL so that reconnections
+   * pick up state that changes over the connection's lifetime (for example the
+   * FDv2 `basis` selector, which must be replayed on reconnect).
+   */
+  urlBuilder?: () => string;
 }
 
 type BuiltInEventMap = {

--- a/packages/sdk/react-native/src/platform/PlatformRequests.ts
+++ b/packages/sdk/react-native/src/platform/PlatformRequests.ts
@@ -21,6 +21,7 @@ export default class PlatformRequests implements Requests {
       body: eventSourceInitDict.body,
       retryAndHandleError: eventSourceInitDict.errorFilter,
       logger: this._logger,
+      urlBuilder: eventSourceInitDict.urlBuilder,
     });
   }
 


### PR DESCRIPTION
## Summary

The shared FDv2 streaming source (`StreamingFDv2Base`) passes a `urlBuilder` callback to `requests.createEventSource` so that every (re)connection recomputes the stream URL and replays the current `basis` selector. The browser SDK's `DefaultBrowserEventSource` honors this.

The React Native vendored EventSource (`fromExternal/react-native-sse`) did not:
- it captured the URL once in its constructor and reused it on every reconnect, and
- `PlatformRequests.createEventSource` never forwarded `urlBuilder`.

As a result, after an FDv2 stream reconnect the RN SDK sent an empty `basis` instead of the previously-known selector. This caused the `streaming/fdv2/reconnection state management/{saves,replaces,updates} previously known state` contract tests to fail on React Native (the browser SDK passes them).

This change threads `urlBuilder` through `EventSourceOptions` -> `PlatformRequests.createEventSource` -> the RN `EventSource`, which now recomputes `_url` from `urlBuilder` on each `_open()` -- mirroring the browser implementation.

Verified against sdk-test-harness v3.1.0-alpha.6 on an Android emulator: the three "previously known state" reconnection tests now pass. Added a unit test covering URL recomputation on reconnect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted streaming reconnect behavior with browser parity; covered by a new unit test and existing contract scenarios.
> 
> **Overview**
> React Native FDv2 streaming reconnects now recompute the SSE URL on every open, matching the browser SDK.
> 
> The vendored RN `EventSource` adds an optional **`urlBuilder`** on `EventSourceOptions` and invokes it in **`_open()`** before each initial and retry connection so dynamic query state (e.g. FDv2 **`basis`**) is replayed instead of the constructor URL being reused forever. **`PlatformRequests.createEventSource`** forwards **`eventSourceInitDict.urlBuilder`** into that implementation.
> 
> A unit test asserts **`urlBuilder`** runs on first connect and that a forced reconnect uses the updated URL (e.g. **`?basis=initial`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0230d4ba20f7fedfde2a2f207bbed0488c7adcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->