### PR TITLE
chore: Add react-sdk testing example with client-testing-plugin

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -127,3 +127,17 @@ jobs:
           workspace_name: '@launchdarkly/react-sdk-example-bootstrap'
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           before_test: 'yarn workspace @launchdarkly/react-sdk-example-bootstrap playwright install --with-deps chromium'
+
+  run-testing-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./actions/setup-yarn
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: yarn workspaces focus @launchdarkly/react-sdk-example-testing
+      - name: Build SDK dependencies
+        run: yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/react-sdk-example-testing' run build
+      - name: Run tests
+        run: yarn workspace @launchdarkly/react-sdk-example-testing test

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "packages/sdk/react/examples/features/bootstrap",
     "packages/sdk/react/examples/hello-react",
     "packages/sdk/react/examples/react-server-example",
+    "packages/sdk/react/examples/testing",
     "packages/sdk/react/examples/vercel-edge",
     "packages/sdk/react-native",
     "packages/sdk/react-native/example",

--- a/packages/sdk/react/examples/testing/README.md
+++ b/packages/sdk/react/examples/testing/README.md
@@ -1,0 +1,70 @@
+# Client Testing Plugin - React SDK example
+
+A working unit-test pattern for the LaunchDarkly React SDK using
+`@launchdarkly/client-testing-plugin`. This is the recommended replacement
+for the deprecated `jest-launchdarkly-mock`.
+
+> See the plugin [README](../../../../tooling/client-testing-plugin/README.md) for the full
+> documentation.
+
+## Run the tests
+
+From the repository root:
+
+```bash
+yarn install
+yarn workspace @launchdarkly/react-sdk-example-testing test
+```
+
+## What's in the example
+
+- [`src/Banner.tsx`](./src/Banner.tsx) - a tiny React component that reads
+  `show-banner` and `greeting` from the React SDK via the typed variation
+  hooks (`useBoolVariation`, `useStringVariation`).
+- [`src/__tests__/Banner.test.tsx`](./src/__tests__/Banner.test.tsx) - Jest +
+  `@testing-library/react` tests that drive the component through the
+  `@launchdarkly/client-testing-plugin/react-sdk` wrapper.
+- [`setup-jest.js`](./setup-jest.js) - a minimal jest setup that is needed to mock
+  out globals that are used by the React SDK.
+
+## Base example
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { createTestClient } from '@launchdarkly/client-testing-plugin/react-sdk';
+import { createLDReactProviderWithClient } from '@launchdarkly/react-sdk';
+
+const { client, testData } = createTestClient(
+  { kind: 'user', key: 'tester' },
+  { 'show-banner': true, greeting: 'Welcome' },
+);
+await client.start({ bootstrap: {} });
+
+const LDProvider = createLDReactProviderWithClient(client);
+
+render(
+  <LDProvider>
+    <Banner />
+  </LDProvider>,
+);
+```
+
+`createTestClient` returns the SDK client + the `TestData` instance which could be
+used to control the flagstore states.
+
+## Updating flag values after the component has rendered
+
+Mutate `testData` in `act(...)` to drive re-renders.
+
+```tsx
+import { act } from '@testing-library/react';
+
+// initial render with greeting = 'Welcome'
+expect(screen.getByRole('banner')).toHaveTextContent('Welcome');
+
+await act(async () => {
+  testData.setString('greeting', 'Updated greeting');
+});
+
+expect(await screen.findByText('Updated greeting')).toBeInTheDocument();
+```

--- a/packages/sdk/react/examples/testing/jest.config.js
+++ b/packages/sdk/react/examples/testing/jest.config.js
@@ -1,0 +1,26 @@
+// Jest config for the React SDK + client-testing-plugin example.
+//
+// Make sure `tsconfig.json` is the single source of truth for workspace path aliases.
+const path = require('path');
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.json');
+
+const reactDir = path.dirname(require.resolve('react/package.json'));
+const reactDomDir = path.dirname(require.resolve('react-dom/package.json'));
+
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { esModuleInterop: true } }],
+  },
+  testMatch: ['**/*.test.ts?(x)'],
+  testPathIgnorePatterns: ['node_modules', 'dist'],
+  modulePathIgnorePatterns: ['dist'],
+  setupFiles: ['./setup-jest.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    ...pathsToModuleNameMapper(compilerOptions.paths || {}, { prefix: '<rootDir>/' }),
+    '^react$': reactDir,
+    '^react-dom(.*)$': `${reactDomDir}$1`,
+  },
+};

--- a/packages/sdk/react/examples/testing/package.json
+++ b/packages/sdk/react/examples/testing/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@launchdarkly/react-sdk-example-testing",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Example: unit-testing React components with @launchdarkly/client-testing-plugin and the React SDK",
+  "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/sdk/react/examples/testing",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchdarkly/js-core.git"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "npx jest --ci"
+  },
+  "dependencies": {
+    "@launchdarkly/client-testing-plugin": "0.1.1",
+    "@launchdarkly/js-client-sdk": "4.9.0",
+    "@launchdarkly/react-sdk": "4.1.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
+    "@types/jest": "^29.5.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jest": "^30.2.0",
+    "jest-environment-jsdom": "^30.0.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "5.1.6"
+  }
+}

--- a/packages/sdk/react/examples/testing/setup-jest.js
+++ b/packages/sdk/react/examples/testing/setup-jest.js
@@ -1,0 +1,36 @@
+const { TextEncoder, TextDecoder } = require('node:util');
+const crypto = require('node:crypto');
+
+global.TextEncoder = TextEncoder;
+
+Object.assign(window, { TextDecoder, TextEncoder });
+
+// Stub EventSource for tests that register change listeners (which triggers
+// automatic streaming in the browser SDK). The real EventSource isn't available
+// in jsdom.
+if (typeof global.EventSource === 'undefined') {
+  global.EventSource = class EventSource {
+    constructor() {
+      // no-op
+    }
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+  };
+}
+
+// jsdom doesn't provide crypto.subtle, which the SDK needs for context hashing.
+// Based on: https://stackoverflow.com/a/71750830
+Object.defineProperty(global.self, 'crypto', {
+  value: {
+    getRandomValues: (arr) => crypto.randomBytes(arr.length),
+    subtle: {
+      digest: (algorithm, data) =>
+        new Promise((resolve) =>
+          resolve(
+            crypto.createHash(algorithm.toLowerCase().replace('-', '')).update(data).digest(),
+          ),
+        ),
+    },
+  },
+});

--- a/packages/sdk/react/examples/testing/setup-jest.js
+++ b/packages/sdk/react/examples/testing/setup-jest.js
@@ -5,20 +5,6 @@ global.TextEncoder = TextEncoder;
 
 Object.assign(window, { TextDecoder, TextEncoder });
 
-// Stub EventSource for tests that register change listeners (which triggers
-// automatic streaming in the browser SDK). The real EventSource isn't available
-// in jsdom.
-if (typeof global.EventSource === 'undefined') {
-  global.EventSource = class EventSource {
-    constructor() {
-      // no-op
-    }
-    addEventListener() {}
-    removeEventListener() {}
-    close() {}
-  };
-}
-
 // jsdom doesn't provide crypto.subtle, which the SDK needs for context hashing.
 // Based on: https://stackoverflow.com/a/71750830
 Object.defineProperty(global.self, 'crypto', {
@@ -34,3 +20,4 @@ Object.defineProperty(global.self, 'crypto', {
     },
   },
 });
+

--- a/packages/sdk/react/examples/testing/src/Banner.tsx
+++ b/packages/sdk/react/examples/testing/src/Banner.tsx
@@ -1,0 +1,21 @@
+import { useBoolVariation, useStringVariation } from '@launchdarkly/react-sdk';
+
+/**
+ * A small example component that reads two flags from the React SDK:
+ *  - `show-banner` (boolean): whether the banner should render at all.
+ *  - `greeting`    (string):  the message shown inside the banner.
+ *
+ * Defaults are passed to each hook so undefined flag values do not crash the
+ * component when the SDK is still initializing or a flag has not been
+ * overridden.
+ */
+export function Banner() {
+  const showBanner = useBoolVariation('show-banner', false);
+  const greeting = useStringVariation('greeting', 'Hello');
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return <div role="banner">{greeting}</div>;
+}

--- a/packages/sdk/react/examples/testing/src/__tests__/Banner.test.tsx
+++ b/packages/sdk/react/examples/testing/src/__tests__/Banner.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Demonstrates the canonical unit-test pattern for components that consume
+ * flags from `@launchdarkly/react-sdk`.
+ *
+ * Two helpers are available from `@launchdarkly/client-testing-plugin/react-sdk`:
+ *
+ * - `createTestClientProvider(context, initialFlags)` - the ergonomic shorthand.
+ *   Returns `{ Provider, client, testData }` with the client already started.
+ *   Use this for most tests.
+ *
+ * - `createTestClient(context, initialFlags)` - the lower-level form.
+ *   Returns `{ client, testData }` without starting the client. Use this when
+ *   you need to configure the client further before calling `client.start()`,
+ *   or when you need to call `createLDReactProviderWithClient` yourself.
+ */
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+
+import { createTestClient, createTestClientProvider } from '@launchdarkly/client-testing-plugin/react-sdk';
+import { createLDReactProviderWithClient } from '@launchdarkly/react-sdk';
+
+import { Banner } from '../Banner';
+
+// -- createTestClientProvider --------------------------------------------------
+//
+// `createTestClientProvider` starts the client automatically and returns a
+// pre-wired Provider. This is the recommended form for most tests.
+
+it('createTestClientProvider: shows the banner when show-banner is true', async () => {
+  const { Provider, client } = await createTestClientProvider(
+    { kind: 'user', key: 'tester' },
+    { 'show-banner': true, greeting: 'Welcome' },
+    { diagnosticOptOut: true },
+  );
+
+  render(
+    <Provider>
+      <Banner />
+    </Provider>,
+  );
+
+  expect(screen.getByRole('banner')).toHaveTextContent('Welcome');
+  await client.close();
+});
+
+it('createTestClientProvider: hides the banner when show-banner is false', async () => {
+  const { Provider, client } = await createTestClientProvider(
+    { kind: 'user', key: 'tester' },
+    { 'show-banner': false },
+    { diagnosticOptOut: true },
+  );
+
+  render(
+    <Provider>
+      <Banner />
+    </Provider>,
+  );
+
+  expect(screen.queryByRole('banner')).toBeNull();
+  await client.close();
+});
+
+it('createTestClientProvider: re-renders when a flag is updated at runtime via testData', async () => {
+  const { Provider, client, testData } = await createTestClientProvider(
+    { kind: 'user', key: 'tester' },
+    { 'show-banner': true, greeting: 'Welcome' },
+    { diagnosticOptOut: true },
+  );
+
+  render(
+    <Provider>
+      <Banner />
+    </Provider>,
+  );
+
+  expect(screen.getByRole('banner')).toHaveTextContent('Welcome');
+
+  await act(async () => {
+    testData.setString('greeting', 'Updated greeting');
+  });
+
+  expect(await screen.findByText('Updated greeting')).toBeInTheDocument();
+  await client.close();
+});
+
+it('createTestClientProvider: isolates flag state across tests with a fresh TestData instance', async () => {
+  // No initial flags -- banner falls through to its default of `false` and
+  // renders nothing, even though a previous test had `show-banner` set to true.
+  const { Provider, client } = await createTestClientProvider(
+    { kind: 'user', key: 'tester' },
+    undefined,
+    { diagnosticOptOut: true },
+  );
+
+  render(
+    <Provider>
+      <Banner />
+    </Provider>,
+  );
+
+  expect(screen.queryByRole('banner')).toBeNull();
+  await client.close();
+});
+
+// -- createTestClient ----------------------------------------------------------
+//
+// `createTestClient` returns the client without starting it. Use this when you
+// need to call `createLDReactProviderWithClient` yourself or configure the
+// client before starting.
+
+it('createTestClient: shows the banner when show-banner is true', async () => {
+  const { client } = createTestClient(
+    { kind: 'user', key: 'tester' },
+    { 'show-banner': true, greeting: 'Welcome' },
+    { diagnosticOptOut: true },
+  );
+  await client.start({ bootstrap: {} });
+
+  const LDProvider = createLDReactProviderWithClient(client);
+  render(
+    <LDProvider>
+      <Banner />
+    </LDProvider>,
+  );
+
+  expect(screen.getByRole('banner')).toHaveTextContent('Welcome');
+  await client.close();
+});
+
+it('createTestClient: re-renders when a flag is updated at runtime via testData', async () => {
+  const { client, testData } = createTestClient(
+    { kind: 'user', key: 'tester' },
+    { 'show-banner': true, greeting: 'Welcome' },
+    { diagnosticOptOut: true },
+  );
+  await client.start({ bootstrap: {} });
+
+  const LDProvider = createLDReactProviderWithClient(client);
+  render(
+    <LDProvider>
+      <Banner />
+    </LDProvider>,
+  );
+
+  expect(screen.getByRole('banner')).toHaveTextContent('Welcome');
+
+  await act(async () => {
+    testData.setString('greeting', 'Updated greeting');
+  });
+
+  expect(await screen.findByText('Updated greeting')).toBeInTheDocument();
+  await client.close();
+});

--- a/packages/sdk/react/examples/testing/tsconfig.json
+++ b/packages/sdk/react/examples/testing/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "lib": ["es6", "dom"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noImplicitOverride": true,
+    "paths": {
+      "@launchdarkly/client-testing-plugin": ["../../../../tooling/client-testing-plugin/src/index.ts"],
+      "@launchdarkly/client-testing-plugin/react-sdk": ["../../../../tooling/client-testing-plugin/src/clients/react-sdk.ts"],
+      "@launchdarkly/react-sdk": ["../../src/client/index.ts"]
+    },
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2017",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tooling/client-testing-plugin/README.md
+++ b/packages/tooling/client-testing-plugin/README.md
@@ -71,7 +71,7 @@ render(<LDProvider><MyComponent /></LDProvider>);
 testData.setString('greeting', 'Updated');
 ```
 
