### PR TITLE
feat: openfeature-node-server migration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -583,9 +583,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    # if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-openfeature-node-server-released == 'true'}}
-    # TODO: Uncomment this when the package is ready to be released.
-    if: false
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-openfeature-node-server-released == 'true'}}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - id: release-openfeature-node-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,7 @@ flowchart LR
     server-ai[sdk/server-ai]
     react[sdk/react]
     shopify-oxygen[sdk/shopify-oxygen]
+    openfeature-node-server[sdk/openfeature-node-server]
 
     %% Store packages
     redis[store/node-server-sdk-redis]
@@ -203,7 +204,10 @@ flowchart LR
     
     akamai-edgeworker --> akamai-base
     akamai-edgeworker --> akamai-edgekv
-    
+
+    openfeature-server-common --> openfeature-node-server
+    server-node --> openfeature-node-server
+
     %% Dependencies for store packages
     sdk-server --> redis
     sdk-server --> dynamodb
@@ -215,7 +219,7 @@ flowchart LR
     react-native -.-> jest
     
     class common,sdk-client,sdk-server,sdk-server-edge,akamai-edgeworker,openfeature-server-common shared
-    class server-node,cloudflare,fastly,react-native,browser,vercel,akamai-base,akamai-edgekv,server-ai,react,shopify-oxygen sdk
+    class server-node,cloudflare,fastly,react-native,browser,vercel,akamai-base,akamai-edgekv,server-ai,react,shopify-oxygen,openfeature-node-server sdk
     class redis,dynamodb store
     class node-otel telemetry
     class jest tooling
@@ -232,7 +236,7 @@ There are a number of categories of packages in the monorepo:
    - `shared/openfeature-server-common`: Common code for server-side OpenFeature providers
 
 2. **SDK packages** (blue): Actual SDK implementations for different platforms
-   - Browser, React Native, Server Node, Cloudflare, Fastly, Vercel, Akamai, etc.
+   - Browser, React Native, Server Node, Cloudflare, Fastly, Vercel, Akamai, OpenFeature, etc.
 
 3. **Store packages** (green): Persistent storage implementations
    - Redis and DynamoDB implementations

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/server-sdk-ai](packages/sdk/server-ai/README.md)                | [![NPM][sdk-server-ai-npm-badge]][sdk-server-ai-npm-link]         | [server-ai][package-sdk-server-ai-issues]         | [![Actions Status][sdk-server-ai-ci-badge]][sdk-server-ai-ci]         |
 | [@launchdarkly/shopify-oxygen-sdk](packages/sdk/shopify-oxygen/README.md)      | [![NPM][sdk-shopify-oxygen-npm-badge]][sdk-shopify-oxygen-npm-link] | [Shopify Oxygen][package-sdk-shopify-oxygen-issues] | [![Actions Status][sdk-shopify-oxygen-ci-badge]][sdk-shopify-oxygen-ci] |
 | [@launchdarkly/react-sdk](packages/sdk/react/README.md)                       | [![NPM][sdk-react-npm-badge]][sdk-react-npm-link]                   | [React][package-sdk-react-issues]                   | [![Actions Status][sdk-react-ci-badge]][sdk-react-ci]                   |
+| [@launchdarkly/openfeature-node-server](packages/sdk/openfeature-node-server/README.md) | [![NPM][sdk-openfeature-node-server-npm-badge]][sdk-openfeature-node-server-npm-link] | [OpenFeature Node Server][package-sdk-openfeature-node-server-issues] | [![Actions Status][sdk-openfeature-node-server-ci-badge]][sdk-openfeature-node-server-ci] |
 <!--| [@launchdarkly/browser](packages/sdk/combined-browser/README.md)                  | [![NPM][sdk-combined-browser-npm-badge]][sdk-browser-npm-link]             | [Combined Browser][package-sdk-combined-browser-issues]             | [![Actions Status][sdk-combined-browser-ci-badge]][sdk-combined-browser-ci]             |-->
 
 | Shared packages                                                                      | npm                                                                       | issues                                                      | tests                                                                           |
