### PR TITLE
chore: updating test files to not break when node is in v24

### DIFF
--- a/packages/sdk/electron/__tests__/platform/ElectronInfo.test.ts
+++ b/packages/sdk/electron/__tests__/platform/ElectronInfo.test.ts
@@ -2,6 +2,23 @@ import * as os from 'os';
 
 import ElectronInfo from '../../src/platform/ElectronInfo';
 
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  platform: jest.fn(),
+  release: jest.fn(),
+  arch: jest.fn(),
+}));
+
+const actualOs = jest.requireActual<typeof os>('os');
+
+// Restore real os implementations before each test so non-mock tests still work.
+// Mock tests override these per-test with mockReturnValue.
+beforeEach(() => {
+  (os.platform as jest.Mock).mockImplementation(actualOs.platform);
+  (os.release as jest.Mock).mockImplementation(actualOs.release);
+  (os.arch as jest.Mock).mockImplementation(actualOs.arch);
+});
+
 describe('given an information instance', () => {
   const info = new ElectronInfo();
 
@@ -34,15 +51,14 @@ describe('given an information instance', () => {
 describe('given an information instance with mock data', () => {
   const info = new ElectronInfo();
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('can get platform information', () => {
-    const platformSpy = jest.spyOn(os, 'platform');
-    platformSpy.mockReturnValue('darwin');
-
-    const releaseSpy = jest.spyOn(os, 'release');
-    releaseSpy.mockReturnValue('0.0.0');
-
-    const archSpy = jest.spyOn(os, 'arch');
-    archSpy.mockReturnValue('x64');
+    (os.platform as jest.Mock).mockReturnValue('darwin');
+    (os.release as jest.Mock).mockReturnValue('0.0.0');
+    (os.arch as jest.Mock).mockReturnValue('x64');
 
     global.process = {
       ...process,
@@ -65,9 +81,7 @@ describe('given an information instance with mock data', () => {
     ['linux', 'Linux'],
     ['some_os', 'some_os'],
   ])('handles known platforms', (platform, processed) => {
-    const platformSpy = jest.spyOn(os, 'platform');
-    // @ts-ignore
-    platformSpy.mockReturnValue(platform);
+    (os.platform as jest.Mock).mockReturnValue(platform);
 
     const data = info.platformData();
     expect(data.os).toBeDefined();

--- a/packages/sdk/server-node/__tests__/platform/NodeInfo.test.ts
+++ b/packages/sdk/server-node/__tests__/platform/NodeInfo.test.ts
@@ -2,6 +2,23 @@ import * as os from 'os';
 
 import NodeInfo from '../../src/platform/NodeInfo';
 
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  platform: jest.fn(),
+  version: jest.fn(),
+  arch: jest.fn(),
+}));
+
+const actualOs = jest.requireActual<typeof os>('os');
+
+// Restore real os implementations before each test so non-mock tests still work.
+// Mock tests override these per-test with mockReturnValue.
+beforeEach(() => {
+  (os.platform as jest.Mock).mockImplementation(actualOs.platform);
+  (os.version as jest.Mock).mockImplementation(actualOs.version);
+  (os.arch as jest.Mock).mockImplementation(actualOs.arch);
+});
+
 describe('given an information instance', () => {
   const info = new NodeInfo({});
 
@@ -34,15 +51,14 @@ test('it supports wrapper name and version', () => {
 describe('given an information instance with mock data', () => {
   const info = new NodeInfo({});
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('can get platform information', () => {
-    const platformSpy = jest.spyOn(os, 'platform');
-    platformSpy.mockReturnValue('darwin');
-
-    const versionSpy = jest.spyOn(os, 'version');
-    versionSpy.mockReturnValue('0.0.0');
-
-    const archSpy = jest.spyOn(os, 'arch');
-    archSpy.mockReturnValue('s390x');
+    (os.platform as jest.Mock).mockReturnValue('darwin');
+    (os.version as jest.Mock).mockReturnValue('0.0.0');
+    (os.arch as jest.Mock).mockReturnValue('s390x');
 
     global.process = {
       ...process,
@@ -64,9 +80,7 @@ describe('given an information instance with mock data', () => {
     ['linux', 'Linux'],
     ['some_os', 'some_os'],
   ])('handles known platforms', (platform, processed) => {
-    const platformSpy = jest.spyOn(os, 'platform');
-    // @ts-ignore
-    platformSpy.mockReturnValue(platform);
+    (os.platform as jest.Mock).mockReturnValue(platform);
 
     const data = info.platformData();
     expect(data.os).toBeDefined();


### PR DESCRIPTION
Node v24 makes `os.platform` immutable which causes the `spyOn` to fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths affected.
> 
> **Overview**
> Updates **Electron** and **server-node** platform info tests so they run on **Node v24**, where `os.platform` (and related APIs) are no longer spyable with `jest.spyOn`.
> 
> Both test files now **`jest.mock('os')`** with `jest.fn()` stand-ins for the `os` methods under test, **`beforeEach`** restores real implementations for tests that use the live OS, and the mock-data suites set **`mockReturnValue`** instead of spies. Mock suites also add **`afterEach(jest.clearAllMocks)`**. Production SDK code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4828bcac467dc7e86d38d9f9fd24a3cf74779d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->