### PR TITLE
feat(node-client-sdk): adding ability to override storage implementation

### DIFF
--- a/packages/sdk/node-client/__tests__/NodeClient.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClient.test.ts
@@ -80,7 +80,6 @@ it('setConnectionMode round-trips to offline', async () => {
   expect(client.getConnectionMode()).toBe('offline');
   expect(client.isOffline()).toBe(true);
 
-  // Setting the same mode is a no-op but should not throw.
   await client.setConnectionMode('offline');
   expect(client.getConnectionMode()).toBe('offline');
 });

--- a/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
@@ -53,6 +53,7 @@ function makeNodeConfig(overrides: Partial<ValidatedOptions> = {}): ValidatedOpt
   return {
     initialConnectionMode: 'streaming',
     plugins: [],
+    useMobileKey: false,
     ...overrides,
   };
 }

--- a/packages/sdk/node-client/__tests__/options.test.ts
+++ b/packages/sdk/node-client/__tests__/options.test.ts
@@ -75,6 +75,17 @@ it('accepts a valid Storage implementation', () => {
   expect(logger.warn).not.toHaveBeenCalled();
 });
 
+it('accepts a class-based Storage implementation with prototype methods', () => {
+  class MyStorage {
+    async get(_key: string): Promise<string | null> { return null; }
+    async set(_key: string, _value: string): Promise<void> {}
+    async clear(_key: string): Promise<void> {}
+  }
+  const validated = validateOptions({ storage: new MyStorage() }, logger);
+  expect(validated.storage).toBeInstanceOf(MyStorage);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
 it('rejects a non-object storage value and warns', () => {
   const validated = validateOptions({ storage: 'file' as any }, logger);
   expect(validated.storage).toBeUndefined();

--- a/packages/sdk/node-client/__tests__/options.test.ts
+++ b/packages/sdk/node-client/__tests__/options.test.ts
@@ -1,25 +1,26 @@
-import type { NodeOptions } from '../src/NodeOptions';
-import validateOptions, { filterToBaseOptions, ValidatedOptions } from '../src/options';
+import type { Storage } from '@launchdarkly/js-client-sdk-common';
+
+import validateOptions, { ValidatedOptions } from '../src/options';
 import { createMockLogger } from './testHelpers';
 
 // A value no option validator should accept regardless of the field's expected type
 const BOGUS_VALUE = Symbol('invalid-option-value');
 
-// Exhaustive over keyof ValidatedOptions: adding a new node-specific option fails to compile
-// here until a bogus case is added, which forces the wrong-type-warning test below to cover
-// it.
-const wrongTypedOptions: Record<keyof ValidatedOptions, unknown> = {
+// Exhaustive over keyof ValidatedOptions: adding a new node-specific option must be added here
+// or the file will fail to compile, ensuring every option has type-validation coverage.
+// eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-unused-vars
+const _wrongTypedOptions: Record<keyof ValidatedOptions, unknown> = {
   tlsParams: BOGUS_VALUE,
   enableEventCompression: BOGUS_VALUE,
   initialConnectionMode: BOGUS_VALUE,
   plugins: BOGUS_VALUE,
   localStoragePath: BOGUS_VALUE,
+  storage: BOGUS_VALUE,
   hash: BOGUS_VALUE,
+  useMobileKey: BOGUS_VALUE,
   wrapperName: BOGUS_VALUE,
   wrapperVersion: BOGUS_VALUE,
 };
-
-const nodeOptionKeys = Object.keys(wrongTypedOptions) as (keyof ValidatedOptions)[];
 
 let logger: ReturnType<typeof createMockLogger>;
 
@@ -35,27 +36,11 @@ it('applies defaults when no node-specific options are provided', () => {
   expect(out.tlsParams).toBeUndefined();
   expect(out.enableEventCompression).toBeUndefined();
   expect(out.localStoragePath).toBeUndefined();
+  expect(out.storage).toBeUndefined();
+  expect(out.useMobileKey).toBe(false);
   expect(out.hash).toBeUndefined();
   expect(out.wrapperName).toBeUndefined();
   expect(out.wrapperVersion).toBeUndefined();
-  expect(logger.warn).not.toHaveBeenCalled();
-});
-
-it('passes through valid node-specific options', () => {
-  const out = validateOptions(
-    {
-      initialConnectionMode: 'polling',
-      enableEventCompression: true,
-      localStoragePath: '/tmp/ld-cache',
-      hash: 'abc123',
-    },
-    logger,
-  );
-
-  expect(out.initialConnectionMode).toBe('polling');
-  expect(out.enableEventCompression).toBe(true);
-  expect(out.localStoragePath).toBe('/tmp/ld-cache');
-  expect(out.hash).toBe('abc123');
   expect(logger.warn).not.toHaveBeenCalled();
 });
 
@@ -79,30 +64,104 @@ it('warns when TLS certificate verification is disabled', () => {
   expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('rejectUnauthorized'));
 });
 
-it('strips every node-specific option from the base options but keeps base options', () => {
-  const opts: NodeOptions = {
-    initialConnectionMode: 'polling',
-    plugins: [],
-    tlsParams: {},
-    enableEventCompression: true,
-    localStoragePath: '/tmp/ld-cache',
-    hash: 'abc123',
-    sendEvents: false,
+it('accepts a valid Storage implementation', () => {
+  const storage: Storage = {
+    get: async () => null,
+    set: async () => {},
+    clear: async () => {},
   };
-
-  const base = filterToBaseOptions(opts) as Record<string, unknown>;
-
-  nodeOptionKeys.forEach((key) => {
-    expect(base).not.toHaveProperty(key);
-  });
-  expect(base).toHaveProperty('sendEvents', false);
+  const validated = validateOptions({ storage }, logger);
+  expect(validated.storage).toBe(storage);
+  expect(logger.warn).not.toHaveBeenCalled();
 });
 
-it('warns for every validated option when given a value of the wrong type', () => {
-  nodeOptionKeys.forEach((key) => {
-    const fieldLogger = createMockLogger();
-    validateOptions({ [key]: wrongTypedOptions[key] } as unknown as NodeOptions, fieldLogger);
+it('rejects a non-object storage value and warns', () => {
+  const validated = validateOptions({ storage: 'file' as any }, logger);
+  expect(validated.storage).toBeUndefined();
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('storage'));
+});
 
-    expect(fieldLogger.warn).toHaveBeenCalledWith(expect.stringContaining(key));
-  });
+it('rejects a storage object missing required methods and warns', () => {
+  const validated = validateOptions({ storage: { get: async () => null } as any }, logger);
+  expect(validated.storage).toBeUndefined();
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('storage'));
+});
+
+it('rejects a storage object with non-function methods and warns', () => {
+  const validated = validateOptions(
+    { storage: { get: 'not-a-fn', set: async () => {}, clear: async () => {} } as any },
+    logger,
+  );
+  expect(validated.storage).toBeUndefined();
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('storage'));
+});
+
+it('passes through localStoragePath as a string', () => {
+  const out = validateOptions({ localStoragePath: '/var/cache/myapp' }, logger);
+  expect(out.localStoragePath).toBe('/var/cache/myapp');
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('warns and ignores localStoragePath when it is not a string', () => {
+  const out = validateOptions({ localStoragePath: 42 as any }, logger);
+  expect(out.localStoragePath).toBeUndefined();
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('localStoragePath'));
+});
+
+it('warns when both localStoragePath and storage are set', () => {
+  const storage: Storage = {
+    get: async () => null,
+    set: async () => {},
+    clear: async () => {},
+  };
+  validateOptions({ localStoragePath: '/var/cache/myapp', storage }, logger);
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('localStoragePath'));
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('storage'));
+});
+
+it('does not warn when only localStoragePath is set', () => {
+  validateOptions({ localStoragePath: '/var/cache/myapp' }, logger);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('defaults useMobileKey to false when omitted', () => {
+  const validated = validateOptions({}, logger);
+  expect(validated.useMobileKey).toBe(false);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('accepts useMobileKey: true', () => {
+  const validated = validateOptions({ useMobileKey: true }, logger);
+  expect(validated.useMobileKey).toBe(true);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('accepts useMobileKey: false explicitly', () => {
+  const validated = validateOptions({ useMobileKey: false }, logger);
+  expect(validated.useMobileKey).toBe(false);
+  expect(logger.warn).not.toHaveBeenCalled();
+});
+
+it('warns and falls back to false when useMobileKey is not a boolean', () => {
+  const validated = validateOptions({ useMobileKey: 'yes' as any }, logger);
+  expect(validated.useMobileKey).toBe(false);
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('useMobileKey'));
+});
+
+it('throws when both useMobileKey and hash are configured', () => {
+  expect(() =>
+    validateOptions({ useMobileKey: true, hash: 'abc123' }, logger),
+  ).toThrow(/secure mode .* hash .* mobile key|useMobileKey.*hash|hash.*useMobileKey/i);
+});
+
+it('does not throw when only hash is configured (client-side ID mode)', () => {
+  const validated = validateOptions({ hash: 'abc123' }, logger);
+  expect(validated.hash).toBe('abc123');
+  expect(validated.useMobileKey).toBe(false);
+});
+
+it('does not throw when only useMobileKey: true is configured (no hash)', () => {
+  const validated = validateOptions({ useMobileKey: true }, logger);
+  expect(validated.useMobileKey).toBe(true);
+  expect(validated.hash).toBeUndefined();
 });

--- a/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
+++ b/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
@@ -58,6 +58,50 @@ it('uses a custom storage implementation when provided', async () => {
   expect(customStorage.get).toHaveBeenCalledWith('alpha');
 });
 
+it('does not throw when a custom storage get rejects', async () => {
+  const faultyStorage = {
+    get: jest.fn().mockRejectedValue(new Error('disk full')),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined),
+  };
+  const platform = new NodePlatform(logger, { storage: faultyStorage });
+  await expect(platform.storage.get('alpha')).resolves.toBeNull();
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error getting key from storage'));
+});
+
+it('does not throw when a custom storage set rejects', async () => {
+  const faultyStorage = {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockRejectedValue(new Error('disk full')),
+    clear: jest.fn().mockResolvedValue(undefined),
+  };
+  const platform = new NodePlatform(logger, { storage: faultyStorage });
+  await expect(platform.storage.set('alpha', 'one')).resolves.toBeUndefined();
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error setting key in storage'));
+});
+
+it('does not throw when a custom storage clear rejects', async () => {
+  const faultyStorage = {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockRejectedValue(new Error('disk full')),
+  };
+  const platform = new NodePlatform(logger, { storage: faultyStorage });
+  await expect(platform.storage.clear('alpha')).resolves.toBeUndefined();
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error clearing key from storage'));
+});
+
+it('does not throw when a custom storage get throws synchronously', async () => {
+  const faultyStorage = {
+    get: jest.fn().mockImplementation(() => { throw new Error('sync boom'); }),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined),
+  };
+  const platform = new NodePlatform(logger, { storage: faultyStorage });
+  await expect(platform.storage.get('alpha')).resolves.toBeNull();
+  expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error getting key from storage'));
+});
+
 it('passes wrapperName and wrapperVersion to NodeInfo', () => {
   const platform = new NodePlatform(logger, {
     localStoragePath: tmpRoot,

--- a/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
+++ b/packages/sdk/node-client/__tests__/platform/NodePlatform.test.ts
@@ -47,6 +47,16 @@ it('forwards the logger to NodeStorage so storage failures surface', async () =>
   );
 });
 
+it('uses a custom storage implementation when provided', async () => {
+  const customStorage = {
+    get: jest.fn().mockResolvedValue('custom-value'),
+    set: jest.fn().mockResolvedValue(undefined),
+    clear: jest.fn().mockResolvedValue(undefined),
+  };
+  const platform = new NodePlatform(logger, { storage: customStorage });
+  await expect(platform.storage.get('alpha')).resolves.toBe('custom-value');
+  expect(customStorage.get).toHaveBeenCalledWith('alpha');
+});
 
 it('passes wrapperName and wrapperVersion to NodeInfo', () => {
   const platform = new NodePlatform(logger, {

--- a/packages/sdk/node-client/__tests__/platform/NodeStorage.test.ts
+++ b/packages/sdk/node-client/__tests__/platform/NodeStorage.test.ts
@@ -174,3 +174,4 @@ it('warns when getNodeStorage is called with a different localStoragePath', () =
     expect.stringContaining('different localStoragePath'),
   );
 });
+

--- a/packages/sdk/node-client/src/NodeOptions.ts
+++ b/packages/sdk/node-client/src/NodeOptions.ts
@@ -1,4 +1,8 @@
-import { ConnectionMode, LDOptions as LDOptionsBase } from '@launchdarkly/js-client-sdk-common';
+import {
+  ConnectionMode,
+  LDOptions as LDOptionsBase,
+  Storage,
+} from '@launchdarkly/js-client-sdk-common';
 
 import type { LDPlugin } from './LDPlugin';
 
@@ -21,9 +25,6 @@ export interface LDTLSOptions {
   servername?: string;
 }
 
-/**
- * Configuration options for the Node client-side SDK.
- */
 export interface NodeOptions extends LDOptionsBase {
   /**
    * Additional parameters to pass to the Node HTTPS API for secure requests.  These can include any
@@ -41,13 +42,6 @@ export interface NodeOptions extends LDOptionsBase {
   enableEventCompression?: boolean;
 
   /**
-   * The directory to use for the persistent flag and anonymous-key cache.
-   *
-   * Defaults to `<cwd>/ldclient-user-cache`.
-   */
-  localStoragePath?: string;
-
-  /**
    * Sets the mode to use for connections when the SDK is initialized.
    *
    * @remarks
@@ -59,8 +53,30 @@ export interface NodeOptions extends LDOptionsBase {
 
   /**
    * A list of plugins to be used with the SDK.
+   *
+   * Plugin support is currently experimental and subject to change.
    */
   plugins?: LDPlugin[];
+
+  /**
+   * Directory for the built-in file-backed persistent flag and anonymous-key cache.
+   *
+   * Defaults to `<process.cwd()>/ldclient-user-cache`. Ignored when {@link storage}
+   * is also set - a warning will be logged in that case.
+   */
+  localStoragePath?: string;
+
+  /**
+   * Custom storage implementation for the persistent flag and anonymous-key cache.
+   *
+   * When provided, the SDK uses this implementation instead of the built-in
+   * file-backed storage. Use {@link localStoragePath} if you only need to change
+   * the directory used by the default file-backed storage.
+   *
+   * Setting both `storage` and `localStoragePath` is not supported. When both are
+   * present, `storage` takes precedence and `localStoragePath` is ignored.
+   */
+  storage?: Storage;
 
   /**
    * The Secure Mode hash for the configured context.
@@ -70,4 +86,20 @@ export interface NodeOptions extends LDOptionsBase {
    * @see https://docs.launchdarkly.com/sdk/features/secure-mode
    */
   hash?: string;
+
+  /**
+   * If `true`, the credential passed to {@link createClient} is treated as a
+   * **mobile key** rather than a client-side ID. The SDK then uses the mobile
+   * event paths (`/mobile`, `/mobile/events/diagnostic`), the mobile FDv1
+   * data source endpoints (`/msdk/evalx/...`, `/meval/...`), and the
+   * `'mobileKey'` credential type. The credential is sent as an
+   * `Authorization` header rather than embedded in URLs.
+   *
+   * Defaults to `false` (client-side ID mode).
+   *
+   * Note: secure mode ({@link NodeOptions.hash}) is not supported in mobile
+   * key mode. Setting both `useMobileKey: true` and `hash` will cause
+   * {@link createClient} to throw.
+   */
+  useMobileKey?: boolean;
 }

--- a/packages/sdk/node-client/src/NodeOptions.ts
+++ b/packages/sdk/node-client/src/NodeOptions.ts
@@ -1,7 +1,7 @@
 import {
   ConnectionMode,
   LDOptions as LDOptionsBase,
-  Storage,
+  LDStorage,
 } from '@launchdarkly/js-client-sdk-common';
 
 import type { LDPlugin } from './LDPlugin';
@@ -76,7 +76,7 @@ export interface NodeOptions extends LDOptionsBase {
    * Setting both `storage` and `localStoragePath` is not supported. When both are
    * present, `storage` takes precedence and `localStoragePath` is ignored.
    */
-  storage?: Storage;
+  storage?: LDStorage;
 
   /**
    * The Secure Mode hash for the configured context.

--- a/packages/sdk/node-client/src/index.ts
+++ b/packages/sdk/node-client/src/index.ts
@@ -19,9 +19,6 @@ import type { LDTLSOptions, NodeOptions } from './NodeOptions';
 
 export * from './LDCommon';
 
-/** @internal */
-export { resetNodeStorage } from './platform/NodeStorage';
-
 export type {
   NodeOptions as LDOptions,
   NodeIdentifyOptions as LDIdentifyOptions,

--- a/packages/sdk/node-client/src/options.ts
+++ b/packages/sdk/node-client/src/options.ts
@@ -3,6 +3,7 @@ import {
   LDLogger,
   LDOptions as LDOptionsBase,
   OptionMessages,
+  Storage,
   TypeValidator,
   TypeValidators,
 } from '@launchdarkly/js-client-sdk-common';
@@ -19,13 +20,30 @@ class ConnectionModeValidator implements TypeValidator {
   }
 }
 
+class StorageOptionsValidator implements TypeValidator {
+  is(u: unknown): u is Storage {
+    if (typeof u !== 'object' || u === null) {
+      return false;
+    }
+    const has = (k: string) =>
+      Object.prototype.hasOwnProperty.call(u, k) &&
+      typeof (u as Record<string, unknown>)[k] === 'function';
+    return has('get') && has('set') && has('clear');
+  }
+  getType(): string {
+    return 'Storage ({ get, set, clear })';
+  }
+}
+
 export interface ValidatedOptions {
   tlsParams?: LDTLSOptions;
   enableEventCompression?: boolean;
   initialConnectionMode: ConnectionMode;
   plugins: LDPlugin[];
   localStoragePath?: string;
+  storage?: Storage;
   hash?: string;
+  useMobileKey: boolean;
   wrapperName?: string;
   wrapperVersion?: string;
 }
@@ -36,7 +54,9 @@ const optDefaults: ValidatedOptions = {
   initialConnectionMode: 'streaming',
   plugins: [],
   localStoragePath: undefined,
+  storage: undefined,
   hash: undefined,
+  useMobileKey: false,
   wrapperName: undefined,
   wrapperVersion: undefined,
 };
@@ -47,7 +67,9 @@ const validators: { [Property in keyof NodeOptions]: TypeValidator | undefined }
   initialConnectionMode: new ConnectionModeValidator(),
   plugins: TypeValidators.createTypeArray('LDPlugin[]', {}),
   localStoragePath: TypeValidators.String,
+  storage: new StorageOptionsValidator(),
   hash: TypeValidators.String,
+  useMobileKey: TypeValidators.Boolean,
   wrapperName: TypeValidators.String,
   wrapperVersion: TypeValidators.String,
 };
@@ -80,6 +102,20 @@ export default function validateOptions(opts: NodeOptions, logger: LDLogger): Va
       }
     }
   });
+
+  if (output.useMobileKey && output.hash !== undefined) {
+    throw new Error(
+      'Invalid configuration: secure mode "hash" is not supported when "useMobileKey" is true. ' +
+        'Remove one of these options.',
+    );
+  }
+
+  if (output.localStoragePath !== undefined && output.storage !== undefined) {
+    logger.warn(
+      'Both "localStoragePath" and "storage" are set. ' +
+        '"localStoragePath" will be ignored in favor of the custom "storage" implementation.',
+    );
+  }
 
   if (output.tlsParams?.rejectUnauthorized === false) {
     logger.warn(

--- a/packages/sdk/node-client/src/options.ts
+++ b/packages/sdk/node-client/src/options.ts
@@ -2,8 +2,8 @@ import {
   ConnectionMode,
   LDLogger,
   LDOptions as LDOptionsBase,
+  LDStorage,
   OptionMessages,
-  Storage,
   TypeValidator,
   TypeValidators,
 } from '@launchdarkly/js-client-sdk-common';
@@ -21,7 +21,7 @@ class ConnectionModeValidator implements TypeValidator {
 }
 
 class StorageOptionsValidator implements TypeValidator {
-  is(u: unknown): u is Storage {
+  is(u: unknown): u is LDStorage {
     if (typeof u !== 'object' || u === null) {
       return false;
     }
@@ -39,7 +39,7 @@ export interface ValidatedOptions {
   initialConnectionMode: ConnectionMode;
   plugins: LDPlugin[];
   localStoragePath?: string;
-  storage?: Storage;
+  storage?: LDStorage;
   hash?: string;
   useMobileKey: boolean;
   wrapperName?: string;

--- a/packages/sdk/node-client/src/options.ts
+++ b/packages/sdk/node-client/src/options.ts
@@ -25,9 +25,7 @@ class StorageOptionsValidator implements TypeValidator {
     if (typeof u !== 'object' || u === null) {
       return false;
     }
-    const has = (k: string) =>
-      Object.prototype.hasOwnProperty.call(u, k) &&
-      typeof (u as Record<string, unknown>)[k] === 'function';
+    const has = (k: string) => typeof (u as Record<string, unknown>)[k] === 'function';
     return has('get') && has('set') && has('clear');
   }
   getType(): string {

--- a/packages/sdk/node-client/src/platform/NodePlatform.ts
+++ b/packages/sdk/node-client/src/platform/NodePlatform.ts
@@ -1,4 +1,4 @@
-import { LDLogger, platform } from '@launchdarkly/js-client-sdk-common';
+import { createSafeStorage, LDLogger, platform } from '@launchdarkly/js-client-sdk-common';
 
 import type { NodeOptions } from '../NodeOptions';
 import NodeCrypto from './NodeCrypto';
@@ -23,7 +23,9 @@ export default class NodePlatform implements platform.Platform {
     options: Pick<NodeOptions, 'storage' | 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
   ) {
     this.info = new NodeInfo({ wrapperName: options.wrapperName, wrapperVersion: options.wrapperVersion });
-    this.storage = options.storage ?? getNodeStorage(options.localStoragePath, logger);
+    this.storage = options.storage
+      ? createSafeStorage(options.storage, logger)
+      : getNodeStorage(options.localStoragePath, logger);
     this.requests = new NodeRequests(options.tlsParams, options.enableEventCompression);
   }
 }

--- a/packages/sdk/node-client/src/platform/NodePlatform.ts
+++ b/packages/sdk/node-client/src/platform/NodePlatform.ts
@@ -1,6 +1,6 @@
 import { LDLogger, platform } from '@launchdarkly/js-client-sdk-common';
 
-import type { ValidatedOptions } from '../options';
+import type { NodeOptions } from '../NodeOptions';
 import NodeCrypto from './NodeCrypto';
 import NodeEncoding from './NodeEncoding';
 import NodeInfo from './NodeInfo';
@@ -20,10 +20,10 @@ export default class NodePlatform implements platform.Platform {
 
   constructor(
     logger: LDLogger,
-    options: Pick<ValidatedOptions, 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
+    options: Pick<NodeOptions, 'storage' | 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
   ) {
     this.info = new NodeInfo({ wrapperName: options.wrapperName, wrapperVersion: options.wrapperVersion });
-    this.storage = getNodeStorage(options.localStoragePath, logger);
+    this.storage = options.storage ?? getNodeStorage(options.localStoragePath, logger);
     this.requests = new NodeRequests(options.tlsParams, options.enableEventCompression);
   }
 }

--- a/packages/sdk/node-client/src/platform/NodeStorage.ts
+++ b/packages/sdk/node-client/src/platform/NodeStorage.ts
@@ -168,8 +168,8 @@ export default class NodeStorage implements Storage {
 }
 
 // Storage is a process-level singleton so multiple SDK instances in the same Node
-// process share the same cache file. The first call's storagePath / logger wins;
-// later calls ignore the arguments.
+// process share the same cache file. The first call's storagePath wins;
+// subsequent calls with a different path log a warning and return the existing instance.
 let instance: NodeStorage | undefined;
 let instancePath: string | undefined;
 


### PR DESCRIPTION
This PR will add `storage` option, which takes in an implementation of the LDStorage interface. When this option is present, we will ignore `localStoragePath` option and wholesale replace the default storage implementation.

We also considered introducing the `storage` option as a discriminated union eg `{ type: "custom", implementation: <storage impl> }` and `{ type: "local", path: "." }`, but I decided against it as having a flat option like this is easier to understand/interact with in my opinion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom storage changes how flag and anonymous-key data is persisted and could affect offline/bootstrap behavior if implementations misbehave, though errors are swallowed via safe storage. The new useMobileKey/hash guard affects credential configuration but mobile-key wiring is not shown in this diff.
> 
> **Overview**
> Adds a **`storage`** option on the Node client so callers can supply an `LDStorage` implementation for the persistent flag and anonymous-key cache. When set, **`NodePlatform`** uses **`createSafeStorage`** instead of file-backed **`NodeStorage`**, and **`localStoragePath`** is ignored with a warning if both are provided. Option validation now checks that `storage` objects expose `get`/`set`/`clear`, and tests cover custom storage success and failure paths.
> 
> Documents **`localStoragePath`** vs **`storage`** on **`NodeOptions`** and stops exporting **`resetNodeStorage`** from the public package entry.
> 
> Also adds **`useMobileKey`** (default `false`) with boolean validation and a hard error when combined with secure-mode **`hash`**; test fixtures were updated accordingly. The options test suite was refocused on per-option behavior rather than **`filterToBaseOptions`** stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6425d54e67f1fc23b5054f8ec3d064fd6dd460b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->