### PR TITLE
chore: Bump vite to ^8.0.16

### DIFF
--- a/packages/sdk/browser/contract-tests/entity/package.json
+++ b/packages/sdk/browser/contract-tests/entity/package.json
@@ -26,6 +26,6 @@
     "playwright": "^1.49.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0",
-    "vite": "^5.4.1"
+    "vite": "^8.0.16"
   }
 }

--- a/packages/sdk/electron/contract-tests/entity/package.json
+++ b/packages/sdk/electron/contract-tests/entity/package.json
@@ -27,7 +27,7 @@
     "electron": "^40.2.1",
     "playwright": "^1.49.1",
     "typescript": "~4.5.4",
-    "vite": "^5.4.21"
+    "vite": "^8.0.16"
   },
   "peerDependencies": {
     "electron": "^40.2.1"

--- a/packages/sdk/electron/example/package.json
+++ b/packages/sdk/electron/example/package.json
@@ -37,7 +37,7 @@
     "playwright": "^1.49.1",
     "typescript": "~4.5.4",
     "typescript-eslint": "^8.0.0",
-    "vite": "^5.4.21"
+    "vite": "^8.0.16"
   },
   "peerDependencies": {
     "electron": "^40.4.1"

--- a/packages/sdk/react/examples/features/bootstrap/package.json
+++ b/packages/sdk/react/examples/features/bootstrap/package.json
@@ -23,9 +23,9 @@
     "@types/node": "^20.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@vitejs/plugin-react": "^4",
+    "@vitejs/plugin-react": "^6",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^6"
+    "vite": "^8.0.16"
   }
 }

--- a/packages/sdk/react/examples/features/bootstrap/vite.config.ts
+++ b/packages/sdk/react/examples/features/bootstrap/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   // Only expose client-safe LaunchDarkly env vars. Do NOT add `LAUNCHDARKLY_` as a broad prefix --
   // that would bake `LAUNCHDARKLY_SDK_KEY` (a server-side secret) into the client bundle.
   envPrefix: ['VITE_', 'LAUNCHDARKLY_CLIENT_SIDE_ID', 'LAUNCHDARKLY_FLAG_KEY'],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   build: {
     rollupOptions: {
       output: {

--- a/packages/sdk/react/examples/features/data-saving-mode/package.json
+++ b/packages/sdk/react/examples/features/data-saving-mode/package.json
@@ -17,8 +17,8 @@
     "@types/node": "^16.18.18",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitejs/plugin-react": "^4",
+    "@vitejs/plugin-react": "^6",
     "typescript": "^5.0.0",
-    "vite": "^6"
+    "vite": "^8.0.16"
   }
 }

--- a/packages/sdk/react/examples/features/data-saving-mode/vite.config.ts
+++ b/packages/sdk/react/examples/features/data-saving-mode/vite.config.ts
@@ -6,4 +6,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react()],
   envPrefix: ['VITE_', 'LAUNCHDARKLY_'],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 });

--- a/packages/sdk/react/examples/hello-react/package.json
+++ b/packages/sdk/react/examples/hello-react/package.json
@@ -19,8 +19,8 @@
     "@types/node": "^16.18.18",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "@vitejs/plugin-react": "^4",
+    "@vitejs/plugin-react": "^6",
     "typescript": "^5.0.0",
-    "vite": "^6"
+    "vite": "^8.0.16"
   }
 }

--- a/packages/sdk/react/examples/hello-react/vite.config.ts
+++ b/packages/sdk/react/examples/hello-react/vite.config.ts
@@ -6,4 +6,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react()],
   envPrefix: ['VITE_', 'LAUNCHDARKLY_'],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
 });

--- a/packages/sdk/svelte/example/package.json
+++ b/packages/sdk/svelte/example/package.json
@@ -31,14 +31,14 @@
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/package": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/eslint": "8.56.0",
     "eslint-plugin-svelte": "^2.35.1",
     "jsdom": "^24.0.0",
     "svelte-check": "^3.6.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
-    "vite": "^6.0.2",
+    "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/sdk/svelte/package.json
+++ b/packages/sdk/svelte/package.json
@@ -55,7 +55,7 @@
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/package": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/svelte": "^5.2.0",
     "@types/jest": "^29.5.11",
     "@vitest/coverage-v8": "^4.1.8",
@@ -76,7 +76,7 @@
     "typedoc": "0.25.0",
     "typescript": "5.1.6",
     "typescript-eslint": "^8.0.0",
-    "vite": "^6.0.2",
+    "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }
 }


### PR DESCRIPTION
This PR will bump `vite` to v8 as well as fix various dev dependencies that has vite as transient deps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devDependencies, examples, and contract-test build configs; published SDK runtime code is unaffected, though Vite 8 may surface build or dev-server regressions in those workspaces.
> 
> **Overview**
> Upgrades **Vite** to `^8.0.16` in browser/electron contract-test harnesses, electron and React/Svelte examples, and the Svelte SDK package dev tooling (from Vite 5/6).
> 
> Companion devDependency bumps align with Vite 8: **`@vitejs/plugin-react`** `^4` → `^6` on React examples and **`@sveltejs/vite-plugin-svelte`** `^5` → `^7.1.2` on Svelte packages.
> 
> React example Vite configs add **`resolve.dedupe: ['react', 'react-dom']`** so the upgraded bundler resolves a single React copy in the monorepo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 886eea9c6bd07eeeccd01e7b538d5852fd6c7241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->