### PR TITLE
feat!: release `@launchdarkly/openfeature-js-server-common`

### DIFF
--- a/.github/workflows/openfeature-server-common.yaml
+++ b/.github/workflows/openfeature-server-common.yaml
@@ -1,0 +1,33 @@
+name: shared/openfeature-server-common
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-openfeature-server-common:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Node versions to run on.
+        version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./actions/setup-yarn
+        with:
+          node-version: ${{ matrix.version }}
+          registry-url: 'https://registry.npmjs.org'
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/openfeature-js-server-common'
+          workspace_path: packages/shared/openfeature-server-common

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -545,7 +545,7 @@ jobs:
 
   release-openfeature-server-common:
     runs-on: ubuntu-latest
-    needs: ['release-please']
+    needs: ['release-please', 'release-common']
     permissions:
       id-token: write
       contents: write
@@ -561,7 +561,7 @@ jobs:
 
   release-openfeature-node-server:
     runs-on: ubuntu-latest
-    needs: ['release-please', 'release-server-node']
+    needs: ['release-please', 'release-server-node', 'release-openfeature-server-common']
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,7 @@ on:
           - packages/sdk/shopify-oxygen
           - packages/sdk/electron
           - packages/sdk/react
+          - packages/shared/openfeature-server-common
           - packages/sdk/openfeature-node-server
           - packages/sdk/vue
       prerelease:
@@ -108,6 +109,7 @@ jobs:
       package-sdk-shopify-oxygen-released: ${{ steps.release.outputs['packages/sdk/shopify-oxygen--release_created'] }}
       package-sdk-electron-released: ${{ steps.release.outputs['packages/sdk/electron--release_created'] }}
       package-sdk-react-released: ${{ steps.release.outputs['packages/sdk/react--release_created'] }}
+      package-shared-openfeature-server-common-released: ${{ steps.release.outputs['packages/shared/openfeature-server-common--release_created'] }}
       package-sdk-openfeature-node-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-node-server--release_created'] }}
       package-tooling-client-testing-plugin-released: ${{ steps.release.outputs['packages/tooling/client-testing-plugin--release_created'] }}
       package-sdk-vue-released: ${{ steps.release.outputs['packages/sdk/vue--release_created'] }}
@@ -539,6 +541,22 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/sdk/react
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-openfeature-server-common:
+    runs-on: ubuntu-latest
+    needs: ['release-please']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-shared-openfeature-server-common-released == 'true'}}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - id: release-openfeature-server-common
+        name: Full release of packages/shared/openfeature-server-common
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/shared/openfeature-server-common
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   release-openfeature-node-server:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,7 +15,7 @@
   "packages/sdk/vercel": "1.3.48",
   "packages/shared/akamai-edgeworker-sdk": "2.0.23",
   "packages/shared/common": "2.25.1",
-  "packages/shared/openfeature-server-common": "1.0.0",
+  "packages/shared/openfeature-server-common": "0.1.3",
   "packages/shared/sdk-client": "1.29.0",
   "packages/shared/sdk-server": "2.19.1",
   "packages/shared/sdk-server-edge": "2.6.22",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -15,7 +15,7 @@
   "packages/sdk/vercel": "1.3.48",
   "packages/shared/akamai-edgeworker-sdk": "2.0.23",
   "packages/shared/common": "2.25.1",
-  "packages/shared/openfeature-server-common": "0.1.3",
+  "packages/shared/openfeature-server-common": "1.0.0",
   "packages/shared/sdk-client": "1.29.0",
   "packages/shared/sdk-server": "2.19.1",
   "packages/shared/sdk-server-edge": "2.6.22",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,7 @@ flowchart LR
     common --> sdk-server
     common --> sdk-server-edge
     common --> akamai-edgeworker
+    common --> openfeature-server-common
     sdk-server --> sdk-server-edge
     
     %% Dependencies for SDK packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ flowchart LR
     sdk-server[shared/sdk-server]
     sdk-server-edge[shared/sdk-server-edge]
     akamai-edgeworker[shared/akamai-edgeworker-sdk]
+    openfeature-server-common[shared/openfeature-server-common]
 
     %% SDK packages
     server-node[sdk/server-node]
