### PR TITLE
test: update test implementation to work well with typescript 6

### DIFF
--- a/packages/sdk/akamai-base/__tests__/index.test.ts
+++ b/packages/sdk/akamai-base/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { EdgeProvider, init } from '../src/index';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 const sdkKey = 'test-sdk-key';
 const flagKey1 = 'testFlag1';

--- a/packages/sdk/akamai-base/tsconfig.json
+++ b/packages/sdk/akamai-base/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "allowJs": true,
     "declaration": true,

--- a/packages/sdk/akamai-edgekv/__tests__/index.test.ts
+++ b/packages/sdk/akamai-edgekv/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import EdgeKVProvider from '../src/edgekv/edgeKVProvider';
 import { init as initWithEdgeKV, LDClient, LDContext, LDLogger } from '../src/index';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 jest.mock('../src/edgekv/edgekv', () => ({
   EdgeKV: jest.fn(),

--- a/packages/sdk/akamai-edgekv/tsconfig.json
+++ b/packages/sdk/akamai-edgekv/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "allowJs": true,
     "declaration": true,

--- a/packages/sdk/cloudflare/__tests__/index.test.ts
+++ b/packages/sdk/cloudflare/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import { Miniflare } from 'miniflare';
 import { LDClient, LDContext } from '@launchdarkly/js-server-sdk-common-edge';
 
 import { init } from '../src/index';
-import * as allFlagsSegments from './testData.json';
+import allFlagsSegments from './testData.json';
 
 const mf = new Miniflare({
   modules: true,

--- a/packages/sdk/cloudflare/tsconfig.json
+++ b/packages/sdk/cloudflare/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,
     "lib": ["es6"],

--- a/packages/sdk/fastly/__tests__/api/EdgeFeatureStore.test.ts
+++ b/packages/sdk/fastly/__tests__/api/EdgeFeatureStore.test.ts
@@ -2,7 +2,7 @@ import { AsyncStoreFacade, LDFeatureStore } from '@launchdarkly/js-server-sdk-co
 
 import { EdgeFeatureStore } from '../../src/api/EdgeFeatureStore';
 import mockEdgeProvider from '../utils/mockEdgeProvider';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 describe('EdgeFeatureStore', () => {
   const clientSideId = 'client-side-id';

--- a/packages/sdk/fastly/__tests__/index.test.ts
+++ b/packages/sdk/fastly/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { KVStore } from 'fastly:kv-store';
 
 import { LDClient } from '../src/api';
 import { init } from '../src/index';
-import * as testData from './utils/testData.json';
+import testData from './utils/testData.json';
 
 // Tell Jest to use the manual mock
 jest.mock('fastly:kv-store');

--- a/packages/sdk/fastly/jest.config.json
+++ b/packages/sdk/fastly/jest.config.json
@@ -1,9 +1,28 @@
 {
-  "transform": { "^.+\\.ts?$": "ts-jest" },
-  "testMatch": ["**/*.test.ts?(x)"],
-  "testPathIgnorePatterns": ["node_modules", "example", "dist"],
-  "modulePathIgnorePatterns": ["dist"],
+  "transform": {
+    "^.+\\.ts?$": "ts-jest"
+  },
+  "testMatch": [
+    "**/*.test.ts?(x)"
+  ],
+  "testPathIgnorePatterns": [
+    "node_modules",
+    "example",
+    "dist"
+  ],
+  "modulePathIgnorePatterns": [
+    "dist"
+  ],
   "testEnvironment": "node",
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
-  "collectCoverageFrom": ["src/**/*.ts"]
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ],
+  "collectCoverageFrom": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/sdk/fastly/tsconfig.json
+++ b/packages/sdk/fastly/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source

--- a/packages/sdk/shopify-oxygen/__tests__/setup.ts
+++ b/packages/sdk/shopify-oxygen/__tests__/setup.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { jest } from '@jest/globals';
 
-import * as allFlagsSegments from './testData.json';
+import allFlagsSegments from './testData.json';
 
 // @ts-ignore
 global.setInterval = () => ({}) as any;

--- a/packages/sdk/shopify-oxygen/tsconfig.json
+++ b/packages/sdk/shopify-oxygen/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,
     "lib": ["es6"],

--- a/packages/sdk/vercel/__tests__/api/EdgeFeatureStore.test.ts
+++ b/packages/sdk/vercel/__tests__/api/EdgeFeatureStore.test.ts
@@ -3,7 +3,7 @@ import * as edgeExports from '@launchdarkly/js-server-sdk-common-edge';
 
 import { EdgeFeatureStore } from '../../src/api/EdgeFeatureStore';
 import mockEdgeProvider from '../utils/mockEdgeProvider';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 describe('EdgeFeatureStore', () => {
   const sdkKey = 'sdkKey';

--- a/packages/sdk/vercel/__tests__/index.test.ts
+++ b/packages/sdk/vercel/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { LDClient, LDContext } from '@launchdarkly/js-server-sdk-common-edge';
 
 import { init } from '../src/index';
 import mockEdgeConfigClient from './utils/mockEdgeConfigClient';
-import * as testData from './utils/testData.json';
+import testData from './utils/testData.json';
 
 const sdkKey = 'test-sdk-key';
 const flagKey1 = 'testFlag1';

--- a/packages/sdk/vercel/tsconfig.json
+++ b/packages/sdk/vercel/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cache.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/cache.test.ts
@@ -1,7 +1,7 @@
 import { AsyncStoreFacade, LDFeatureStore } from '@launchdarkly/js-server-sdk-common';
 
 import { EdgeFeatureStore, EdgeProvider } from '../../src/featureStore';
-import * as testData from '../testData.json';
+import testData from '../testData.json';
 
 describe('EdgeFeatureStore', () => {
   const sdkKey = 'sdkKey';

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/index.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/featureStore/index.test.ts
@@ -1,7 +1,7 @@
 import { AsyncStoreFacade, LDFeatureStore } from '@launchdarkly/js-server-sdk-common';
 
 import { EdgeFeatureStore, EdgeProvider } from '../../src/featureStore';
-import * as testData from '../testData.json';
+import testData from '../testData.json';
 
 describe('EdgeFeatureStore', () => {
   const sdkKey = 'sdkKey';

--- a/packages/shared/akamai-edgeworker-sdk/__tests__/index.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { EdgeProvider, init, LDLogger, LDMultiKindContext, LDSingleKindContext } from '../dist';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 const createClient = (sdkKey: string, mockLogger: LDLogger, mockEdgeProvider: EdgeProvider) =>
   init({

--- a/packages/shared/akamai-edgeworker-sdk/tsconfig.json
+++ b/packages/shared/akamai-edgeworker-sdk/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source

--- a/packages/shared/sdk-client/__tests__/LDCLientImpl.inspections.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDCLientImpl.inspections.test.ts
@@ -6,7 +6,7 @@ import { LDInspection } from '../src/api/LDInspection';
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags, PatchFlag } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.changeemitter.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.changeemitter.test.ts
@@ -4,7 +4,7 @@ import LDClientImpl from '../src/LDClientImpl';
 import LDEmitter from '../src/LDEmitter';
 import { Flags, PatchFlag } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.events.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.events.test.ts
@@ -11,7 +11,7 @@ import {
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventProcessor } from './eventProcessor';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.hooks.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.hooks.test.ts
@@ -3,7 +3,7 @@ import { AutoEnvAttributes } from '@launchdarkly/js-sdk-common';
 import { Hook, HookMetadata } from '../src/api';
 import LDClientImpl from '../src/LDClientImpl';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.start.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.start.test.ts
@@ -5,7 +5,7 @@ import * as bootstrapModule from '../src/flag-manager/bootstrap';
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { goodBootstrapData, goodBootstrapDataWithReasons } from './flag-manager/testBootstrapData';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.storage.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.storage.test.ts
@@ -5,7 +5,7 @@ import LDClientImpl from '../src/LDClientImpl';
 import LDEmitter from '../src/LDEmitter';
 import { Flags, PatchFlag } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.test.ts
@@ -5,7 +5,7 @@ import { DataSourceState } from '../src/datasource/DataSourceStatus';
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.timeout.test.ts
@@ -4,7 +4,7 @@ import { toMulti } from '../src/context/addAutoEnv';
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
+++ b/packages/shared/sdk-client/__tests__/LDClientImpl.variation.test.ts
@@ -9,7 +9,7 @@ import {
 import LDClientImpl from '../src/LDClientImpl';
 import { Flags } from '../src/types';
 import { createBasicPlatform } from './createBasicPlatform';
-import * as mockResponseJson from './evaluation/mockResponse.json';
+import mockResponseJson from './evaluation/mockResponse.json';
 import { MockEventSource } from './streaming/LDClientImpl.mocks';
 import { makeTestDataManagerFactory } from './TestDataManager';
 

--- a/packages/shared/sdk-client/tsconfig.json
+++ b/packages/shared/sdk-client/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitOverride": true,
     // Needed for CommonJS modules: markdown-it, fs-extra
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source

--- a/packages/shared/sdk-server-edge/__tests__/api/EdgeFeatureStore.test.ts
+++ b/packages/shared/sdk-server-edge/__tests__/api/EdgeFeatureStore.test.ts
@@ -2,7 +2,7 @@ import { AsyncStoreFacade, LDFeatureStore } from '@launchdarkly/js-server-sdk-co
 
 import { EdgeFeatureStore } from '../../src/api/EdgeFeatureStore';
 import mockEdgeProvider from '../../src/utils/mockEdgeProvider';
-import * as testData from './testData.json';
+import testData from './testData.json';
 
 describe('EdgeFeatureStore', () => {
   const sdkKey = 'sdkKey';

--- a/packages/shared/sdk-server-edge/tsconfig.json
+++ b/packages/shared/sdk-server-edge/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true, // enables importers to jump to source


### PR DESCRIPTION
This PR will update the way that tests import modules. This is to make the syntax of this module compatible with typescript 6.

Specifically the issue that the current syntax runs into is detailed in https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#deprecated:---esmoduleinterop-false-and---allowsyntheticdefaultimports-false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and TypeScript config-only changes with no production code paths modified.
> 
> **Overview**
> Prepares multiple SDK packages for **TypeScript 6** by turning on **`esModuleInterop`** in their `tsconfig.json` files (alongside existing `allowSyntheticDefaultImports`).
> 
> Test fixtures that used namespace JSON imports (`import * as … from '…json'`) now use **default imports** (`import … from '…json'`), matching the interop model TypeScript 6 expects. Affected areas include edge SDK tests (Akamai, Cloudflare, Fastly, Vercel, Shopify Oxygen), shared `sdk-client` / `akamai-edgeworker-sdk` / `sdk-server-edge` tests, and a formatting-only update to `packages/sdk/fastly/jest.config.json`.
> 
> **No runtime or library `src` changes**—only compiler settings and test import style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e817dc076fece60bd36d3f81b2f37697ec5674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->