### PR TITLE
chore(node-client-sdk): adding additional option values

### DIFF
--- a/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
@@ -1,0 +1,296 @@
+import {
+  ApplicationTags,
+  base64UrlEncode,
+  Configuration,
+  Context,
+  Encoding,
+  FlagManager,
+  internal,
+  LDEmitter,
+  LDHeaders,
+  LDLogger,
+  Platform,
+  Response,
+  ServiceEndpoints,
+} from '@launchdarkly/js-client-sdk-common';
+
+import NodeDataManager from '../src/NodeDataManager';
+import type { NodeIdentifyOptions } from '../src/NodeIdentifyOptions';
+import { ValidatedOptions } from '../src/options';
+import NodeCrypto from '../src/platform/NodeCrypto';
+import NodeEncoding from '../src/platform/NodeEncoding';
+import NodeInfo from '../src/platform/NodeInfo';
+
+function mockResponse(value: string, statusCode: number) {
+  const response: Response = {
+    headers: {
+      // @ts-ignore
+      get: jest.fn(),
+      // @ts-ignore
+      keys: jest.fn(),
+      // @ts-ignore
+      values: jest.fn(),
+      // @ts-ignore
+      entries: jest.fn(),
+      // @ts-ignore
+      has: jest.fn(),
+    },
+    status: statusCode,
+    text: () => Promise.resolve(value),
+    json: () => Promise.resolve(JSON.parse(value)),
+  };
+  return Promise.resolve(response);
+}
+
+function mockFetch(value: string, statusCode: number = 200) {
+  const f = jest.fn();
+  // @ts-ignore
+  f.mockResolvedValue(mockResponse(value, statusCode));
+  return f;
+}
+
+function makeNodeConfig(overrides: Partial<ValidatedOptions> = {}): ValidatedOptions {
+  return {
+    initialConnectionMode: 'streaming',
+    plugins: [],
+    ...overrides,
+  };
+}
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe('given a NodeDataManager with mocked dependencies', () => {
+  let platform: jest.Mocked<Platform>;
+  let flagManager: jest.Mocked<FlagManager>;
+  let config: Configuration;
+  let baseHeaders: LDHeaders;
+  let emitter: jest.Mocked<LDEmitter>;
+  let diagnosticsManager: jest.Mocked<internal.DiagnosticsManager>;
+  let logger: LDLogger;
+  let eventSourceCloseMethod: jest.Mock;
+
+  beforeEach(() => {
+    logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    eventSourceCloseMethod = jest.fn();
+
+    config = {
+      logger,
+      maxCachedContexts: 5,
+      capacity: 100,
+      diagnosticRecordingInterval: 1000,
+      flushInterval: 1000,
+      streamInitialReconnectDelay: 1000,
+      allAttributesPrivate: false,
+      debug: true,
+      diagnosticOptOut: false,
+      sendEvents: false,
+      sendLDHeaders: true,
+      useReport: false,
+      withReasons: true,
+      privateAttributes: [],
+      tags: new ApplicationTags({}),
+      serviceEndpoints: new ServiceEndpoints('', ''),
+      pollInterval: 1000,
+      userAgentHeaderName: 'user-agent',
+      trackEventModifier: (event) => event,
+      hooks: [],
+      inspectors: [],
+      getImplementationHooks: () => [],
+      credentialType: 'clientSideId',
+    };
+
+    platform = {
+      crypto: new NodeCrypto(),
+      info: new NodeInfo(),
+      requests: {
+        createEventSource: jest.fn((streamUri: string = '', options: any = {}) => ({
+          streamUri,
+          options,
+          onclose: jest.fn(),
+          addEventListener: jest.fn(),
+          close: eventSourceCloseMethod,
+        })),
+        fetch: mockFetch('{"flagA": true}', 200),
+        getEventSourceCapabilities: jest.fn(() => ({})),
+      },
+      storage: {
+        clear: jest.fn(),
+        get: jest.fn(),
+        set: jest.fn(),
+      },
+      encoding: new NodeEncoding(),
+    } as unknown as jest.Mocked<Platform>;
+
+    flagManager = {
+      loadCached: jest.fn(),
+      get: jest.fn(),
+      getAll: jest.fn(),
+      init: jest.fn(),
+      upsert: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+      setBootstrap: jest.fn(),
+    } as unknown as jest.Mocked<FlagManager>;
+
+    baseHeaders = {};
+    emitter = {
+      emit: jest.fn(),
+    } as unknown as jest.Mocked<LDEmitter>;
+    diagnosticsManager = {} as unknown as jest.Mocked<internal.DiagnosticsManager>;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function makeDataManager(nodeConfig: ValidatedOptions) {
+    return new NodeDataManager(
+      platform,
+      flagManager,
+      'test-credential',
+      config,
+      nodeConfig,
+      () => ({
+        pathGet(encoding: Encoding, plainContextString: string): string {
+          return `/poll/${base64UrlEncode(plainContextString, encoding)}`;
+        },
+        pathReport(_encoding: Encoding, _plainContextString: string): string {
+          return '/poll/context';
+        },
+        pathPost(_encoding: Encoding, _plainContextString: string): string {
+          throw new Error('Post unsupported.');
+        },
+        pathPing(_encoding: Encoding, _plainContextString: string): string {
+          throw new Error('Ping for polling unsupported.');
+        },
+      }),
+      () => ({
+        pathGet(encoding: Encoding, plainContextString: string): string {
+          return `/stream/${base64UrlEncode(plainContextString, encoding)}`;
+        },
+        pathReport(_encoding: Encoding, _plainContextString: string): string {
+          return '/stream/context';
+        },
+        pathPost(_encoding: Encoding, _plainContextString: string): string {
+          throw new Error('Post unsupported.');
+        },
+        pathPing(_encoding: Encoding, _plainContextString: string): string {
+          return '/ping';
+        },
+      }),
+      baseHeaders,
+      emitter,
+      diagnosticsManager,
+    );
+  }
+
+  it('includes the config-level hash in streaming requests', async () => {
+    const dataManager = makeDataManager(makeNodeConfig({ hash: 'config-hash' }));
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {});
+
+    expect(platform.requests.createEventSource).toHaveBeenCalledWith(
+      expect.stringContaining('h=config-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('includes the config-level hash in polling requests', async () => {
+    const dataManager = makeDataManager(
+      makeNodeConfig({ initialConnectionMode: 'polling', hash: 'config-hash' }),
+    );
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await new Promise<void>((resolve) => {
+      const identifyResolve = jest.fn().mockImplementation(resolve);
+      dataManager.identify(identifyResolve, jest.fn(), context, {});
+    });
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('h=config-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('per-identify hash overrides config hash in streaming requests', async () => {
+    const dataManager = makeDataManager(makeNodeConfig({ hash: 'config-hash' }));
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'per-identify-hash',
+    } as NodeIdentifyOptions);
+
+    expect(platform.requests.createEventSource).toHaveBeenCalledWith(
+      expect.stringContaining('h=per-identify-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('per-identify hash overrides config hash in polling requests', async () => {
+    const dataManager = makeDataManager(
+      makeNodeConfig({ initialConnectionMode: 'polling', hash: 'config-hash' }),
+    );
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await new Promise<void>((resolve) => {
+      const identifyResolve = jest.fn().mockImplementation(resolve);
+      dataManager.identify(identifyResolve, jest.fn(), context, {
+        hash: 'per-identify-hash',
+      } as NodeIdentifyOptions);
+    });
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('h=per-identify-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('uses per-identify hash when no config hash is set in streaming requests', async () => {
+    const dataManager = makeDataManager(makeNodeConfig());
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'identify-only-hash',
+    } as NodeIdentifyOptions);
+
+    expect(platform.requests.createEventSource).toHaveBeenCalledWith(
+      expect.stringContaining('h=identify-only-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('does not include the h param in streaming requests when no hash is configured', async () => {
+    const dataManager = makeDataManager(makeNodeConfig());
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {});
+
+    const [streamUri] = (platform.requests.createEventSource as jest.Mock).mock.calls[0];
+    expect(streamUri).not.toContain('h=');
+  });
+
+  it('does not include the h param in polling requests when no hash is configured', async () => {
+    const dataManager = makeDataManager(makeNodeConfig({ initialConnectionMode: 'polling' }));
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await new Promise<void>((resolve) => {
+      const identifyResolve = jest.fn().mockImplementation(resolve);
+      dataManager.identify(identifyResolve, jest.fn(), context, {});
+    });
+
+    const [pollUri] = (platform.requests.fetch as jest.Mock).mock.calls[0];
+    expect(pollUri).not.toContain('h=');
+  });
+});

--- a/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
@@ -293,4 +293,69 @@ describe('given a NodeDataManager with mocked dependencies', () => {
     const [pollUri] = (platform.requests.fetch as jest.Mock).mock.calls[0];
     expect(pollUri).not.toContain('h=');
   });
+
+  it('falls back to config hash on second identify when per-identify hash is omitted', async () => {
+    const dataManager = makeDataManager(makeNodeConfig({ hash: 'config-hash' }));
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+    const context2 = Context.fromLDContext({ kind: 'user', key: 'test-user-2' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'per-identify-hash',
+    } as NodeIdentifyOptions);
+    (platform.requests.createEventSource as jest.Mock).mockClear();
+
+    await dataManager.identify(jest.fn(), jest.fn(), context2, {});
+
+    expect(platform.requests.createEventSource).toHaveBeenCalledWith(
+      expect.stringContaining('h=config-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('omits h param on second identify when per-identify hash is omitted and no config hash is set', async () => {
+    const dataManager = makeDataManager(makeNodeConfig());
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+    const context2 = Context.fromLDContext({ kind: 'user', key: 'test-user-2' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'per-identify-hash',
+    } as NodeIdentifyOptions);
+    (platform.requests.createEventSource as jest.Mock).mockClear();
+
+    await dataManager.identify(jest.fn(), jest.fn(), context2, {});
+
+    const [streamUri] = (platform.requests.createEventSource as jest.Mock).mock.calls[0];
+    expect(streamUri).not.toContain('h=');
+  });
+
+  it('per-identify hash persists when connection mode switches to polling', async () => {
+    const dataManager = makeDataManager(makeNodeConfig({ hash: 'config-hash' }));
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'per-identify-hash',
+    } as NodeIdentifyOptions);
+
+    await dataManager.setConnectionMode('polling');
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('h=per-identify-hash'),
+      expect.anything(),
+    );
+  });
+
+  it('includes the per-identify hash in the connection opened after bootstrap', async () => {
+    const dataManager = makeDataManager(makeNodeConfig());
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await dataManager.identify(jest.fn(), jest.fn(), context, {
+      hash: 'per-identify-hash',
+      bootstrap: {},
+    } as NodeIdentifyOptions);
+
+    expect(platform.requests.createEventSource).toHaveBeenCalledWith(
+      expect.stringContaining('h=per-identify-hash'),
+      expect.anything(),
+    );
+  });
 });

--- a/packages/sdk/node-client/__tests__/options.test.ts
+++ b/packages/sdk/node-client/__tests__/options.test.ts
@@ -15,6 +15,8 @@ const wrongTypedOptions: Record<keyof ValidatedOptions, unknown> = {
   plugins: BOGUS_VALUE,
   localStoragePath: BOGUS_VALUE,
   hash: BOGUS_VALUE,
+  wrapperName: BOGUS_VALUE,
+  wrapperVersion: BOGUS_VALUE,
 };
 
 const nodeOptionKeys = Object.keys(wrongTypedOptions) as (keyof ValidatedOptions)[];
@@ -34,6 +36,8 @@ it('applies defaults when no node-specific options are provided', () => {
   expect(out.enableEventCompression).toBeUndefined();
   expect(out.localStoragePath).toBeUndefined();
   expect(out.hash).toBeUndefined();
+  expect(out.wrapperName).toBeUndefined();
+  expect(out.wrapperVersion).toBeUndefined();
   expect(logger.warn).not.toHaveBeenCalled();
 });
 
@@ -52,6 +56,13 @@ it('passes through valid node-specific options', () => {
   expect(out.enableEventCompression).toBe(true);
   expect(out.localStoragePath).toBe('/tmp/ld-cache');
   expect(out.hash).toBe('abc123');
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('passes through wrapperName and wrapperVersion', () => {
+  const out = validateOptions({ wrapperName: 'my-wrapper', wrapperVersion: '1.0.0' }, logger);
+  expect(out.wrapperName).toBe('my-wrapper');
+  expect(out.wrapperVersion).toBe('1.0.0');
   expect(logger.warn).not.toHaveBeenCalled();
 });
 

--- a/packages/sdk/node-client/__tests__/platform/NodeInfo.test.ts
+++ b/packages/sdk/node-client/__tests__/platform/NodeInfo.test.ts
@@ -58,3 +58,17 @@ it('passes through an unknown os platform name', () => {
   const info = new NodeInfo();
   expect(info.platformData().os).toEqual({ name: 'freebsd', version: '14.0', arch: 'arm64' });
 });
+
+it('includes wrapperName and wrapperVersion in sdkData when configured', () => {
+  const info = new NodeInfo({ wrapperName: 'my-wrapper', wrapperVersion: '1.0.0' });
+  const data = info.sdkData();
+  expect(data.wrapperName).toEqual('my-wrapper');
+  expect(data.wrapperVersion).toEqual('1.0.0');
+});
+
+it('omits wrapperName and wrapperVersion from sdkData when not configured', () => {
+  const info = new NodeInfo();
+  const data = info.sdkData();
+  expect(data.wrapperName).toBeUndefined();
+  expect(data.wrapperVersion).toBeUndefined();
+});

--- a/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
+++ b/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
@@ -47,3 +47,21 @@ it('forwards the logger to NodeStorage so storage failures surface', async () =>
   );
 });
 
+
+it('passes wrapperName and wrapperVersion to NodeInfo', () => {
+  const platform = new NodePlatform(logger, {
+    localStoragePath: tmpRoot,
+    wrapperName: 'test-wrapper',
+    wrapperVersion: '2.0.0',
+  });
+  const sdkData = platform.info.sdkData();
+  expect(sdkData.wrapperName).toBe('test-wrapper');
+  expect(sdkData.wrapperVersion).toBe('2.0.0');
+});
+
+it('omits wrapperName and wrapperVersion from NodeInfo when not configured', () => {
+  const platform = new NodePlatform(logger, { localStoragePath: tmpRoot });
+  const sdkData = platform.info.sdkData();
+  expect(sdkData.wrapperName).toBeUndefined();
+  expect(sdkData.wrapperVersion).toBeUndefined();
+});

--- a/packages/sdk/node-client/src/LDClient.ts
+++ b/packages/sdk/node-client/src/LDClient.ts
@@ -2,11 +2,12 @@ import type {
   ConnectionMode,
   LDClient as LDClientBase,
   LDContext,
-  LDIdentifyOptions,
   LDIdentifyResult,
   LDStartOptions,
   LDWaitForInitializationResult,
 } from '@launchdarkly/js-client-sdk-common';
+
+import type { NodeIdentifyOptions } from './NodeIdentifyOptions';
 
 export type { LDStartOptions };
 
@@ -29,7 +30,7 @@ export interface LDClient extends Omit<LDClientBase, 'identify'> {
    * @param identifyOptions Optional configuration. @see {@link LDIdentifyOptions}.
    * @returns A promise which resolves to an object containing the result of the identify operation.
    */
-  identify(context: LDContext, identifyOptions?: LDIdentifyOptions): Promise<LDIdentifyResult>;
+  identify(context: LDContext, identifyOptions?: NodeIdentifyOptions): Promise<LDIdentifyResult>;
 
   /**
    * Starts the client and returns a promise that resolves to the initialization result.

--- a/packages/sdk/node-client/src/LDCommon.ts
+++ b/packages/sdk/node-client/src/LDCommon.ts
@@ -5,7 +5,6 @@ export type {
 } from '@launchdarkly/js-client-sdk-common';
 
 export type {
-  LDIdentifyOptions,
   AutoEnvAttributes,
   BasicLogger,
   BasicLoggerOptions,

--- a/packages/sdk/node-client/src/LDCommon.ts
+++ b/packages/sdk/node-client/src/LDCommon.ts
@@ -1,4 +1,10 @@
 export type {
+  InitializerEntry,
+  ModeDefinition,
+  SynchronizerEntry,
+} from '@launchdarkly/js-client-sdk-common';
+
+export type {
   LDIdentifyOptions,
   AutoEnvAttributes,
   BasicLogger,

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -12,7 +12,6 @@ import {
   LDEmitterEventName,
   LDFlagValue,
   LDHeaders,
-  LDIdentifyOptions,
   LDIdentifyResult,
   LDPluginEnvironmentMetadata,
 } from '@launchdarkly/js-client-sdk-common';
@@ -21,6 +20,7 @@ import basicLogger from './basicLogger';
 import type { LDClient, LDStartOptions } from './LDClient';
 import type { LDPlugin } from './LDPlugin';
 import NodeDataManager from './NodeDataManager';
+import type { NodeIdentifyOptions } from './NodeIdentifyOptions';
 import type { NodeOptions } from './NodeOptions';
 import validateOptions, { filterToBaseOptions } from './options';
 import NodePlatform from './platform/NodePlatform';
@@ -89,9 +89,9 @@ export class NodeClient extends LDClientImpl {
 
   override async identifyResult(
     context: LDContext,
-    identifyOptions?: LDIdentifyOptions,
+    identifyOptions?: NodeIdentifyOptions,
   ): Promise<LDIdentifyResult> {
-    const options =
+    const options: NodeIdentifyOptions =
       identifyOptions?.sheddable === undefined
         ? { ...identifyOptions, sheddable: true }
         : identifyOptions;
@@ -100,7 +100,7 @@ export class NodeClient extends LDClientImpl {
 
   async setConnectionMode(mode: ConnectionMode): Promise<void> {
     const dataManager = this.dataManager as NodeDataManager;
-    return dataManager.setConnectionMode(
+    await dataManager.setConnectionMode(
       mode,
       () => this.flush(),
       (enabled) => this.setEventSendingEnabled(enabled, false),
@@ -152,7 +152,7 @@ export function makeClient(
     off: (key: string, callback: (...args: unknown[]) => void) =>
       impl.off(key as LDEmitterEventName, callback as (...args: unknown[]) => void),
     flush: () => impl.flush(),
-    identify: (ctx: LDContext, identifyOptions?: LDIdentifyOptions) =>
+    identify: (ctx: LDContext, identifyOptions?: NodeIdentifyOptions) =>
       impl.identifyResult(ctx, identifyOptions),
     getContext: () => impl.getContext(),
     close: () => impl.close(),

--- a/packages/sdk/node-client/src/NodeDataManager.ts
+++ b/packages/sdk/node-client/src/NodeDataManager.ts
@@ -15,12 +15,14 @@ import {
   readFlagsFromBootstrap,
 } from '@launchdarkly/js-client-sdk-common';
 
+import type { NodeIdentifyOptions } from './NodeIdentifyOptions';
 import type { ValidatedOptions } from './options';
 
 const logTag = '[NodeDataManager]';
 
 export default class NodeDataManager extends BaseDataManager {
   protected connectionMode: ConnectionMode = 'streaming';
+  private _currentHash?: string;
   private _pendingIdentifyReject?: (err: Error) => void;
   // Serializes connection-mode transitions so concurrent calls cannot leave state
   // (event-sending, processor, mode) out of sync.
@@ -50,6 +52,7 @@ export default class NodeDataManager extends BaseDataManager {
       diagnosticsManager,
     );
     this.connectionMode = _nodeConfig.initialConnectionMode;
+    this._currentHash = _nodeConfig.hash;
   }
 
   private _debugLog(message: any, ...args: any[]) {
@@ -78,6 +81,14 @@ export default class NodeDataManager extends BaseDataManager {
       return;
     }
     this.context = context;
+
+    const nodeOptions = identifyOptions as NodeIdentifyOptions | undefined;
+    this._currentHash = nodeOptions?.hash ?? this._nodeConfig.hash;
+    if (this._currentHash) {
+      this.setConnectionParams({ queryParameters: [{ key: 'h', value: this._currentHash }] });
+    } else {
+      this.setConnectionParams();
+    }
 
     // Snapshot the mode before any await so the bootstrap path and the stale-snapshot
     // detection below both see a consistent starting point.
@@ -201,7 +212,7 @@ export default class NodeDataManager extends BaseDataManager {
       [],
       this.config.withReasons,
       this.config.useReport,
-      this._nodeConfig.hash,
+      this._currentHash,
     );
 
     this.updateProcessor?.close();

--- a/packages/sdk/node-client/src/NodeDataManager.ts
+++ b/packages/sdk/node-client/src/NodeDataManager.ts
@@ -83,6 +83,9 @@ export default class NodeDataManager extends BaseDataManager {
     this.context = context;
 
     const nodeOptions = identifyOptions as NodeIdentifyOptions | undefined;
+
+    // We will treat empty string as `null`/`undefined`. This should be more
+    // ergonomic for users who have multiple settings for this value.
     this._currentHash = nodeOptions?.hash || this._nodeConfig.hash;
     if (this._currentHash) {
       this.setConnectionParams({ queryParameters: [{ key: 'h', value: this._currentHash }] });

--- a/packages/sdk/node-client/src/NodeDataManager.ts
+++ b/packages/sdk/node-client/src/NodeDataManager.ts
@@ -83,7 +83,7 @@ export default class NodeDataManager extends BaseDataManager {
     this.context = context;
 
     const nodeOptions = identifyOptions as NodeIdentifyOptions | undefined;
-    this._currentHash = nodeOptions?.hash ?? this._nodeConfig.hash;
+    this._currentHash = nodeOptions?.hash || this._nodeConfig.hash;
     if (this._currentHash) {
       this.setConnectionParams({ queryParameters: [{ key: 'h', value: this._currentHash }] });
     } else {

--- a/packages/sdk/node-client/src/NodeIdentifyOptions.ts
+++ b/packages/sdk/node-client/src/NodeIdentifyOptions.ts
@@ -1,0 +1,17 @@
+import type { LDIdentifyOptions } from '@launchdarkly/js-client-sdk-common';
+
+/**
+ * Options for {@link LDClient.identify} on the Node.js client-side SDK.
+ */
+export interface NodeIdentifyOptions extends LDIdentifyOptions {
+  /**
+   * The signed context key for
+   * [Secure Mode](https://docs.launchdarkly.com/sdk/features/secure-mode).
+   *
+   * When provided, overrides the `hash` value from the SDK configuration for
+   * this identify call and all subsequent network requests until the next
+   * `identify`. When omitted, the SDK uses the `hash` from `LDOptions` (if
+   * configured).
+   */
+  hash?: string;
+}

--- a/packages/sdk/node-client/src/NodeOptions.ts
+++ b/packages/sdk/node-client/src/NodeOptions.ts
@@ -65,6 +65,8 @@ export interface NodeOptions extends LDOptionsBase {
   /**
    * The Secure Mode hash for the configured context.
    *
+   * This value can be overridden on a per-identify basis via {@link NodeIdentifyOptions.hash}.
+   *
    * @see https://docs.launchdarkly.com/sdk/features/secure-mode
    */
   hash?: string;

--- a/packages/sdk/node-client/src/index.ts
+++ b/packages/sdk/node-client/src/index.ts
@@ -14,6 +14,7 @@ import basicLogger from './basicLogger';
 import type { LDClient, LDStartOptions } from './LDClient';
 import type { LDPlugin } from './LDPlugin';
 import { makeClient } from './NodeClient';
+import type { NodeIdentifyOptions } from './NodeIdentifyOptions';
 import type { LDTLSOptions, NodeOptions } from './NodeOptions';
 
 export * from './LDCommon';
@@ -23,6 +24,7 @@ export { resetNodeStorage } from './platform/NodeStorage';
 
 export type {
   NodeOptions as LDOptions,
+  NodeIdentifyOptions as LDIdentifyOptions,
   LDClient,
   LDPlugin,
   LDStartOptions,

--- a/packages/sdk/node-client/src/options.ts
+++ b/packages/sdk/node-client/src/options.ts
@@ -26,6 +26,8 @@ export interface ValidatedOptions {
   plugins: LDPlugin[];
   localStoragePath?: string;
   hash?: string;
+  wrapperName?: string;
+  wrapperVersion?: string;
 }
 
 const optDefaults: ValidatedOptions = {
@@ -35,18 +37,19 @@ const optDefaults: ValidatedOptions = {
   plugins: [],
   localStoragePath: undefined,
   hash: undefined,
+  wrapperName: undefined,
+  wrapperVersion: undefined,
 };
 
-// Keyed off ValidatedOptions so adding a Node-specific option fails to compile until a
-// validator is registered here (and a default in optDefaults), forcing validation/logging
-// coverage for the new field.
-const validators: Record<keyof ValidatedOptions, TypeValidator> = {
+const validators: { [Property in keyof NodeOptions]: TypeValidator | undefined } = {
   tlsParams: TypeValidators.Object,
   enableEventCompression: TypeValidators.Boolean,
   initialConnectionMode: new ConnectionModeValidator(),
   plugins: TypeValidators.createTypeArray('LDPlugin[]', {}),
   localStoragePath: TypeValidators.String,
   hash: TypeValidators.String,
+  wrapperName: TypeValidators.String,
+  wrapperVersion: TypeValidators.String,
 };
 
 export function filterToBaseOptions(opts: NodeOptions): LDOptionsBase {
@@ -63,7 +66,10 @@ export default function validateOptions(opts: NodeOptions, logger: LDLogger): Va
   const output: ValidatedOptions = { ...optDefaults };
 
   Object.entries(validators).forEach((entry) => {
-    const [key, validator] = entry as [keyof ValidatedOptions, TypeValidator];
+    const [key, validator] = entry as [keyof NodeOptions, TypeValidator | undefined];
+    if (!validator) {
+      return;
+    }
     const value = opts[key];
     if (value !== undefined) {
       if (validator.is(value)) {

--- a/packages/sdk/node-client/src/platform/NodeInfo.ts
+++ b/packages/sdk/node-client/src/platform/NodeInfo.ts
@@ -36,12 +36,17 @@ export default class NodeInfo implements Info {
   }
 
   sdkData(): SdkData {
-    return {
+    const data: SdkData = {
       name: sdkName,
       version: sdkVersion,
       userAgentBase: 'NodeClient',
-      wrapperName: this._config.wrapperName,
-      wrapperVersion: this._config.wrapperVersion,
     };
+    if (this._config.wrapperName) {
+      data.wrapperName = this._config.wrapperName;
+    }
+    if (this._config.wrapperVersion) {
+      data.wrapperVersion = this._config.wrapperVersion;
+    }
+    return data;
   }
 }

--- a/packages/sdk/node-client/src/platform/NodeInfo.ts
+++ b/packages/sdk/node-client/src/platform/NodeInfo.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import { Info, PlatformData, SdkData } from '@launchdarkly/js-client-sdk-common';
 
 const sdkName = 'node-client-sdk';
-const sdkVersion = '0.0.4'; // x-release-please-version
+const sdkVersion = '0.0.1'; // x-release-please-version
 
 function processPlatformName(name: string): string {
   switch (name) {
@@ -19,6 +19,8 @@ function processPlatformName(name: string): string {
 }
 
 export default class NodeInfo implements Info {
+  constructor(private readonly _config: { wrapperName?: string; wrapperVersion?: string } = {}) {}
+
   platformData(): PlatformData {
     return {
       os: {
@@ -38,6 +40,8 @@ export default class NodeInfo implements Info {
       name: sdkName,
       version: sdkVersion,
       userAgentBase: 'NodeClient',
+      wrapperName: this._config.wrapperName,
+      wrapperVersion: this._config.wrapperVersion,
     };
   }
 }

--- a/packages/sdk/node-client/src/platform/NodeInfo.ts
+++ b/packages/sdk/node-client/src/platform/NodeInfo.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import { Info, PlatformData, SdkData } from '@launchdarkly/js-client-sdk-common';
 
 const sdkName = 'node-client-sdk';
-const sdkVersion = '0.0.1'; // x-release-please-version
+const sdkVersion = '0.0.4'; // x-release-please-version
 
 function processPlatformName(name: string): string {
   switch (name) {

--- a/packages/sdk/node-client/src/platform/NodePlatform.ts
+++ b/packages/sdk/node-client/src/platform/NodePlatform.ts
@@ -8,7 +8,7 @@ import NodeRequests from './NodeRequests';
 import { getNodeStorage } from './NodeStorage';
 
 export default class NodePlatform implements platform.Platform {
-  info: platform.Info = new NodeInfo();
+  info: platform.Info;
 
   crypto: platform.Crypto = new NodeCrypto();
 
@@ -20,8 +20,9 @@ export default class NodePlatform implements platform.Platform {
 
   constructor(
     logger: LDLogger,
-    options: Pick<ValidatedOptions, 'localStoragePath' | 'tlsParams' | 'enableEventCompression'>,
+    options: Pick<ValidatedOptions, 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
   ) {
+    this.info = new NodeInfo({ wrapperName: options.wrapperName, wrapperVersion: options.wrapperVersion });
     this.storage = getNodeStorage(options.localStoragePath, logger);
     this.requests = new NodeRequests(options.tlsParams, options.enableEventCompression);
   }


### PR DESCRIPTION
This PR will add some missed option values:
- NodeIdentifyOptions extends LDIdentifyOptions with an optional hash field; per-identify hash overrides the config-level hash for that call and all subsequent requests until the next identify
- NodeInfo accepts wrapperName/wrapperVersion and forwards them to sdkData(); NodePlatform reads these from ValidatedOptions
- Also adding unit tests for datamanager


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Secure Mode `hash` changes which contexts are accepted on stream/poll URLs; behavior is covered by tests but mistakes could block flag delivery for signed contexts.
> 
> **Overview**
> Adds **Secure Mode** support on `identify` and wires **wrapper SDK metadata** through the Node client-side SDK.
> 
> **Per-identify `hash`:** New `NodeIdentifyOptions` (exported as `LDIdentifyOptions`) adds an optional Secure Mode hash. `NodeDataManager` keeps a `_currentHash` from config or the latest identify (per-identify wins; empty string is ignored), sets the `h` query parameter on stream/poll connections, and uses it in `makeRequestor`. A later `identify` without `hash` falls back to the config `hash` or omits `h`. Public `identify` typings now use `NodeIdentifyOptions`.
> 
> **Wrapper metadata:** `wrapperName` and `wrapperVersion` are validated in node options, passed from `NodePlatform` into `NodeInfo`, and included in `sdkData()` when set. Option validation now iterates `NodeOptions` keys so base options with validators are handled consistently.
> 
> **Tests:** New `NodeDataManager` tests cover hash behavior across streaming, polling, mode switches, bootstrap, and fallback; platform/options tests cover wrapper fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bdaf08158090125b249b57a669ddafe92f6db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->