@@ -212,7 +213,7 @@ flowchart LR
     %% Dependencies for tooling packages
     react-native -.-> jest
     
-    class common,sdk-client,sdk-server,sdk-server-edge,akamai-edgeworker shared
+    class common,sdk-client,sdk-server,sdk-server-edge,akamai-edgeworker,openfeature-server-common shared
     class server-node,cloudflare,fastly,react-native,browser,vercel,akamai-base,akamai-edgekv,server-ai,react,shopify-oxygen sdk
     class redis,dynamodb store
     class node-otel telemetry
@@ -227,6 +228,7 @@ There are a number of categories of packages in the monorepo:
    - `shared/sdk-server`: Common code for server-side SDKs
    - `shared/sdk-server-edge`: Common code for edge SDKs
    - `shared/akamai-edgeworker-sdk`: Common code for Akamai edge worker SDKs
+   - `shared/openfeature-server-common`: Common code for server-side OpenFeature providers
 
 2. **SDK packages** (blue): Actual SDK implementations for different platforms
    - Browser, React Native, Server Node, Cloudflare, Fastly, Vercel, Akamai, etc.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/js-client-sdk-common](packages/shared/sdk-client/README.md)           | [![NPM][js-client-sdk-common-npm-badge]][js-client-sdk-common-npm-link]   | [Common Client][package-shared-sdk-client-issues]           | [![Actions Status][shared-sdk-client-ci-badge]][shared-sdk-client-ci]           |
 | [@launchdarkly/js-server-sdk-common](packages/shared/sdk-server/README.md)           | [![NPM][js-server-sdk-common-npm-badge]][js-server-sdk-common-npm-link]   | [Common Server][package-shared-sdk-server-issues]           | [![Actions Status][shared-sdk-server-ci-badge]][shared-sdk-server-ci]           |
 | [@launchdarkly/js-server-sdk-common-edge](packages/shared/sdk-server-edge/README.md) | [![NPM][js-server-sdk-common-edge-badge]][js-server-sdk-common-edge-link] | [Common Server Edge][package-shared-sdk-server-edge-issues] | [![Actions Status][shared-sdk-server-edge-ci-badge]][shared-sdk-server-edge-ci] |
+| [@launchdarkly/openfeature-js-server-common](packages/shared/openfeature-server-common/README.md) | [![NPM][openfeature-js-server-common-npm-badge]][openfeature-js-server-common-npm-link] | [OpenFeature Server Common][package-shared-openfeature-server-common-issues] | [![Actions Status][shared-openfeature-server-common-ci-badge]][shared-openfeature-server-common-ci] |
 
 | Store Packages                                                                              | npm                                                       | issues                                | tests                                                         |
 | ------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------- |