@@ -258,3 +259,9 @@ We encourage pull requests and other contributions from the community. Check out
 [shared-openfeature-server-common-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml/badge.svg
 [shared-openfeature-server-common-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-server-common.yaml
 [package-shared-openfeature-server-common-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+shared%2Fopenfeature-server-common%22+
+[//]: # 'sdk/openfeature-node-server'
+[sdk-openfeature-node-server-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yaml/badge.svg
+[sdk-openfeature-node-server-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yaml
+[sdk-openfeature-node-server-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-node-server.svg?style=flat-square
+[sdk-openfeature-node-server-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-node-server
+[package-sdk-openfeature-node-server-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fopenfeature-node-server%22+

--- a/packages/sdk/openfeature-node-server/README.md
+++ b/packages/sdk/openfeature-node-server/README.md
@@ -1,14 +1,10 @@
 # LaunchDarkly OpenFeature Provider for the Node.js Server-Side SDK
 
-<!--
 [![NPM][openfeature-node-server-npm-badge]][openfeature-node-server-npm-link]
 [![Actions Status][openfeature-node-server-ci-badge]][openfeature-node-server-ci]
--->
-
-> [!CAUTION]
-> This SDK is experimental and should NOT be considered ready for production use.
-> It may change or be removed without notice and is not subject to backwards
-> compatibility guarantees.
+[![Documentation][openfeature-node-server-ghp-badge]][openfeature-node-server-ghp-link]
+[![NPM][openfeature-node-server-dm-badge]][openfeature-node-server-npm-link]
+[![NPM][openfeature-node-server-dt-badge]][openfeature-node-server-npm-link]
 
 This package provides an [OpenFeature](https://openfeature.dev/) provider that wraps the [LaunchDarkly Server-Side SDK for Node.js](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/server-node).
 
@@ -56,9 +52,11 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
   - [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/ 'LaunchDarkly API Documentation') for our API documentation
   - [blog.launchdarkly.com](https://blog.launchdarkly.com/ 'LaunchDarkly Blog Documentation') for the latest product updates
 
-<!--
+[openfeature-node-server-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yaml/badge.svg
+[openfeature-node-server-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yaml
 [openfeature-node-server-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-node-server.svg?style=flat-square
 [openfeature-node-server-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-node-server
-[openfeature-node-server-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml/badge.svg
-[openfeature-node-server-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-node-server.yml
--->
+[openfeature-node-server-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
+[openfeature-node-server-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/openfeature-node-server/docs/
+[openfeature-node-server-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/openfeature-node-server.svg?style=flat-square
+[openfeature-node-server-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/openfeature-node-server.svg?style=flat-square

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -413,12 +413,12 @@
       "release-as": "1.0.0"
     },
     "packages/sdk/openfeature-node-server": {
-      "bump-minor-pre-major": true,
+      "release-as": "1.3.0",
       "extra-files": [
         "src/LaunchDarklyProvider.ts",
         {
           "type": "json",
-          "path": "/packages/sdk/openfeature-node-server/examples/getting-started/package.json",
+          "path": "examples/getting-started/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/openfeature-node-server']"
         }
       ]


### PR DESCRIPTION
This PR will publish a new minor version of the openfeature node provider from this monorepo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling automated npm publish for a server-side feature-flag provider is customer-facing; version pinning to 1.3.0 must align with the intended migration from the prior release line.
> 
> **Overview**
> **Turns on publishing** for `@launchdarkly/openfeature-node-server` by replacing the disabled `release-openfeature-node-server` job (`if: false`) with the normal release-please gate, and pinning **`release-as`: `1.3.0`** in `release-please-config.json` (with a corrected `examples/getting-started` extra-file path).
> 
> **Docs and discoverability:** root `README.md` lists the package with CI/npm/issue badges; `CONTRIBUTING.md` adds it to the dependency diagram (from `openfeature-server-common` and `server-node`). The package **README** removes the experimental caution and shows live NPM, CI, docs, and download badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da6fa187411927f4a82aa296bd87048c74a1ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->