### PR TITLE
feat!: pre-release `@launchdarkly/node-client-sdk` as `0.1.0`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,6 +62,7 @@ on:
           - packages/sdk/combined-browser
           - packages/sdk/shopify-oxygen
           - packages/sdk/electron
+          - packages/sdk/node-client
           - packages/sdk/react
           - packages/sdk/openfeature-node-server
           - packages/sdk/vue
@@ -111,6 +112,7 @@ jobs:
       package-sdk-openfeature-node-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-node-server--release_created'] }}
       package-tooling-client-testing-plugin-released: ${{ steps.release.outputs['packages/tooling/client-testing-plugin--release_created'] }}
       package-sdk-vue-released: ${{ steps.release.outputs['packages/sdk/vue--release_created'] }}
+      package-node-client-released: ${{ steps.release.outputs['packages/sdk/node-client--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0
         id: release
@@ -409,6 +411,22 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/tooling/client-testing-plugin
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-node-client:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-sdk-client']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-node-client-released == 'true'}}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - id: release-node-client
+        name: Full release of packages/sdk/node-client
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/sdk/node-client
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   release-server-ai:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,7 +8,7 @@
   "packages/sdk/cloudflare": "2.7.25",
   "packages/sdk/combined-browser": "0.1.27",
   "packages/sdk/fastly": "0.2.15",
-  "packages/sdk/node-client": "0.0.4",
+  "packages/sdk/node-client": "0.1.0",
   "packages/sdk/react-native": "10.19.0",
   "packages/sdk/server-ai": "1.1.0",
   "packages/sdk/server-node": "9.11.2",

--- a/packages/sdk/node-client/README.md
+++ b/packages/sdk/node-client/README.md
@@ -1,21 +1,16 @@
 # LaunchDarkly Node.js Client-Side SDK
 
-<!--
-[![NPM][npm-badge]][npm-link]
-[![Actions Status][ci-badge]][ci-link]
-[![Documentation][ghp-badge]][ghp-link]
-[![NPM][npm-dm-badge]][npm-link]
-[![NPM][npm-dt-badge]][npm-link]
--->
+[![NPM][node-client-npm-badge]][node-client-npm-link]
+[![Actions Status][node-client-ci-badge]][node-client-ci]
+[![Documentation][node-client-ghp-badge]][node-client-ghp-link]
+[![NPM][node-client-dm-badge]][node-client-npm-link]
+[![NPM][node-client-dt-badge]][node-client-npm-link]
 
 > [!CAUTION]
-> This SDK is experimental and should NOT be considered ready for production use.
-> It may change or be removed without notice and is not subject to backwards
-> compatibility guarantees.
-
-<!--
-> Pin to a specific minor version and review the [changelog](link-to-changelog) before upgrading.
--->
+> This SDK is in pre-release and not subject to backwards compatibility
+> guarantees. The API may change based on feedback.
+>
+> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
 
 ## Getting started
 
@@ -37,13 +32,11 @@ Refer to the [SDK documentation](https://launchdarkly.com/docs/sdk/client-side/n
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
 
 
-<!--
-[npm-badge]: https://img.shields.io/npm/v/@launchdarkly/node-client-sdk.svg?style=flat-square
-[npm-link]: https://www.npmjs.com/package/@launchdarkly/node-client-sdk
-[npm-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/node-client-sdk.svg?style=flat-square
-[npm-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/node-client-sdk.svg?style=flat-square
-[ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml/badge.svg
-[ci-link]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml
-[ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
-[ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/node-client/docs/
--->
+[node-client-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml/badge.svg
+[node-client-ci]: https://github.com/launchdarkly/js-core/actions/workflows/node-client.yml
+[node-client-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/node-client-sdk.svg?style=flat-square
+[node-client-npm-link]: https://www.npmjs.com/package/@launchdarkly/node-client-sdk
+[node-client-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[node-client-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/node-client/docs/
+[node-client-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/node-client-sdk.svg?style=flat-square
+[node-client-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/node-client-sdk.svg?style=flat-square

--- a/packages/sdk/node-client/package.json
+++ b/packages/sdk/node-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchdarkly/node-client-sdk",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "LaunchDarkly Client-Side SDK for Node.js",
   "homepage": "https://github.com/launchdarkly/js-core/tree/main/packages/sdk/node-client",
   "repository": {
@@ -41,7 +41,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@launchdarkly/js-client-sdk-common": "workspace:^",
+    "@launchdarkly/js-client-sdk-common": "1.29.0",
     "launchdarkly-eventsource": "2.2.0"
   },
   "devDependencies": {

--- a/packages/sdk/node-client/src/platform/NodeInfo.ts
+++ b/packages/sdk/node-client/src/platform/NodeInfo.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import { Info, PlatformData, SdkData } from '@launchdarkly/js-client-sdk-common';
 
 const sdkName = 'node-client-sdk';
-const sdkVersion = '0.0.4'; // x-release-please-version
+const sdkVersion = '0.1.0'; // x-release-please-version
 
 function processPlatformName(name: string): string {
   switch (name) {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -106,6 +106,11 @@
           "type": "json",
           "path": "/packages/tooling/client-testing-plugin/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/js-client-sdk-common']"
+        },
+        {
+          "type": "json",
+          "path": "/packages/sdk/node-client/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/js-client-sdk-common']"
         }
       ]
     },
@@ -155,6 +160,7 @@
     },
     "packages/sdk/node-client": {
       "bump-minor-pre-major": true,
+      "prerelease": true,
       "extra-files": [
         "src/platform/NodeInfo.ts"
       ]


### PR DESCRIPTION
This PR will do a pre-release of node client sdk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated npm publishing for a public SDK and pins a shared dependency for release; no application runtime logic changes in the diff, but a mistaken publish or wrong dependency version would affect consumers.
> 
> **Overview**
> Prepares **`@launchdarkly/node-client-sdk`** for its first intentional pre-release at **0.1.0** (from 0.0.4), including npm publish wiring and release-please metadata.
> 
> **Release automation:** Adds `packages/sdk/node-client` to manual publish options, a `package-node-client-released` output, and a **`release-node-client`** job (after `release-sdk-client`) that runs `./actions/full-release`. Marks the package **`prerelease: true`** in `release-please-config.json` and syncs `@launchdarkly/js-client-sdk-common` in `node-client/package.json` when `sdk-client` is released.
> 
> **Publish-ready package metadata:** Bumps version in the manifest, `package.json`, and `NodeInfo.ts`. Pins `@launchdarkly/js-client-sdk-common` to **1.29.0** instead of `workspace:^` so the published tarball has a concrete dependency version.
> 
> **Docs:** README switches from experimental placeholder badges to live NPM/CI/docs badges and updates the caution to **pre-release** (API may change; pin minor versions and read `CHANGELOG.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0292bf97151193d7f75a53292a7436884ce8828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->