### PR TITLE
chore(deps): remove `turbo` dependency

### DIFF
--- a/packages/sdk/vercel/examples/complete/package.json
+++ b/packages/sdk/vercel/examples/complete/package.json
@@ -10,7 +10,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@launchdarkly/vercel-server-sdk": "workspace:^",
+    "@launchdarkly/vercel-server-sdk": "1.3.48",
     "@vercel/edge-config": "^1.1.0",
     "launchdarkly-js-client-sdk": "^3.1.3",
     "launchdarkly-react-client-sdk": "^3.0.6",
@@ -26,7 +26,6 @@
     "eslint-config-next": "canary",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
-    "turbo": "^1.8.5",
     "typescript": "5.1.6"
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -232,6 +232,11 @@
           "type": "json",
           "path": "/packages/sdk/react/examples/vercel-edge/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/vercel-server-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "examples/complete/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/vercel-server-sdk']"
         }
       ]
     },


### PR DESCRIPTION
`turbo` dependency is not used for anything in the vercel example.

this commit will also fix the `package.json` for the "complete" vercel
example so the `@launchdarkly/vercel-server-sdk` references a valid
semver.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example and release-please config only; no runtime SDK or production code changes.
> 
> **Overview**
> Cleans up the Vercel **complete** example and wires it into release automation.
> 
> The example drops the unused **`turbo`** devDependency and pins **`@launchdarkly/vercel-server-sdk`** to **`1.3.48`** instead of the monorepo **`workspace:^`** protocol so installs use a real semver.
> 
> **`release-please-config.json`** now lists **`examples/complete/package.json`** under **`packages/sdk/vercel`** `extra-files`, so future **`@launchdarkly/vercel-server-sdk`** releases can bump that dependency alongside the existing React Vercel-edge example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d137a85599bb2a613731d194b06502aa12b7672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->