### PR TITLE
ci: allow for prerelease to propagate from `full-release` action

### DIFF
--- a/actions/full-release/action.yml
+++ b/actions/full-release/action.yml
@@ -7,6 +7,10 @@ inputs:
   aws_assume_role:
     description: 'The ARN of an AWS IAM role to assume. Used to auth with AWS to upload results to S3.'
     required: true
+  prerelease:
+    description: 'Is this a prerelease. If so, then the latest tag will not be updated in npm. Defaults to `false`.'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -32,8 +36,9 @@ runs:
       with:
         workspace_name: ${{ env.WORKSPACE_NAME }}
         workspace_path: ${{ inputs.workspace_path }}
-        prerelease: false
+        prerelease: ${{ inputs.prerelease }}
         dry_run: false
-    - uses: ./actions/publish-docs
+    - if: ${{ inputs.prerelease != 'true' }}
+      uses: ./actions/publish-docs
       with:
         workspace_path: ${{ inputs.workspace_path }}


### PR DESCRIPTION
This PR should make it easier to do pre-releases without updating the `latest` tag in NPM by letting us propagate the `prerelease` input from the `full-release` action down to the `publish` action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow wiring only; default behavior unchanged when `prerelease` is omitted.
> 
> **Overview**
> Adds an optional **`prerelease`** input to the **`full-release`** composite action (default `false`) and forwards it to **`publish`** instead of always passing `false`, so callers can run pre-releases without moving npm’s **`latest`** tag.
> 
> When **`prerelease`** is `true`, the **`publish-docs`** step is skipped so documentation is not published for pre-releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a47be5bc581297cff40359958703d4c0c7a1e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->