### PR TITLE
feat: add region to model type

### DIFF
--- a/packages/sdk/server-ai/src/api/config/types.ts
+++ b/packages/sdk/server-ai/src/api/config/types.ts
@@ -37,6 +37,11 @@ export interface LDModelConfig {
    * Additional user-specified parameters.
    */
   custom?: { [index: string]: unknown };
+
+  /**
+   * The region for the model.
+   */
+  region?: string;
 }
 
 export interface LDProviderConfig {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.atlassian.net/jira/software/c/projects/AIC/boards/2045?selectedIssue=AIC-2688

**Describe the solution you've provided**

Adds the `region` property to `LDModelConfig`.

**Additional context**

Some model providers, namely Bedrock, require including a region field on a given call. A call for a sonnet model might look like: global.anthropic.sonnet-4-7 or us.anthropic.sonnet-4-7 etc.

This field was added on the UI for Bedrock models and is optionally includable. Users would be expected to prepend their region to their model names if they're using a provider that requires it.

> The node SDK just passes the model wholesale from the API response, so no need to do any property passing here

Tested in the Node sdk pointed at a local instance:

<img width="668" height="156" alt="Screenshot 2026-06-05 at 12 26 36 PM" src="https://github.com/user-attachments/assets/e79a0d19-534f-4a7b-8d47-eae124cbfe1e" />

```json
{ name: 'anthropic.claude-opus-4-7', parameters: {}, region: 'us' }
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only additive optional field with no runtime behavior changes in this PR.
> 
> **Overview**
> Adds an optional **`region`** field to **`LDModelConfig`** so AI Config model objects can carry provider-specific region metadata (e.g. Bedrock), aligned with the UI and API shape.
> 
> Consumers that pass through the model from the API response get typed access to `region` without SDK mapping changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3547c34714e9fe1d2212e106b0eff7de8acce3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->