### PR TITLE
chore(vue-sdk): add variation composables

### DIFF
--- a/packages/sdk/vue/__tests__/client/composables.test.ts
+++ b/packages/sdk/vue/__tests__/client/composables.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { LDVueClient } from '../../src/client/LDClient';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick, type Component } from 'vue';
+
+import {
+  useBoolVariation,
+  useInitializationStatus,
+  useLDClient,
+} from '../../src/client/composables';
+import { createLDProviderWithClient } from '../../src/client/provider/LDProvider';
+import { makeMockClient } from './mockClient';
+
+function mountUnderProvider(client: LDVueClient, child: Component) {
+  const Provider = createLDProviderWithClient(client);
+  return mount(Provider, { slots: { default: () => h(child) } });
+}
+
+it('useBoolVariation returns the evaluated value when ready', () => {
+  const { client, controls } = makeMockClient({ boolValue: true });
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(wrapper.text()).toBe('true');
+  expect(client.boolVariation as unknown as jest.Mock).toHaveBeenCalledWith('flag', false);
+  expect(controls.handlerCount('change:flag')).toBe(1);
+});
+
+it('re-evaluates when the flag changes', async () => {
+  const { client, controls } = makeMockClient({ boolValue: true });
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('true');
+
+  controls.setBool(false);
+  controls.emitChange('flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe('false');
+});
+
+it('does not evaluate before the client is ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(wrapper.text()).toBe('false');
+  expect(client.boolVariation as unknown as jest.Mock).not.toHaveBeenCalled();
+});
+
+it('cleans up the change listener on unmount', () => {
+  const { client, controls } = makeMockClient();
+  const Child = defineComponent({
+    setup() {
+      useBoolVariation('flag', false);
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:flag')).toBe(0);
+});
+
+it('useInitializationStatus reflects status reactively', async () => {
+  const { client, controls } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  const Child = defineComponent({
+    setup() {
+      const status = useInitializationStatus();
+      return () => h('div', status.value.status);
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('initializing');
+
+  controls.emitInitStatus({ status: 'complete' });
+  await nextTick();
+  expect(wrapper.text()).toBe('complete');
+});
+
+it('useInitializationStatus surfaces the error on failure', async () => {
+  const { client, controls } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  const error = new Error('boom');
+  const Child = defineComponent({
+    setup() {
+      const status = useInitializationStatus();
+      return () =>
+        h('div', status.value.status === 'failed' ? status.value.error.message : status.value.status);
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  controls.emitInitStatus({ status: 'failed', error });
+  await nextTick();
+
+  expect(wrapper.text()).toBe('boom');
+});
+
+it('useLDClient returns the provided client', () => {
+  const { client } = makeMockClient();
+  let injected: unknown;
+  const Child = defineComponent({
+    setup() {
+      injected = useLDClient();
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  expect(injected).toBe(client);
+});
+
+it('throws when used without a provider', () => {
+  const Child = defineComponent({
+    render: () => h('div'),
+    setup() {
+      useLDClient();
+    },
+  });
+
+  expect(() => mount(Child)).toThrow(/LaunchDarkly client was not found/);
+});

--- a/packages/sdk/vue/__tests__/client/composables/useVariation.test.ts
+++ b/packages/sdk/vue/__tests__/client/composables/useVariation.test.ts
@@ -1,0 +1,447 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { LDVueClient } from '../../../src/client/LDClient';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick, ref, type Component } from 'vue';
+
+import {
+  useBoolVariation,
+  useJsonVariation,
+  useNumberVariation,
+  useStringVariation,
+} from '../../../src/client/composables';
+import { createLDProviderWithClient } from '../../../src/client/provider/LDProvider';
+import { makeMockClient } from '../mockClient';
+
+function mountUnderProvider(client: LDVueClient, child: Component) {
+  const Provider = createLDProviderWithClient(client);
+  return mount(Provider, { slots: { default: () => h(child) } });
+}
+
+// useBoolVariation
+
+it('useBoolVariation calls client.boolVariation with key and defaultValue', () => {
+  const { client } = makeMockClient({ boolValue: true });
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.boolVariation).toHaveBeenCalledWith('my-flag', false);
+  expect(wrapper.text()).toBe('true');
+});
+
+it('useBoolVariation evaluates exactly once on mount (no duplicate analytics impression)', () => {
+  const { client } = makeMockClient({ boolValue: true });
+
+  const Child = defineComponent({
+    setup() {
+      useBoolVariation('my-flag', false);
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+
+  expect(client.boolVariation).toHaveBeenCalledTimes(1);
+});
+
+it('useBoolVariation subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+
+  const Child = defineComponent({
+    setup() {
+      useBoolVariation('my-flag', false);
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useBoolVariation re-renders with new value when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient({ boolValue: false });
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('false');
+
+  controls.setBool(true);
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe('true');
+});
+
+it('useBoolVariation does not call variation when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+
+  const Child = defineComponent({
+    setup() {
+      useBoolVariation('my-flag', false);
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+
+  expect(client.boolVariation).not.toHaveBeenCalled();
+});
+
+it('useBoolVariation returns defaultValue when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(wrapper.text()).toBe('false');
+});
+
+it('useBoolVariation evaluates once when initialization completes', async () => {
+  const { client, controls } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('false');
+  expect(client.boolVariation).not.toHaveBeenCalled();
+
+  controls.emitInitStatus({ status: 'complete' });
+  await nextTick();
+
+  expect(client.boolVariation).toHaveBeenCalledTimes(1);
+  expect(wrapper.text()).toBe('true');
+});
+
+it('useBoolVariation evaluates when initialization fails (client returns defaults on failure)', async () => {
+  const { client, controls } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  (client.boolVariation as jest.Mock).mockReturnValue(false);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  expect(client.boolVariation).not.toHaveBeenCalled();
+
+  controls.emitInitStatus({ status: 'failed', error: new Error('network error') });
+  await nextTick();
+
+  expect(client.boolVariation).toHaveBeenCalledTimes(1);
+});
+
+it('useBoolVariation re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.boolVariation as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.boolVariation as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+it('useBoolVariation re-evaluates and re-subscribes when key changes', async () => {
+  const { client, controls } = makeMockClient();
+  (client.boolVariation as jest.Mock).mockImplementation((k: string, def: boolean) => {
+    if (k === 'flag-a') return false;
+    if (k === 'flag-b') return true;
+    return def;
+  });
+
+  const flagKey = ref('flag-a');
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation(flagKey, false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('false');
+  expect(controls.handlerCount('change:flag-a')).toBe(1);
+  expect(controls.handlerCount('change:flag-b')).toBe(0);
+
+  flagKey.value = 'flag-b';
+  await nextTick();
+
+  expect(wrapper.text()).toBe('true');
+  expect(controls.handlerCount('change:flag-a')).toBe(0);
+  expect(controls.handlerCount('change:flag-b')).toBe(1);
+});
+
+// useStringVariation
+
+it('useStringVariation calls client.stringVariation with key and defaultValue', () => {
+  const { client } = makeMockClient();
+  (client.stringVariation as jest.Mock).mockReturnValue('hello');
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useStringVariation('my-flag', 'default');
+      return () => h('div', flag.value);
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.stringVariation).toHaveBeenCalledWith('my-flag', 'default');
+  expect(wrapper.text()).toBe('hello');
+});
+
+it('useStringVariation subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+
+  const Child = defineComponent({
+    setup() {
+      useStringVariation('my-flag', 'default');
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useStringVariation re-renders with new value when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  (client.stringVariation as jest.Mock).mockReturnValue('before');
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useStringVariation('my-flag', 'default');
+      return () => h('div', flag.value);
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('before');
+
+  (client.stringVariation as jest.Mock).mockReturnValue('after');
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe('after');
+});
+
+it('useStringVariation re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.stringVariation as jest.Mock).mockReturnValue('value');
+
+  const Child = defineComponent({
+    setup() {
+      useStringVariation('my-flag', 'default');
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.stringVariation as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.stringVariation as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+// useNumberVariation
+
+it('useNumberVariation calls client.numberVariation with key and defaultValue', () => {
+  const { client } = makeMockClient();
+  (client.numberVariation as jest.Mock).mockReturnValue(42);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useNumberVariation('my-flag', 0);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.numberVariation).toHaveBeenCalledWith('my-flag', 0);
+  expect(wrapper.text()).toBe('42');
+});
+
+it('useNumberVariation subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+
+  const Child = defineComponent({
+    setup() {
+      useNumberVariation('my-flag', 0);
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useNumberVariation re-renders with new value when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  (client.numberVariation as jest.Mock).mockReturnValue(1);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useNumberVariation('my-flag', 0);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('1');
+
+  (client.numberVariation as jest.Mock).mockReturnValue(99);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe('99');
+});
+
+it('useNumberVariation re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.numberVariation as jest.Mock).mockReturnValue(5);
+
+  const Child = defineComponent({
+    setup() {
+      useNumberVariation('my-flag', 0);
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.numberVariation as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.numberVariation as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+// useJsonVariation
+
+it('useJsonVariation calls client.jsonVariation with key and defaultValue', () => {
+  const { client } = makeMockClient();
+  const result = { enabled: true };
+  (client.jsonVariation as jest.Mock).mockReturnValue(result);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useJsonVariation('my-flag', {});
+      return () => h('div', JSON.stringify(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.jsonVariation).toHaveBeenCalledWith('my-flag', {});
+  expect(wrapper.text()).toBe(JSON.stringify(result));
+});
+
+it('useJsonVariation subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+
+  const Child = defineComponent({
+    setup() {
+      useJsonVariation('my-flag', {});
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useJsonVariation re-renders with new value when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  (client.jsonVariation as jest.Mock).mockReturnValue({ x: 1 });
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useJsonVariation('my-flag', {});
+      return () => h('div', JSON.stringify(flag.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe('{"x":1}');
+
+  (client.jsonVariation as jest.Mock).mockReturnValue({ x: 2 });
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe('{"x":2}');
+});
+
+it('useJsonVariation re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.jsonVariation as jest.Mock).mockReturnValue({ value: 'a' });
+
+  const Child = defineComponent({
+    setup() {
+      useJsonVariation('my-flag', {});
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.jsonVariation as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.jsonVariation as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});

--- a/packages/sdk/vue/__tests__/client/composables/useVariation.test.ts
+++ b/packages/sdk/vue/__tests__/client/composables/useVariation.test.ts
@@ -184,6 +184,30 @@ it('useBoolVariation re-evaluates when context changes after identify', async ()
   expect((client.boolVariation as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
 });
 
+it('useBoolVariation evaluates only once per identify (no duplicate analytics impression)', async () => {
+  const { client, controls } = makeMockClient();
+  (client.boolVariation as jest.Mock).mockReturnValue(true);
+
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => h('div', String(flag.value));
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  (client.boolVariation as jest.Mock).mockClear();
+
+  // A single identify() in the base SDK emits change:<key> synchronously AND notifies
+  // context subscribers, so model both for one identify.
+  controls.emitChange('my-flag');
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  // One identify must produce exactly one evaluation -> one analytics impression.
+  expect(client.boolVariation as jest.Mock).toHaveBeenCalledTimes(1);
+});
+
 it('useBoolVariation re-evaluates and re-subscribes when key changes', async () => {
   const { client, controls } = makeMockClient();
   (client.boolVariation as jest.Mock).mockImplementation((k: string, def: boolean) => {

--- a/packages/sdk/vue/__tests__/client/composables/useVariationDetail.test.ts
+++ b/packages/sdk/vue/__tests__/client/composables/useVariationDetail.test.ts
@@ -1,0 +1,545 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { LDEvaluationDetailTyped } from '@launchdarkly/js-client-sdk';
+import type { LDVueClient } from '../../../src/client/LDClient';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, nextTick, ref, type Component } from 'vue';
+
+import {
+  useBoolVariationDetail,
+  useJsonVariationDetail,
+  useNumberVariationDetail,
+  useStringVariationDetail,
+} from '../../../src/client/composables';
+import { createLDProviderWithClient } from '../../../src/client/provider/LDProvider';
+import { makeMockClient } from '../mockClient';
+
+function mountUnderProvider(client: LDVueClient, child: Component) {
+  const Provider = createLDProviderWithClient(client);
+  return mount(Provider, { slots: { default: () => h(child) } });
+}
+
+const NOT_READY_REASON = { kind: 'ERROR', errorKind: 'CLIENT_NOT_READY' } as const;
+
+// useBoolVariationDetail
+
+it('useBoolVariationDetail calls client.boolVariationDetail with key and defaultValue and returns full detail', () => {
+  const { client } = makeMockClient();
+  const detail: LDEvaluationDetailTyped<boolean> = {
+    value: true,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  (client.boolVariationDetail as jest.Mock).mockReturnValue(detail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useBoolVariationDetail('my-flag', false);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.boolVariationDetail).toHaveBeenCalledWith('my-flag', false);
+  expect(wrapper.text()).toBe(JSON.stringify(detail));
+});
+
+it('useBoolVariationDetail subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+  (client.boolVariationDetail as jest.Mock).mockReturnValue({
+    value: false,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useBoolVariationDetail('my-flag', false);
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useBoolVariationDetail re-renders with updated detail when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  const initialDetail: LDEvaluationDetailTyped<boolean> = {
+    value: false,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  const updatedDetail: LDEvaluationDetailTyped<boolean> = {
+    value: true,
+    variationIndex: 1,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.boolVariationDetail as jest.Mock).mockReturnValue(initialDetail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useBoolVariationDetail('my-flag', false);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe(JSON.stringify(initialDetail));
+
+  (client.boolVariationDetail as jest.Mock).mockReturnValue(updatedDetail);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe(JSON.stringify(updatedDetail));
+});
+
+it('useBoolVariationDetail re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.boolVariationDetail as jest.Mock).mockReturnValue({
+    value: true,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useBoolVariationDetail('my-flag', false);
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.boolVariationDetail as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.boolVariationDetail as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+it('useBoolVariationDetail returns CLIENT_NOT_READY detail when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+
+  const Child = defineComponent({
+    setup() {
+      const d = useBoolVariationDetail('my-flag', false);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.boolVariationDetail).not.toHaveBeenCalled();
+  const rendered = JSON.parse(wrapper.text()) as LDEvaluationDetailTyped<boolean>;
+  expect(rendered.value).toBe(false);
+  expect(rendered.variationIndex).toBeNull();
+  expect(rendered.reason).toEqual(NOT_READY_REASON);
+});
+
+// useStringVariationDetail
+
+it('useStringVariationDetail calls client.stringVariationDetail with key and defaultValue and returns full detail', () => {
+  const { client } = makeMockClient();
+  const detail: LDEvaluationDetailTyped<string> = {
+    value: 'on',
+    variationIndex: 1,
+    reason: { kind: 'RULE_MATCH', ruleIndex: 0, ruleId: 'r1' },
+  };
+  (client.stringVariationDetail as jest.Mock).mockReturnValue(detail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useStringVariationDetail('my-flag', 'off');
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.stringVariationDetail).toHaveBeenCalledWith('my-flag', 'off');
+  expect(wrapper.text()).toBe(JSON.stringify(detail));
+});
+
+it('useStringVariationDetail subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+  (client.stringVariationDetail as jest.Mock).mockReturnValue({
+    value: 'off',
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useStringVariationDetail('my-flag', 'off');
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useStringVariationDetail re-renders with updated detail when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  const initialDetail: LDEvaluationDetailTyped<string> = {
+    value: 'before',
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  const updatedDetail: LDEvaluationDetailTyped<string> = {
+    value: 'after',
+    variationIndex: 1,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.stringVariationDetail as jest.Mock).mockReturnValue(initialDetail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useStringVariationDetail('my-flag', 'default');
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe(JSON.stringify(initialDetail));
+
+  (client.stringVariationDetail as jest.Mock).mockReturnValue(updatedDetail);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe(JSON.stringify(updatedDetail));
+});
+
+it('useStringVariationDetail re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.stringVariationDetail as jest.Mock).mockReturnValue({
+    value: 'value',
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useStringVariationDetail('my-flag', 'default');
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.stringVariationDetail as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.stringVariationDetail as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+it('useStringVariationDetail returns CLIENT_NOT_READY detail when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+
+  const Child = defineComponent({
+    setup() {
+      const d = useStringVariationDetail('my-flag', 'default');
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.stringVariationDetail).not.toHaveBeenCalled();
+  const rendered = JSON.parse(wrapper.text()) as LDEvaluationDetailTyped<string>;
+  expect(rendered.value).toBe('default');
+  expect(rendered.variationIndex).toBeNull();
+  expect(rendered.reason).toEqual(NOT_READY_REASON);
+});
+
+// useNumberVariationDetail
+
+it('useNumberVariationDetail calls client.numberVariationDetail with key and defaultValue and returns full detail', () => {
+  const { client } = makeMockClient();
+  const detail: LDEvaluationDetailTyped<number> = {
+    value: 99,
+    variationIndex: 2,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.numberVariationDetail as jest.Mock).mockReturnValue(detail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useNumberVariationDetail('my-flag', 0);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.numberVariationDetail).toHaveBeenCalledWith('my-flag', 0);
+  expect(wrapper.text()).toBe(JSON.stringify(detail));
+});
+
+it('useNumberVariationDetail subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+  (client.numberVariationDetail as jest.Mock).mockReturnValue({
+    value: 0,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useNumberVariationDetail('my-flag', 0);
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useNumberVariationDetail re-renders with updated detail when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  const initialDetail: LDEvaluationDetailTyped<number> = {
+    value: 1,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  const updatedDetail: LDEvaluationDetailTyped<number> = {
+    value: 99,
+    variationIndex: 1,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.numberVariationDetail as jest.Mock).mockReturnValue(initialDetail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useNumberVariationDetail('my-flag', 0);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe(JSON.stringify(initialDetail));
+
+  (client.numberVariationDetail as jest.Mock).mockReturnValue(updatedDetail);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe(JSON.stringify(updatedDetail));
+});
+
+it('useNumberVariationDetail re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.numberVariationDetail as jest.Mock).mockReturnValue({
+    value: 5,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useNumberVariationDetail('my-flag', 0);
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.numberVariationDetail as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.numberVariationDetail as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+it('useNumberVariationDetail returns CLIENT_NOT_READY detail when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+
+  const Child = defineComponent({
+    setup() {
+      const d = useNumberVariationDetail('my-flag', 0);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.numberVariationDetail).not.toHaveBeenCalled();
+  const rendered = JSON.parse(wrapper.text()) as LDEvaluationDetailTyped<number>;
+  expect(rendered.value).toBe(0);
+  expect(rendered.variationIndex).toBeNull();
+  expect(rendered.reason).toEqual(NOT_READY_REASON);
+});
+
+// useJsonVariationDetail
+
+it('useJsonVariationDetail calls client.jsonVariationDetail with key and defaultValue and returns full detail', () => {
+  const { client } = makeMockClient();
+  const detail: LDEvaluationDetailTyped<object> = {
+    value: { x: 1 },
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  (client.jsonVariationDetail as jest.Mock).mockReturnValue(detail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useJsonVariationDetail('my-flag', {});
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.jsonVariationDetail).toHaveBeenCalledWith('my-flag', {});
+  expect(wrapper.text()).toBe(JSON.stringify(detail));
+});
+
+it('useJsonVariationDetail subscribes to change:<key> on mount and unsubscribes on unmount', () => {
+  const { client, controls } = makeMockClient();
+  (client.jsonVariationDetail as jest.Mock).mockReturnValue({
+    value: {},
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useJsonVariationDetail('my-flag', {});
+      return () => h('div');
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(controls.handlerCount('change:my-flag')).toBe(1);
+
+  wrapper.unmount();
+  expect(controls.handlerCount('change:my-flag')).toBe(0);
+});
+
+it('useJsonVariationDetail re-renders with updated detail when change:<key> fires', async () => {
+  const { client, controls } = makeMockClient();
+  const initialDetail: LDEvaluationDetailTyped<object> = {
+    value: { x: 1 },
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  const updatedDetail: LDEvaluationDetailTyped<object> = {
+    value: { x: 2 },
+    variationIndex: 1,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.jsonVariationDetail as jest.Mock).mockReturnValue(initialDetail);
+
+  const Child = defineComponent({
+    setup() {
+      const d = useJsonVariationDetail('my-flag', {});
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe(JSON.stringify(initialDetail));
+
+  (client.jsonVariationDetail as jest.Mock).mockReturnValue(updatedDetail);
+  controls.emitChange('my-flag');
+  await nextTick();
+
+  expect(wrapper.text()).toBe(JSON.stringify(updatedDetail));
+});
+
+it('useJsonVariationDetail re-evaluates when context changes after identify', async () => {
+  const { client, controls } = makeMockClient();
+  (client.jsonVariationDetail as jest.Mock).mockReturnValue({
+    value: { a: 1 },
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  });
+
+  const Child = defineComponent({
+    setup() {
+      useJsonVariationDetail('my-flag', {});
+      return () => h('div');
+    },
+  });
+
+  mountUnderProvider(client, Child);
+  const callsBefore = (client.jsonVariationDetail as jest.Mock).mock.calls.length;
+
+  controls.emitContextChange({ kind: 'user', key: 'new-user' });
+  await nextTick();
+
+  expect((client.jsonVariationDetail as jest.Mock).mock.calls.length).toBe(callsBefore + 1);
+});
+
+it('useJsonVariationDetail returns CLIENT_NOT_READY detail when not ready', () => {
+  const { client } = makeMockClient({ ready: false, initializedState: 'initializing' });
+  const defaultValue = { enabled: false };
+
+  const Child = defineComponent({
+    setup() {
+      const d = useJsonVariationDetail('my-flag', defaultValue);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+
+  expect(client.jsonVariationDetail).not.toHaveBeenCalled();
+  const rendered = JSON.parse(wrapper.text()) as LDEvaluationDetailTyped<object>;
+  expect(rendered.value).toEqual(defaultValue);
+  expect(rendered.variationIndex).toBeNull();
+  expect(rendered.reason).toEqual(NOT_READY_REASON);
+});
+
+// reactive key re-subscription (one test per composable, covering the key change case)
+
+it('useBoolVariationDetail re-evaluates and re-subscribes when key changes', async () => {
+  const { client, controls } = makeMockClient();
+  const detailA: LDEvaluationDetailTyped<boolean> = {
+    value: false,
+    variationIndex: 0,
+    reason: { kind: 'OFF' },
+  };
+  const detailB: LDEvaluationDetailTyped<boolean> = {
+    value: true,
+    variationIndex: 1,
+    reason: { kind: 'FALLTHROUGH' },
+  };
+  (client.boolVariationDetail as jest.Mock).mockImplementation((k: string, _def: boolean) => {
+    if (k === 'flag-a') return detailA;
+    if (k === 'flag-b') return detailB;
+    return detailA;
+  });
+
+  const flagKey = ref('flag-a');
+
+  const Child = defineComponent({
+    setup() {
+      const d = useBoolVariationDetail(flagKey, false);
+      return () => h('div', JSON.stringify(d.value));
+    },
+  });
+
+  const wrapper = mountUnderProvider(client, Child);
+  expect(wrapper.text()).toBe(JSON.stringify(detailA));
+  expect(controls.handlerCount('change:flag-a')).toBe(1);
+
+  flagKey.value = 'flag-b';
+  await nextTick();
+
+  expect(wrapper.text()).toBe(JSON.stringify(detailB));
+  expect(controls.handlerCount('change:flag-a')).toBe(0);
+  expect(controls.handlerCount('change:flag-b')).toBe(1);
+});

--- a/packages/sdk/vue/__tests__/client/mockClient.ts
+++ b/packages/sdk/vue/__tests__/client/mockClient.ts
@@ -25,15 +25,15 @@ export function makeMockClient(initial?: {
   let boolValue = initial?.boolValue ?? true;
   let initError: Error | undefined;
 
-  const handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
   const initStatusSubs = new Set<(r: { status: string; error?: Error }) => void>();
   const contextSubs = new Set<(c: unknown) => void>();
 
   const addHandler = (event: string, h: (...args: unknown[]) => void) => {
     if (!handlers.has(event)) {
-      handlers.set(event, new Set());
+      handlers.set(event, []);
     }
-    handlers.get(event)!.add(h);
+    handlers.get(event)!.push(h);
   };
 
   const notReadyDetail = <T>(def: T): LDEvaluationDetailTyped<T> => ({
@@ -71,7 +71,13 @@ export function makeMockClient(initial?: {
     start: jest.fn(),
     close: jest.fn(),
     on: jest.fn((event: string, h: (...args: unknown[]) => void) => addHandler(event, h)),
-    off: jest.fn((event: string, h: (...args: unknown[]) => void) => handlers.get(event)?.delete(h)),
+    off: jest.fn((event: string, h: (...args: unknown[]) => void) => {
+      const arr = handlers.get(event);
+      if (arr) {
+        const idx = arr.indexOf(h);
+        if (idx !== -1) arr.splice(idx, 1);
+      }
+    }),
   };
 
   const controls: MockControls = {
@@ -80,9 +86,9 @@ export function makeMockClient(initial?: {
     },
     emitChange: (key: string) =>
       handlers.get(`change:${key}`)?.forEach((h) => h({ kind: 'user', key: 'context-key' })),
-    handlerCount: (event: string) => handlers.get(event)?.size ?? 0,
+    handlerCount: (event: string) => handlers.get(event)?.length ?? 0,
     emitInitStatus: (r: { status: string; error?: Error }) => {
-      ready = true;
+      ready = r.status !== 'initializing';
       initializedState = r.status;
       initError = r.error;
       initStatusSubs.forEach((cb) => cb(r));

--- a/packages/sdk/vue/__tests__/plugin.test.ts
+++ b/packages/sdk/vue/__tests__/plugin.test.ts
@@ -3,7 +3,7 @@
  */
 import { createApp, defineComponent, h, nextTick } from 'vue';
 
-import { useInitializationStatus, useLDClient } from '../src/client/composables';
+import { useBoolVariation, useInitializationStatus, useLDClient } from '../src/client/composables';
 import { createLDVueInstanceKey } from '../src/client/provider/LDVueContext';
 import { LDVuePlugin, type LDVuePluginOptions } from '../src/plugin';
 import { makeMockClient } from './client/mockClient';
@@ -139,5 +139,25 @@ it('provides via a custom injection key when specified', () => {
   expect(injected).toBe(client);
 });
 
-// TODO(scaffold): variation composable integration test (useBoolVariation under the plugin)
-// arrives in the next PR with the full composable layer.
+it('evaluates flags via useBoolVariation under the plugin', () => {
+  const { client } = makeMockClient({ boolValue: true });
+  createClientMock.mockReturnValue(client);
+
+  let flagValue: boolean | undefined;
+  const Child = defineComponent({
+    setup() {
+      const flag = useBoolVariation('my-flag', false);
+      return () => {
+        flagValue = flag.value;
+        return h('div');
+      };
+    },
+  });
+
+  const app = createApp(Child);
+  app.use(LDVuePlugin, { clientSideID: 'env-id', context: { kind: 'user', key: 'k' } });
+  app.mount(document.createElement('div'));
+
+  expect(flagValue).toBe(true);
+  expect(client.boolVariation).toHaveBeenCalledWith('my-flag', false);
+});

--- a/packages/sdk/vue/src/client/composables/index.ts
+++ b/packages/sdk/vue/src/client/composables/index.ts
@@ -1,3 +1,14 @@
 export { useLDClient } from './useLDClient';
 export { useInitializationStatus } from './useInitializationStatus';
-// TODO(scaffold): variation composables (useBoolVariation, useStringVariation, etc.) arrive in the next PR
+export {
+  useBoolVariation,
+  useStringVariation,
+  useNumberVariation,
+  useJsonVariation,
+} from './useVariation';
+export {
+  useBoolVariationDetail,
+  useStringVariationDetail,
+  useNumberVariationDetail,
+  useJsonVariationDetail,
+} from './useVariationDetail';

--- a/packages/sdk/vue/src/client/composables/useVariation.ts
+++ b/packages/sdk/vue/src/client/composables/useVariation.ts
@@ -1,0 +1,84 @@
+import type { MaybeRefOrGetter, InjectionKey, Ref } from 'vue';
+
+import type { LDVueInstance } from '../LDClient';
+import { useVariationCore } from './useVariationCore';
+
+/**
+ * Reactively evaluates a boolean feature flag.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated as a boolean
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useBoolVariation(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: boolean,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<boolean>> {
+  return useVariationCore(
+    key,
+    defaultValue,
+    (client, k, def) => client.boolVariation(k, def),
+    injectionKey,
+  );
+}
+
+/**
+ * Reactively evaluates a string feature flag.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated as a string
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useStringVariation(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: string,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<string>> {
+  return useVariationCore(
+    key,
+    defaultValue,
+    (client, k, def) => client.stringVariation(k, def),
+    injectionKey,
+  );
+}
+
+/**
+ * Reactively evaluates a numeric feature flag.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated as a number
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useNumberVariation(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: number,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<number>> {
+  return useVariationCore(
+    key,
+    defaultValue,
+    (client, k, def) => client.numberVariation(k, def),
+    injectionKey,
+  );
+}
+
+/**
+ * Reactively evaluates a JSON feature flag.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useJsonVariation<T = unknown>(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: T,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<T>> {
+  return useVariationCore(
+    key,
+    defaultValue,
+    (client, k, def) => client.jsonVariation(k, def) as T,
+    injectionKey,
+  );
+}

--- a/packages/sdk/vue/src/client/composables/useVariationCore.ts
+++ b/packages/sdk/vue/src/client/composables/useVariationCore.ts
@@ -2,6 +2,7 @@ import {
   onScopeDispose,
   readonly,
   ref,
+  shallowRef,
   toValue,
   watch,
   type InjectionKey,
@@ -16,11 +17,9 @@ import { injectLDVueInstance } from './useLDClient';
  * Shared core for the variation composables. Evaluates a flag and keeps the returned ref in sync.
  *
  * @remarks
- * The flag key may be a plain string, a ref, or a getter, so callers can drive a reactive key. The
- * value is re-evaluated when: the flag changes (`change:<key>` event), the key changes, the context
- * changes (after `identify()`), or the client becomes ready. The base SDK emits `change:<key>` with
- * the context (not the new value), so we always re-evaluate via the client rather than reading an
- * event payload.
+ * Re-evaluates when the flag changes (`change:<key>` event), the key changes, the context changes
+ * (after `identify()`), or the client becomes ready. The base SDK emits `change:<key>` with the
+ * context, not the new value, so we always call the client rather than reading the event payload.
  *
  * @internal
  */
@@ -46,14 +45,15 @@ export function useVariationCore<T, R = T>(
   };
 
   let currentKey = toValue(key);
+
+  const flagChanged = shallowRef(0);
   const changeHandler = () => {
-    update();
+    flagChanged.value += 1;
   };
   client.on(`change:${currentKey}`, changeHandler);
 
-  // Re-subscribe when the key changes; re-evaluate when the key, context, or readiness changes.
-  // Both the change-event handler and the context watch may call evaluate() on a single identify().
-  const stop = watch([() => toValue(key), context, initializedState], ([newKey]) => {
+  // Batch all synchronous source mutations into one watch run.
+  const stop = watch([() => toValue(key), context, initializedState, flagChanged], ([newKey]) => {
     if (newKey !== currentKey) {
       client.off(`change:${currentKey}`, changeHandler);
       currentKey = newKey;

--- a/packages/sdk/vue/src/client/composables/useVariationCore.ts
+++ b/packages/sdk/vue/src/client/composables/useVariationCore.ts
@@ -1,0 +1,71 @@
+import {
+  onScopeDispose,
+  readonly,
+  ref,
+  toValue,
+  watch,
+  type InjectionKey,
+  type MaybeRefOrGetter,
+  type Ref,
+} from 'vue';
+
+import type { LDVueClient, LDVueInstance } from '../LDClient';
+import { injectLDVueInstance } from './useLDClient';
+
+/**
+ * Shared core for the variation composables. Evaluates a flag and keeps the returned ref in sync.
+ *
+ * @remarks
+ * The flag key may be a plain string, a ref, or a getter, so callers can drive a reactive key. The
+ * value is re-evaluated when: the flag changes (`change:<key>` event), the key changes, the context
+ * changes (after `identify()`), or the client becomes ready. The base SDK emits `change:<key>` with
+ * the context (not the new value), so we always re-evaluate via the client rather than reading an
+ * event payload.
+ *
+ * @internal
+ */
+export function useVariationCore<T, R = T>(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: T,
+  evaluate: (client: LDVueClient, key: string, defaultValue: T) => R,
+  injectionKey?: InjectionKey<LDVueInstance>,
+  notReadyDefault?: (defaultValue: T) => R,
+): Readonly<Ref<R>> {
+  const { client, context, initializedState } = injectLDVueInstance(injectionKey);
+
+  const evaluateValue = (): R => {
+    if (client.isReady()) {
+      return evaluate(client, toValue(key), defaultValue);
+    }
+    return notReadyDefault ? notReadyDefault(defaultValue) : (defaultValue as unknown as R);
+  };
+
+  const valueRef = ref(evaluateValue()) as Ref<R>;
+  const update = () => {
+    valueRef.value = evaluateValue();
+  };
+
+  let currentKey = toValue(key);
+  const changeHandler = () => {
+    update();
+  };
+  client.on(`change:${currentKey}`, changeHandler);
+
+  // Re-subscribe when the key changes; re-evaluate when the key, context, or readiness changes.
+  // Both the change-event handler and the context watch may call evaluate() on a single identify().
+  const stop = watch([() => toValue(key), context, initializedState], ([newKey]) => {
+    if (newKey !== currentKey) {
+      client.off(`change:${currentKey}`, changeHandler);
+      currentKey = newKey;
+      client.on(`change:${currentKey}`, changeHandler);
+    }
+    update();
+  });
+
+  onScopeDispose(() => {
+    client.off(`change:${currentKey}`, changeHandler);
+    stop();
+  });
+
+  return readonly(valueRef) as Readonly<Ref<R>>;
+}

--- a/packages/sdk/vue/src/client/composables/useVariationDetail.ts
+++ b/packages/sdk/vue/src/client/composables/useVariationDetail.ts
@@ -1,0 +1,102 @@
+import type { LDEvaluationDetailTyped } from '@launchdarkly/js-client-sdk';
+import type { InjectionKey, MaybeRefOrGetter, Ref } from 'vue';
+
+import type { LDVueInstance } from '../LDClient';
+import { useVariationCore } from './useVariationCore';
+
+/**
+ * Returns an evaluation detail with the default value and a CLIENT_NOT_READY error reason, used
+ * before the client is ready.
+ */
+function notReadyDetail<T>(def: T): LDEvaluationDetailTyped<T> {
+  return {
+    value: def,
+    variationIndex: null,
+    reason: { kind: 'ERROR', errorKind: 'CLIENT_NOT_READY' },
+  };
+}
+
+/**
+ * Reactively evaluates a boolean feature flag and exposes the full evaluation detail (value,
+ * variationIndex, reason). Reasons are populated only when `withReasons` is enabled.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useBoolVariationDetail(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: boolean,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<LDEvaluationDetailTyped<boolean>>> {
+  return useVariationCore<boolean, LDEvaluationDetailTyped<boolean>>(
+    key,
+    defaultValue,
+    (client, k, def) => client.boolVariationDetail(k, def),
+    injectionKey,
+    notReadyDetail,
+  );
+}
+
+/**
+ * Reactively evaluates a string feature flag and exposes the full evaluation detail.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useStringVariationDetail(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: string,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<LDEvaluationDetailTyped<string>>> {
+  return useVariationCore<string, LDEvaluationDetailTyped<string>>(
+    key,
+    defaultValue,
+    (client, k, def) => client.stringVariationDetail(k, def),
+    injectionKey,
+    notReadyDetail,
+  );
+}
+
+/**
+ * Reactively evaluates a numeric feature flag and exposes the full evaluation detail.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useNumberVariationDetail(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: number,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<LDEvaluationDetailTyped<number>>> {
+  return useVariationCore<number, LDEvaluationDetailTyped<number>>(
+    key,
+    defaultValue,
+    (client, k, def) => client.numberVariationDetail(k, def),
+    injectionKey,
+    notReadyDetail,
+  );
+}
+
+/**
+ * Reactively evaluates a JSON feature flag and exposes the full evaluation detail.
+ *
+ * @param key the feature flag key (plain, ref, or getter)
+ * @param defaultValue value returned while the flag loads or if it cannot be evaluated
+ * @param injectionKey optional injection key for multiple environments @see {@link createLDVueInstanceKey}
+ */
+export function useJsonVariationDetail<T = unknown>(
+  key: MaybeRefOrGetter<string>,
+  defaultValue: T,
+  injectionKey?: InjectionKey<LDVueInstance>,
+): Readonly<Ref<LDEvaluationDetailTyped<T>>> {
+  return useVariationCore<T, LDEvaluationDetailTyped<T>>(
+    key,
+    defaultValue,
+    (client, k, def) => client.jsonVariationDetail(k, def) as LDEvaluationDetailTyped<T>,
+    injectionKey,
+    notReadyDetail,
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New public API on the flag evaluation path affects when impressions fire and how apps render before init; behavior is heavily tested but mistakes could skew analytics or UI gating.
> 
> **Overview**
> Adds the Vue SDK’s **reactive flag evaluation layer**: typed composables for bool/string/number/JSON flags plus matching `*VariationDetail` helpers, all built on a shared **`useVariationCore`** that wires into the existing provider injection.
> 
> **`useVariationCore`** keeps a readonly ref in sync by calling the client when ready (otherwise defaults or synthetic `CLIENT_NOT_READY` detail), listening on `change:<key>`, and re-running when the flag key, context after `identify()`, or initialization state changes. A batched `watch` is meant to collapse simultaneous `change:<key>` and context updates into **one** evaluation per identify (guarded by tests for duplicate impressions). Listeners are swapped when the key is reactive and removed on scope dispose.
> 
> Public exports move from the prior scaffold TODO to **`composables/index`**. Tests cover provider/plugin integration, lifecycle, and typed behavior; **`makeMockClient`** now tracks handlers in arrays with correct `off` and sets `ready` from init status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1d9cec70f946a3a0ecee8d178ac8c6f31264a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->