### PR TITLE
feat(node-client-sdk): adding support for mobile usage

### DIFF
--- a/packages/sdk/node-client/__tests__/NodeClient.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClient.test.ts
@@ -2,14 +2,86 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
+import type { Response } from '@launchdarkly/js-client-sdk-common';
+
 import { createClient } from '../src';
 import { resetNodeStorage } from '../src/platform/NodeStorage';
+import NodeCrypto from '../src/platform/NodeCrypto';
+import NodeEncoding from '../src/platform/NodeEncoding';
+import NodeInfo from '../src/platform/NodeInfo';
 import { createMockLogger } from './testHelpers';
+
+function mockResponse(value: string, statusCode: number) {
+  const response: Response = {
+    headers: {
+      get: jest.fn(),
+      keys: jest.fn(),
+      values: jest.fn(),
+      entries: jest.fn(),
+      has: jest.fn(),
+    },
+    status: statusCode,
+    text: () => Promise.resolve(value),
+    json: () => Promise.resolve(JSON.parse(value)),
+  };
+  return Promise.resolve(response);
+}
+
+function mockFetch(value: string, statusCode: number = 200) {
+  const f = jest.fn();
+  f.mockResolvedValue(mockResponse(value, statusCode));
+  return f;
+}
+
+const createMockEventSource = (streamUri: string = '', options: any = {}) => ({
+  streamUri,
+  options,
+  onclose: jest.fn(),
+  addEventListener: jest.fn(),
+  close: jest.fn(),
+});
+
+const createMockEventSourceThatDeliversPut = (streamUri: string = '', options: any = {}) => ({
+  ...createMockEventSource(streamUri, options),
+  addEventListener: jest.fn((eventName: string, callback: (e: { data?: string }) => void) => {
+    if (eventName === 'put') {
+      Promise.resolve().then(() => callback({ data: '{}' }));
+    }
+  }),
+});
+
+jest.mock('../src/platform/NodePlatform', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: jest.fn(),
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: {
+      clear: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
+    },
+  })),
+}));
+
+const NodePlatform = require('../src/platform/NodePlatform').default;
+
+const DEFAULT_INITIAL_CONTEXT = { kind: 'user' as const, key: 'bob' };
 
 let tmpRoot: string;
 let logger: ReturnType<typeof createMockLogger>;
 
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
 beforeEach(async () => {
+  jest.clearAllMocks();
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'node-client-test-'));
   resetNodeStorage();
   logger = createMockLogger();