@@ -251,3 +252,9 @@ We encourage pull requests and other contributions from the community. Check out
 [sdk-react-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/react-sdk.svg?style=flat-square
 [sdk-react-npm-link]: https://www.npmjs.com/package/@launchdarkly/react-sdk
 [package-sdk-react-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Freact%22+
+[//]: # 'shared/openfeature-server-common'
+[openfeature-js-server-common-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-js-server-common.svg?style=flat-square
+[openfeature-js-server-common-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-js-server-common
+[shared-openfeature-server-common-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml/badge.svg
+[shared-openfeature-server-common-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml
+[package-shared-openfeature-server-common-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+shared%2Fopenfeature-server-common%22+

--- a/packages/shared/openfeature-server-common/README.md
+++ b/packages/shared/openfeature-server-common/README.md
@@ -1,15 +1,10 @@
 # LaunchDarkly OpenFeature Common Server Provider
 
-<!--
 [![NPM][openfeature-server-common-npm-badge]][openfeature-server-common-npm-link]
 [![Actions Status][openfeature-server-common-ci-badge]][openfeature-server-common-ci]
--->
-
-> [!CAUTION]
-> This SDK is in pre-release and not subject to backwards compatibility
-> guarantees. The API may change based on feedback.
->
-> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
+[![Documentation][openfeature-server-common-ghp-badge]][openfeature-server-common-ghp-link]
+[![NPM][openfeature-server-common-dm-badge]][openfeature-server-common-npm-link]
+[![NPM][openfeature-server-common-dt-badge]][openfeature-server-common-npm-link]
 
 This package contains the shared OpenFeature provider implementation for LaunchDarkly server-side JavaScript SDKs. It provides a base provider class and translation utilities that convert between OpenFeature and LaunchDarkly concepts.
 
@@ -38,9 +33,11 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
 
-<!--
+[openfeature-server-common-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml/badge.svg
+[openfeature-server-common-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml
 [openfeature-server-common-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-js-server-common.svg?style=flat-square
 [openfeature-server-common-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-js-server-common
-[openfeature-server-common-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml/badge.svg
-[openfeature-server-common-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml
--->
+[openfeature-server-common-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[openfeature-server-common-ghp-link]: https://launchdarkly.github.io/js-core/packages/shared/openfeature-server-common/docs/
+[openfeature-server-common-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/openfeature-js-server-common.svg?style=flat-square
+[openfeature-server-common-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/openfeature-js-server-common.svg?style=flat-square

--- a/packages/shared/openfeature-server-common/package.json
+++ b/packages/shared/openfeature-server-common/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "tsup-node",
-    "lint": "npx eslint . --ext .ts",
+    "lint": "npx eslint .",
     "lint:fix": "yarn run lint --fix",
     "test": "jest",
     "check": "yarn lint && yarn build && yarn test"
@@ -47,20 +47,19 @@
     "@openfeature/server-sdk": "^1.16.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
     "@openfeature/core": "^1.10.0",
     "@openfeature/server-sdk": "^1.16.0",
     "@types/jest": "^29.5.3",
-    "@typescript-eslint/eslint-plugin": "^6.20.0",
-    "@typescript-eslint/parser": "^6.20.0",
-    "eslint": "^8.45.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-jest": "^27.6.3",
-    "eslint-plugin-prettier": "^5.0.0",
+    "eslint": "^9.0.0",
+    "eslint-import-resolver-typescript": "^4.0.0",
+    "eslint-plugin-import-x": "^4.0.0",
+    "eslint-plugin-jest": "^28.0.0",
+    "globals": "^16.0.0",
     "jest": "^29.6.1",
-    "prettier": "^3.0.0",
     "ts-jest": "^29.1.1",
     "tsup": "^8.5.1",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "typescript-eslint": "^8.0.0"
   }
 }

--- a/packages/shared/openfeature-server-common/typedoc.json
+++ b/packages/shared/openfeature-server-common/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"],
+  "out": "docs"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -395,8 +395,7 @@
       ]
     },
     "packages/shared/openfeature-server-common": {
-      "bump-minor-pre-major": true,
-      "prerelease": true
+      "release-as": "1.0.0"
     },
     "packages/sdk/openfeature-node-server": {
       "bump-minor-pre-major": true,


### PR DESCRIPTION
This PR will release the openfeature-js-server-common package to npm at version 1. This package is not meant to be used directly, but rather as a shared package that is used by sdks. All this to say, publishing this package is effectively a NOOP.

We just want to make sure this package publishes before we publish `openfeature-node-server`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CI, release automation, and documentation; no application runtime logic changes in the diff.
> 
> **Overview**
> Prepares **`@launchdarkly/openfeature-js-server-common`** for its first stable npm release at **1.0.0** (replacing prerelease settings in `release-please-config.json`).
> 
> Adds a dedicated **CI workflow** (`openfeature-server-common.yaml`) and wires the package into **release-please**: manual publish option, release output flag, and a **`release-openfeature-server-common`** job (after `release-common`). **`release-openfeature-node-server`** now depends on that job so the shared package can publish first.
> 
> Documentation updates list the package in the root **README** and **CONTRIBUTING** dependency diagram. The package **README** drops the pre-release caution and points CI/docs badges at the new workflow. **`typedoc.json`** is added for API docs generation.
> 
> In **`package.json`**, lint moves to ESLint 9 (`typescript-eslint`, `import-x`, etc.) with a simplified `lint` script; runtime library code is unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ecb7111cac4c2ec15f694739400a66ddcfcffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->