### PR TITLE
fix: Check disabled state before AI Config mode mismatch

### DIFF
--- a/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
@@ -354,13 +354,17 @@ describe('config evaluation', () => {
     evaluateSpy.mockRestore();
   });
 
-  it('handles mode mismatch by returning disabled config', async () => {
+  it("returns the caller's default on a genuine mode mismatch", async () => {
     const client = new LDAIClientImpl(mockLdClient);
     const key = 'test-flag';
     const defaultValue: LDAICompletionConfigDefault = {
-      enabled: false,
+      enabled: true,
+      model: { name: 'default-model', parameters: { name: 'default' } },
+      provider: { name: 'default-provider' },
+      messages: [{ role: 'system', content: 'Default message' }],
     };
 
+    // Served variation is enabled but a different mode than requested.
     const mockVariation = {
       model: { name: 'example-provider', parameters: { name: 'imagination' } },
       messages: [{ role: 'system', content: 'Hello' }],
@@ -371,7 +375,12 @@ describe('config evaluation', () => {
 
     const result = await client.completionConfig(key, testContext, defaultValue);
 
-    expect(result.enabled).toBe(false);
+    // The returned config reflects the caller's default, not a disabled config
+    // and not the served variation.
+    expect(result.enabled).toBe(true);
+    expect(result.model).toEqual({ name: 'default-model', parameters: { name: 'default' } });
+    expect(result.provider).toEqual({ name: 'default-provider' });
+    expect(result.messages).toEqual([{ role: 'system', content: 'Default message' }]);
     expect(result.createTracker).toBeInstanceOf(Function);
     expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('mode mismatch'));
   });

--- a/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
@@ -23,9 +23,17 @@ jest.mock('../src/api/judge/Judge', () => {
 });
 jest.mock('../src/api/providers/RunnerFactory');
 
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
 const mockLdClient: jest.Mocked<LDClientMin> = {
   variation: jest.fn(),
   track: jest.fn(),
+  logger: mockLogger,
 };
 
 // Reset mocks before each test
@@ -365,6 +373,64 @@ describe('config evaluation', () => {
 
     expect(result.enabled).toBe(false);
     expect(result.createTracker).toBeInstanceOf(Function);
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('mode mismatch'));
+  });
+
+  it('does not warn about a mode mismatch when an agent config is disabled', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'sample-agent';
+
+    // A disabled variation is served with only `enabled: false` and no mode.
+    const mockVariation = {
+      _ldMeta: { enabled: false },
+    };
+
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.agentConfig(key, testContext);
+
+    expect(result.enabled).toBe(false);
+    expect(result.key).toBe(key);
+    expect(result.createTracker).toBeInstanceOf(Function);
+    // An agent config exposes an evaluator; a judge config does not.
+    expect('evaluator' in result).toBe(true);
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('mode mismatch'));
+  });
+
+  it('does not warn about a mode mismatch when a judge config is disabled', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'sample-judge';
+
+    const mockVariation = {
+      _ldMeta: { enabled: false },
+    };
+
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.judgeConfig(key, testContext);
+
+    expect(result.enabled).toBe(false);
+    expect(result.key).toBe(key);
+    expect(result.createTracker).toBeInstanceOf(Function);
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('mode mismatch'));
+  });
+
+  it('does not warn about a mode mismatch when a completion config is disabled', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'sample-completion';
+
+    const mockVariation = {
+      _ldMeta: { enabled: false },
+    };
+
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.completionConfig(key, testContext);
+
+    expect(result.enabled).toBe(false);
+    expect(result.key).toBe(key);
+    expect(result.createTracker).toBeInstanceOf(Function);
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining('mode mismatch'));
   });
 
   it('handles missing metadata mode by defaulting to completion mode', async () => {
@@ -740,11 +806,11 @@ describe('createJudge method', () => {
     expect(judgeConfigSpy).toHaveBeenCalledWith(key, testContext, defaultValue, undefined);
     expect(RunnerFactory.createModel).toHaveBeenCalledWith(
       mockJudgeConfig,
-      undefined,
+      mockLogger,
       undefined,
       false,
     );
-    expect(Judge).toHaveBeenCalledWith(mockJudgeConfig, mockProvider, 1.0, undefined);
+    expect(Judge).toHaveBeenCalledWith(mockJudgeConfig, mockProvider, 1.0, mockLogger);
     expect(result).toBe(mockJudge);
     judgeConfigSpy.mockRestore();
   });
@@ -800,7 +866,7 @@ describe('createJudge method', () => {
     expect(result).toBeUndefined();
     expect(RunnerFactory.createModel).toHaveBeenCalledWith(
       mockJudgeConfig,
-      undefined,
+      mockLogger,
       undefined,
       false,
     );

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -119,23 +119,26 @@ export class LDAIClientImpl implements LDAIClient {
     // eslint-disable-next-line no-underscore-dangle
     const flagMode = value._ldMeta?.mode ?? 'completion';
 
+    // An enabled variation whose mode differs from the requested mode cannot be
+    // returned as the requested type. Fall back to the caller's supplied default
+    // (converted to the requested mode) rather than the served variation.
+    const sourceValue = flagMode === mode ? value : ldFlagValue;
     if (flagMode !== mode) {
       this._logger?.warn(
-        `AI Config mode mismatch for ${key}: expected ${mode}, got ${flagMode}. Returning disabled config.`,
+        `AI Config mode mismatch for ${key}: expected ${mode}, got ${flagMode}. Returning caller's default.`,
       );
-      return LDAIConfigUtils.createDisabledConfig(key, mode, trackerFactory, evaluator);
     }
 
-    if (flagMode !== 'judge') {
+    if (mode !== 'judge') {
       evaluator = await this._buildEvaluator(
-        value.judgeConfiguration?.judges ?? [],
+        sourceValue.judgeConfiguration?.judges ?? [],
         context,
         variables,
         defaultAiProvider,
       );
     }
 
-    const config = LDAIConfigUtils.fromFlagValue(key, value, trackerFactory, evaluator);
+    const config = LDAIConfigUtils.fromFlagValue(key, sourceValue, trackerFactory, evaluator);
 
     // Apply variable interpolation (always needed for ldctx)
     return this._applyInterpolation(config, context, variables);

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -104,10 +104,20 @@ export class LDAIClientImpl implements LDAIClient {
         graphKey,
       );
 
+    let evaluator = Evaluator.noop();
+
+    // A disabled variation is served without a mode, so short-circuit to a
+    // disabled config of the requested mode before comparing modes. Otherwise
+    // the absent mode defaults to 'completion' and triggers a spurious
+    // mismatch warning for agent and judge requests.
+    // eslint-disable-next-line no-underscore-dangle
+    if (value._ldMeta?.enabled === false) {
+      return LDAIConfigUtils.createDisabledConfig(key, mode, trackerFactory, evaluator);
+    }
+
     // Validate mode match
     // eslint-disable-next-line no-underscore-dangle
     const flagMode = value._ldMeta?.mode ?? 'completion';
-    let evaluator = Evaluator.noop();
 
     if (flagMode !== mode) {
       this._logger?.warn(


### PR DESCRIPTION
This PR fixes two related issues in `LDAIClientImpl._evaluate()` in the `server-ai` package, both around how a served AI Config variation's mode is reconciled with the mode the caller requested.

## Fix 1 — Check disabled state before the mode comparison

**Bug:** A disabled AI Config variation is served by LaunchDarkly as `{"_ldMeta": {"enabled": false}}` with **no `mode` field**. The mode-mismatch check ran *before* the enabled check, so the absent mode defaulted to `'completion'`. Calling `agentConfig()` (or `judgeConfig()`) on a disabled config then made `'completion' !== 'agent'` true and emitted a spurious warning:

> `AI Config mode mismatch for sample-agent: expected agent, got completion. ...`

The config was simply disabled, not a genuine mode mismatch.

**Fix:** Short-circuit disabled variations before the mode comparison. When `value._ldMeta?.enabled === false`, `_evaluate()` returns `LDAIConfigUtils.createDisabledConfig(key, mode, ...)` of the **requested** mode — no mode comparison, no warning. (`=== false` matches the existing disabled-check convention in `agentGraph()`.)

## Fix 2 — Return the caller's default on a genuine mode mismatch

**Bug (pre-existing):** When a config is **enabled** but its mode genuinely differs from what the caller requested (e.g. an enabled completion config requested via `agentConfig()`), js-core logged "...Returning disabled config." and returned an empty disabled config. Per the AI Config spec (the "mode mismatch returns the caller's supplied default" rule, merged to `sdk-specs` main via PR #229 / AIC-2207), the SDK must instead return the **caller's supplied default** of the requested mode. .NET already does this; js-core was off-spec.

**Fix:** In the genuine-mismatch branch (which now only runs for enabled configs, after Fix 1's disabled short-circuit), build the returned config from the caller's supplied default (converted to the requested mode via the already-computed `ldFlagValue`) instead of an empty disabled config. The warning text now reads "Returning caller's default." to match the new behavior and .NET's wording. Matching-mode and disabled paths are unchanged.

## Tests

- Replaced the old "returns disabled config" mismatch test with one asserting the returned config equals the caller's default (enabled, model, provider, messages) and that the warning **is** still emitted.
- Disabled-variation regression tests (agent / judge / completion served as `{"_ldMeta": {"enabled": false}}`) assert no mode-mismatch warning and a disabled config of the requested type — unchanged and still passing.
- All 225 server-ai tests pass; lint clean.

## Companion changes

- Spec change in `sdk-specs` on branch `jb/disabled-config-mode-check`.
- Companion SDK fix in `dotnet-core` on branch `jb/disabled-config-mode-check`.

No changelog or version edits (handled at release time).

BEGIN_COMMIT_OVERRIDE
fix: Check disabled state before AI Config mode mismatch
fix: Return caller's default on AI Config mode mismatch
END_COMMIT_OVERRIDE