@@ -95,4 +167,328 @@ it('start completes in offline mode without performing network identify', async 
 
   const result = await client.start({ timeout: 5 });
   expect(result.status).toBe('complete');
+});
+
+// ------ Mobile key routing tests ------
+
+it('uses /mobile/events/diagnostic when useMobileKey is true', () => {
+  const mockedFetch = jest.fn();
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, { useMobileKey: true });
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/mobile/events/diagnostic',
+    expect.anything(),
+  );
+});
+
+it('uses /mobile for analytics events when useMobileKey is true', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: createMockEventSource,
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+  await client.flush();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/mobile',
+    expect.anything(),
+  );
+});
+
+it('uses mobile polling url (/msdk/evalx/contexts/...) when useMobileKey is true', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+
+  const regex = /https:\/\/clientsdk\.launchdarkly\.com\/msdk\/evalx\/contexts\/.*/;
+  expect(mockedFetch).toHaveBeenCalledWith(expect.stringMatching(regex), expect.anything());
+});
+
+it('uses mobile streaming url (/meval/...) when useMobileKey is true', async () => {
+  const mockedCreateEventSource = jest.fn((streamUri: string = '', options: any = {}) =>
+    createMockEventSourceThatDeliversPut(streamUri, options),
+  );
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: mockedCreateEventSource,
+      fetch: jest.fn(),
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'streaming',
+  });
+  await client.start();
+
+  const regex = /https:\/\/clientstream\.launchdarkly\.com\/meval\/.*/;
+  expect(mockedCreateEventSource).toHaveBeenCalledWith(
+    expect.stringMatching(regex),
+    expect.anything(),
+  );
+});
+
+it('sends Authorization header with the mobile key on polling', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      headers: expect.objectContaining({ authorization: 'mobile-key-123' }),
+    }),
+  );
+});
+
+it('sends Authorization header with the mobile key on streaming', async () => {
+  const mockedCreateEventSource = jest.fn((streamUri: string = '', options: any = {}) =>
+    createMockEventSourceThatDeliversPut(streamUri, options),
+  );
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: mockedCreateEventSource,
+      fetch: jest.fn(),
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'streaming',
+  });
+  await client.start();
+
+  expect(mockedCreateEventSource).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      headers: expect.objectContaining({ authorization: 'mobile-key-123' }),
+    }),
+  );
+});
+
+it('sends Authorization header with the mobile key on event posts', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    diagnosticOptOut: true,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+  await client.flush();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      headers: expect.objectContaining({ authorization: 'mobile-key-123' }),
+    }),
+  );
+});
+
+// ------ Client-side ID (default) routing tests ------
+
+it('uses /events/diagnostic/<credential> by default (client-side ID mode)', () => {
+  const mockedFetch = jest.fn();
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {});
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/events/diagnostic/client-side-id',
+    expect.anything(),
+  );
+});
+
+it('uses /events/bulk/<credential> for analytics events by default', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: createMockEventSource,
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    diagnosticOptOut: true,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+  await client.flush();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/events/bulk/client-side-id',
+    expect.anything(),
+  );
+});
+
+it('uses client-side polling url (/sdk/evalx/<credential>/contexts/...) by default', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+
+  const regex = /https:\/\/clientsdk\.launchdarkly\.com\/sdk\/evalx\/client-side-id\/contexts\/.*/;
+  expect(mockedFetch).toHaveBeenCalledWith(expect.stringMatching(regex), expect.anything());
+});
+
+it('uses client-side streaming url (/eval/<credential>/...) by default', async () => {
+  const mockedCreateEventSource = jest.fn((streamUri: string = '', options: any = {}) =>
+    createMockEventSourceThatDeliversPut(streamUri, options),
+  );
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: mockedCreateEventSource,
+      fetch: jest.fn(),
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'streaming',
+  });
+  await client.start();
+
+  const regex = /https:\/\/clientstream\.launchdarkly\.com\/eval\/client-side-id\/.*/;
+  expect(mockedCreateEventSource).toHaveBeenCalledWith(
+    expect.stringMatching(regex),
+    expect.anything(),
+  );
+});
+
+it('sends Authorization header with the client-side ID by default (polling)', async () => {
+  const mockedFetch = mockFetch('{"flagA": true}', 200);
+  (NodePlatform as jest.Mock).mockReturnValue({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: mockedFetch,
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: { clear: jest.fn(), get: jest.fn(), set: jest.fn() },
+  });
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    diagnosticOptOut: true,
+    sendEvents: false,
+    initialConnectionMode: 'polling',
+  });
+  await client.start();
+
+  expect(mockedFetch).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      headers: expect.objectContaining({ authorization: 'client-side-id' }),
+    }),
+  );
 });

--- a/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeDataManager.test.ts
@@ -345,6 +345,43 @@ describe('given a NodeDataManager with mocked dependencies', () => {
     );
   });
 
