### PR TITLE
chore: Updated pinned version for openfeature-node-server example dependency.

### DIFF
--- a/packages/sdk/openfeature-node-server/examples/getting-started/package.json
+++ b/packages/sdk/openfeature-node-server/examples/getting-started/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@launchdarkly/node-server-sdk": "9.11.1",
-    "@launchdarkly/openfeature-node-server": "1.2.2",
+    "@launchdarkly/openfeature-node-server": "1.2.3",
     "@openfeature/core": "^1.10.0",
     "@openfeature/server-sdk": "^1.16.0"
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Example-only dependency version pin with no runtime or library code changes.
> 
> **Overview**
> Bumps the **getting-started** example’s pinned `@launchdarkly/openfeature-node-server` dependency from **1.2.2** to **1.2.3**, matching the current package release in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a76e55d9e3195adb5b271e474e5a37b38afa73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->