-A runnable example lives under [`example/sdks/react-sdk/`](./example/sdks/react-sdk/).
+A runnable example lives under [`packages/sdk/react/examples/testing/`](../../sdk/react/examples/testing/).
 
 ## Manual setup (advanced)
 

--- a/packages/tooling/client-testing-plugin/__tests__/clients/react-sdk.test.ts
+++ b/packages/tooling/client-testing-plugin/__tests__/clients/react-sdk.test.ts
@@ -39,8 +39,8 @@ it('appends TestData to user-supplied plugins rather than replacing them', async
   await client.close();
 });
 
-it('createTestClientProvider returns a pre-wired Provider, client, and testData', () => {
-  const { Provider, client, testData } = createTestClientProvider(
+it('createTestClientProvider returns a pre-wired Provider, client, and testData', async () => {
+  const { Provider, client, testData } = await createTestClientProvider(
     { kind: 'user', key: 'tester' },
     { 'show-banner': true },
   );

--- a/packages/tooling/client-testing-plugin/__tests__/clients/react-sdk.test.ts
+++ b/packages/tooling/client-testing-plugin/__tests__/clients/react-sdk.test.ts
@@ -47,6 +47,7 @@ it('createTestClientProvider returns a pre-wired Provider, client, and testData'
   expect(Provider).toBeInstanceOf(Function);
   expect(client).toBeDefined();
   expect(testData).toBeInstanceOf(TestData);
+  await client.close();
 });
 
 it('updates flag values dynamically via testData after the client is started', async () => {

--- a/packages/tooling/client-testing-plugin/package.json
+++ b/packages/tooling/client-testing-plugin/package.json
@@ -51,8 +51,8 @@
     "@launchdarkly/js-client-sdk-common": "1.29.0"
   },
   "peerDependencies": {
-    "@launchdarkly/js-client-sdk": ">=4.9.0",
-    "@launchdarkly/react-sdk": ">=4.1.2"
+    "@launchdarkly/js-client-sdk": "^4",
+    "@launchdarkly/react-sdk": "^4"
   },
   "peerDependenciesMeta": {
     "@launchdarkly/js-client-sdk": {

--- a/packages/tooling/client-testing-plugin/src/clients/react-sdk.ts
+++ b/packages/tooling/client-testing-plugin/src/clients/react-sdk.ts
@@ -45,20 +45,23 @@ export function createTestClient(
 
 /**
  * Creates a `@launchdarkly/react-sdk` client and a pre-wired Provider component,
- * ready to wrap components under test.
+ * ready to wrap components under test. The client is started automatically with
+ * an empty bootstrap so initialization does not block on a network call.
  *
  * @param context the LDContext to identify the test client as
  * @param initialFlags optional seed map of flag keys to values
  * @param options optional react-sdk options
  *
- * @returns an object containing the Provider component, client, and testData
+ * @returns a Promise resolving to an object containing the Provider component,
+ *   client, and testData
  */
-export function createTestClientProvider(
+export async function createTestClientProvider(
   context: LDContext,
   initialFlags?: { [key: string]: LDFlagValue },
   options?: Partial<LDReactClientOptions>,
-): CreateTestClientProviderResult {
+): Promise<CreateTestClientProviderResult> {
   const { client, testData } = createTestClient(context, initialFlags, options);
+  await client.start({ bootstrap: {} });
   const Provider = createLDReactProviderWithClient(client);
   return { Provider, client, testData };
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -337,7 +337,14 @@
     },
     "packages/tooling/client-testing-plugin": {
       "bump-minor-pre-major": true,
-      "prerelease": true
+      "prerelease": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "/packages/sdk/react/examples/testing/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/client-testing-plugin']"
+        }
+      ]
     },
     "packages/sdk/combined-browser": {
       "bump-minor-pre-major": true
@@ -368,6 +375,11 @@
         {
           "type": "json",
           "path": "examples/vercel-edge/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/react-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "examples/testing/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/react-sdk']"
         },
         {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -279,6 +279,11 @@
           "type": "json",
           "path": "/packages/tooling/client-testing-plugin/package.json",
           "jsonpath": "$.devDependencies['@launchdarkly/js-client-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "/packages/sdk/react/examples/testing/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/js-client-sdk']"
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> `createTestClientProvider` is a breaking async API change for pre-release test tooling; production SDK paths are unchanged, but downstream test adopters must update call sites.
> 
> **Overview**
> Adds **`@launchdarkly/react-sdk-example-testing`**, a Jest + Testing Library workspace that shows how to unit-test flag-driven components with `@launchdarkly/client-testing-plugin` (replacing the old mock pattern). It includes a small `Banner` sample, `setup-jest.js` for jsdom/crypto gaps, and tests for both `createTestClientProvider` and `createTestClient`.
> 
> **`createTestClientProvider`** in the client-testing-plugin now **`await`s `client.start({ bootstrap: {} })`** and returns a **`Promise`**, so callers must use `await`; plugin tests and the new example are updated accordingly. The plugin README now points at this example instead of the in-package path, and peer dependency ranges are widened to `^4`.
> 
> CI gains **`run-testing-example`** in `react.yml` (focus workspace, build deps, run Jest). Root workspaces and **release-please** extra-files tie SDK/plugin version bumps to the example’s `package.json` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6646c5c3fa778505afde40e8451556a58532ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->