+  it('ignores per-identify hash and logs a warning when useMobileKey is true', async () => {
+    const dataManager = makeDataManager(
+      makeNodeConfig({ useMobileKey: true, initialConnectionMode: 'polling' }),
+    );
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await new Promise<void>((resolve) => {
+      const identifyResolve = jest.fn().mockImplementation(resolve);
+      dataManager.identify(identifyResolve, jest.fn(), context, {
+        hash: 'some-hash',
+      } as NodeIdentifyOptions);
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('hash'));
+    const [pollUri] = (platform.requests.fetch as jest.Mock).mock.calls[0];
+    expect(pollUri).not.toContain('h=some-hash');
+  });
+
+  // Defense-in-depth: createClient rejects hash+useMobileKey at construction, so this
+  // state is unreachable via the public API. The guard in NodeDataManager is still exercised
+  // here directly in case it is ever instantiated outside of NodeClient.
+  it('ignores config-level hash and logs a warning when useMobileKey is true', async () => {
+    const dataManager = makeDataManager(
+      makeNodeConfig({ useMobileKey: true, initialConnectionMode: 'polling', hash: 'config-hash' }),
+    );
+    const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });
+
+    await new Promise<void>((resolve) => {
+      const identifyResolve = jest.fn().mockImplementation(resolve);
+      dataManager.identify(identifyResolve, jest.fn(), context, {});
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('hash'));
+    const [pollUri] = (platform.requests.fetch as jest.Mock).mock.calls[0];
+    expect(pollUri).not.toContain('h=config-hash');
+  });
+
   it('includes the per-identify hash in the connection opened after bootstrap', async () => {
     const dataManager = makeDataManager(makeNodeConfig());
     const context = Context.fromLDContext({ kind: 'user', key: 'test-user' });

--- a/packages/sdk/node-client/__tests__/options.test.ts
+++ b/packages/sdk/node-client/__tests__/options.test.ts
@@ -1,4 +1,4 @@
-import type { Storage } from '@launchdarkly/js-client-sdk-common';
+import type { LDStorage } from '@launchdarkly/js-client-sdk-common';
 
 import validateOptions, { ValidatedOptions } from '../src/options';
 import { createMockLogger } from './testHelpers';
@@ -65,7 +65,7 @@ it('warns when TLS certificate verification is disabled', () => {
 });
 
 it('accepts a valid Storage implementation', () => {
-  const storage: Storage = {
+  const storage: LDStorage = {
     get: async () => null,
     set: async () => {},
     clear: async () => {},
@@ -120,7 +120,7 @@ it('warns and ignores localStoragePath when it is not a string', () => {
 });
 
 it('warns when both localStoragePath and storage are set', () => {
-  const storage: Storage = {
+  const storage: LDStorage = {
     get: async () => null,
     set: async () => {},
     clear: async () => {},

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -14,6 +14,7 @@ import {
   LDHeaders,
   LDIdentifyResult,
   LDPluginEnvironmentMetadata,
+  mobileFdv1Endpoints,
 } from '@launchdarkly/js-client-sdk-common';
 
 import basicLogger from './basicLogger';
@@ -34,19 +35,23 @@ export class NodeClient extends LDClientImpl {
 
     const validatedNodeOptions = validateOptions(options, logger);
 
+    const { useMobileKey } = validatedNodeOptions;
+
     const internalOptions: LDClientInternalOptions = {
-      analyticsEventPath: `/events/bulk/${envKey}`,
-      diagnosticEventPath: `/events/diagnostic/${envKey}`,
+      analyticsEventPath: useMobileKey ? `/mobile` : `/events/bulk/${envKey}`,
+      diagnosticEventPath: useMobileKey
+        ? `/mobile/events/diagnostic`
+        : `/events/diagnostic/${envKey}`,
       highTimeoutThreshold: 15,
       getImplementationHooks: (_environmentMetadata: LDPluginEnvironmentMetadata) =>
         internal.safeGetHooks(logger, _environmentMetadata, validatedNodeOptions.plugins),
-      credentialType: 'clientSideId',
+      credentialType: useMobileKey ? 'mobileKey' : 'clientSideId',
       requiresStart: true,
       initialContext,
     };
 
     const platform = new NodePlatform(logger, validatedNodeOptions);
-    const endpoints = browserFdv1Endpoints(envKey);
+    const endpoints = useMobileKey ? mobileFdv1Endpoints() : browserFdv1Endpoints(envKey);
 
     super(
       envKey,

--- a/packages/sdk/node-client/src/NodeDataManager.ts
+++ b/packages/sdk/node-client/src/NodeDataManager.ts
@@ -87,6 +87,14 @@ export default class NodeDataManager extends BaseDataManager {
     // We will treat empty string as `null`/`undefined`. This should be more
     // ergonomic for users who have multiple settings for this value.
     this._currentHash = nodeOptions?.hash || this._nodeConfig.hash;
+    if (this._currentHash && this._nodeConfig.useMobileKey) {
+      // This deviates from the `createClient` behavior (where the sdk will throw if
+      // constructed with both `hash` and `useMobileKey`) because `identify()` is called
+      // during sdk client runtime and throwing at this stage would likely cause more severe
+      // disruptions to the service.
+      this.logger.warn(`${logTag} 'hash' is ignored in mobile key mode.`);
+      this._currentHash = undefined;
+    }
     if (this._currentHash) {
       this.setConnectionParams({ queryParameters: [{ key: 'h', value: this._currentHash }] });
     } else {

--- a/packages/sdk/node-client/src/options.ts
+++ b/packages/sdk/node-client/src/options.ts
@@ -29,7 +29,7 @@ class StorageOptionsValidator implements TypeValidator {
     return has('get') && has('set') && has('clear');
   }
   getType(): string {
-    return 'Storage ({ get, set, clear })';
+    return 'LDStorage ({ get, set, clear })';
   }
 }
 

--- a/packages/sdk/node-client/src/platform/NodePlatform.ts
+++ b/packages/sdk/node-client/src/platform/NodePlatform.ts
@@ -1,6 +1,6 @@
 import { createSafeStorage, LDLogger, platform } from '@launchdarkly/js-client-sdk-common';
 
-import type { NodeOptions } from '../NodeOptions';
+import type { ValidatedOptions } from '../options';
 import NodeCrypto from './NodeCrypto';
 import NodeEncoding from './NodeEncoding';
 import NodeInfo from './NodeInfo';
@@ -20,7 +20,7 @@ export default class NodePlatform implements platform.Platform {
 
   constructor(
     logger: LDLogger,
-    options: Pick<NodeOptions, 'storage' | 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
+    options: Pick<ValidatedOptions, 'storage' | 'localStoragePath' | 'tlsParams' | 'enableEventCompression' | 'wrapperName' | 'wrapperVersion'>,
   ) {
     this.info = new NodeInfo({ wrapperName: options.wrapperName, wrapperVersion: options.wrapperVersion });
     this.storage = options.storage


### PR DESCRIPTION
SDK-2486

This PR will add support for mobile key as a valid credential.

This PR will also harden some typing in the sdk client code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which LaunchDarkly hosts and paths the SDK hits when `useMobileKey` is set; default client-side ID behavior is unchanged, with validation blocking hash + mobile key at startup.
> 
> **Overview**
> Adds **`useMobileKey`** so the Node client can authenticate with a mobile key instead of a client-side ID. When enabled, **`NodeClient`** switches to mobile FDv1 endpoints (`mobileFdv1Endpoints`), sets **`credentialType`** to `mobileKey`, and uses mobile analytics/diagnostic paths (`/mobile`, `/mobile/events/diagnostic`) rather than the credential-in-path client-side URLs.
> 
> **`NodeDataManager`** drops secure-mode **`hash`** in mobile key mode (warns and omits the `h=` query param) so runtime `identify()` does not throw if a hash is passed. **`validateOptions`** rejects configuring **`hash`** and **`useMobileKey`** together at construction.
> 
> Typing is tightened: custom storage is **`LDStorage`**, and **`NodePlatform`** takes **`ValidatedOptions`** for platform-related fields. Tests mock **`NodePlatform`** and assert mobile vs default URL and **`Authorization`** header behavior for polling, streaming, diagnostics, and events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c003e78b1ba4e62e53b7eae24c8d5741bc89096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->