### PR TITLE
feat: implements _template methods for fetching non-interpolated config

### DIFF
--- a/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
+++ b/packages/sdk/server-ai/__tests__/LDAIClientImpl.test.ts
@@ -1100,3 +1100,211 @@ describe('tools map support', () => {
     expect(result.tools).toBeUndefined();
   });
 });
+
+describe('template methods', () => {
+  it('completionConfigTemplate preserves Mustache placeholders in messages', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-flag';
+    const defaultValue: LDAICompletionConfigDefault = { enabled: false };
+
+    const mockVariation = {
+      model: { name: 'gpt-4' },
+      provider: { name: 'openai' },
+      messages: [
+        { role: 'system', content: 'Hello {{name}}' },
+        { role: 'user', content: 'Score: {{score}}' },
+      ],
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'completion' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.completionConfigTemplate(key, testContext, defaultValue);
+
+    expect(result.messages).toEqual([
+      { role: 'system', content: 'Hello {{name}}' },
+      { role: 'user', content: 'Score: {{score}}' },
+    ]);
+    expect(result.enabled).toBe(true);
+    expect(result.createTracker).toBeDefined();
+  });
+
+  it('completionConfigTemplate emits the correct usage tracking event', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-flag';
+
+    const mockVariation = {
+      messages: [{ role: 'system', content: 'Hello {{name}}' }],
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'completion' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    await client.completionConfigTemplate(key, testContext);
+
+    expect(mockLdClient.track).toHaveBeenCalledWith(
+      '$ld:ai:usage:completion-config-template',
+      testContext,
+      key,
+      1,
+    );
+  });
+
+  it('completionConfigTemplate uses disabled default when no defaultValue is provided', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-flag';
+
+    const mockVariation = {
+      _ldMeta: { variationKey: 'v1', enabled: false, mode: 'completion' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.completionConfigTemplate(key, testContext);
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it('agentConfigTemplate preserves Mustache placeholders in instructions', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-agent';
+    const defaultValue: LDAIAgentConfigDefault = { enabled: false };
+
+    const mockVariation = {
+      model: { name: 'gpt-4' },
+      provider: { name: 'openai' },
+      instructions: 'You are a research assistant specializing in {{topic}}.',
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'agent' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.agentConfigTemplate(key, testContext, defaultValue);
+
+    expect(result.instructions).toBe('You are a research assistant specializing in {{topic}}.');
+    expect(result.enabled).toBe(true);
+    expect(result.createTracker).toBeDefined();
+  });
+
+  it('agentConfigTemplate emits the correct usage tracking event', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-agent';
+
+    const mockVariation = {
+      instructions: 'You are a {{role}}.',
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'agent' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    await client.agentConfigTemplate(key, testContext);
+
+    expect(mockLdClient.track).toHaveBeenCalledWith(
+      '$ld:ai:usage:agent-config-template',
+      testContext,
+      key,
+      1,
+    );
+  });
+
+  it('agentConfigTemplate uses disabled default when no defaultValue is provided', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-agent';
+
+    const mockVariation = {
+      _ldMeta: { variationKey: 'v1', enabled: false, mode: 'agent' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.agentConfigTemplate(key, testContext);
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it('judgeConfigTemplate preserves Mustache placeholders in messages', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-judge';
+    const defaultValue: LDAIJudgeConfigDefault = { enabled: false };
+
+    const mockVariation = {
+      model: { name: 'gpt-4' },
+      provider: { name: 'openai' },
+      evaluationMetricKey: 'relevance',
+      messages: [
+        { role: 'system', content: 'You are a judge evaluating {{criteria}}.' },
+        { role: 'user', content: 'Score: {{score}}' },
+      ],
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'judge' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.judgeConfigTemplate(key, testContext, defaultValue);
+
+    expect(result.messages).toEqual([
+      { role: 'system', content: 'You are a judge evaluating {{criteria}}.' },
+      { role: 'user', content: 'Score: {{score}}' },
+    ]);
+    expect(result.enabled).toBe(true);
+    expect(result.createTracker).toBeDefined();
+  });
+
+  it('judgeConfigTemplate emits the correct usage tracking event', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-judge';
+
+    const mockVariation = {
+      evaluationMetricKey: 'relevance',
+      messages: [{ role: 'system', content: 'You are a {{role}}.' }],
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'judge' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    await client.judgeConfigTemplate(key, testContext);
+
+    expect(mockLdClient.track).toHaveBeenCalledWith(
+      '$ld:ai:usage:judge-config-template',
+      testContext,
+      key,
+      1,
+    );
+  });
+
+  it('judgeConfigTemplate uses disabled default when no defaultValue is provided', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-judge';
+
+    const mockVariation = {
+      _ldMeta: { variationKey: 'v1', enabled: false, mode: 'judge' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.judgeConfigTemplate(key, testContext);
+
+    expect(result.enabled).toBe(false);
+  });
+
+  it('completionConfigTemplate does not apply ldctx interpolation', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-flag';
+
+    const mockVariation = {
+      messages: [{ role: 'system', content: 'User: {{ldctx.key}}' }],
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'completion' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.completionConfigTemplate(key, testContext);
+
+    expect(result.messages?.[0].content).toBe('User: {{ldctx.key}}');
+  });
+
+  it('agentConfigTemplate does not apply ldctx interpolation', async () => {
+    const client = new LDAIClientImpl(mockLdClient);
+    const key = 'test-agent';
+
+    const mockVariation = {
+      instructions: 'Context key: {{ldctx.key}}',
+      _ldMeta: { variationKey: 'v1', enabled: true, mode: 'agent' },
+    };
+    mockLdClient.variation.mockResolvedValue(mockVariation);
+
+    const result = await client.agentConfigTemplate(key, testContext);
+
+    expect(result.instructions).toBe('Context key: {{ldctx.key}}');
+  });
+});

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -37,11 +37,14 @@ import { aiSdkLanguage, aiSdkName, aiSdkVersion } from './sdkInfo';
  */
 const TRACK_SDK_INFO = '$ld:ai:sdk:info';
 const TRACK_USAGE_COMPLETION_CONFIG = '$ld:ai:usage:completion-config';
+const TRACK_USAGE_COMPLETION_CONFIG_TEMPLATE = '$ld:ai:usage:completion-config-template';
 const TRACK_USAGE_CREATE_CHAT = '$ld:ai:usage:create-chat';
 const TRACK_USAGE_CREATE_AGENT = '$ld:ai:usage:create-agent';
 const TRACK_USAGE_JUDGE_CONFIG = '$ld:ai:usage:judge-config';
+const TRACK_USAGE_JUDGE_CONFIG_TEMPLATE = '$ld:ai:usage:judge-config-template';
 const TRACK_USAGE_CREATE_JUDGE = '$ld:ai:usage:create-judge';
 const TRACK_USAGE_AGENT_CONFIG = '$ld:ai:usage:agent-config';
+const TRACK_USAGE_AGENT_CONFIG_TEMPLATE = '$ld:ai:usage:agent-config-template';
 const TRACK_USAGE_AGENT_CONFIGS = '$ld:ai:usage:agent-configs';
 const TRACK_USAGE_AGENT_GRAPH = '$ld:ai:usage:agent-graph';
 
@@ -84,6 +87,7 @@ export class LDAIClientImpl implements LDAIClient {
     variables?: Record<string, unknown>,
     graphKey?: string,
     defaultAiProvider?: SupportedAIProvider,
+    skipInterpolation: boolean = false,
   ): Promise<LDAIConfigKind> {
     const ldFlagValue = LDAIConfigUtils.toFlagValue(defaultValue, mode);
 
@@ -126,6 +130,10 @@ export class LDAIClientImpl implements LDAIClient {
     }
 
     const config = LDAIConfigUtils.fromFlagValue(key, value, trackerFactory, evaluator);
+
+    if (skipInterpolation) {
+      return config;
+    }
 
     // Apply variable interpolation (always needed for ldctx)
     return this._applyInterpolation(config, context, variables);
@@ -311,6 +319,62 @@ export class LDAIClientImpl implements LDAIClient {
       undefined,
       defaultAiProvider,
     );
+  }
+
+  async completionConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<LDAICompletionConfig> {
+    this._ldClient.track(TRACK_USAGE_COMPLETION_CONFIG_TEMPLATE, context, key, 1);
+    return (await this._evaluate(
+      key,
+      context,
+      defaultValue ?? disabledAIConfig,
+      'completion',
+      undefined,
+      undefined,
+      defaultAiProvider,
+      true,
+    )) as LDAICompletionConfig;
+  }
+
+  async agentConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIAgentConfigDefault,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<LDAIAgentConfig> {
+    this._ldClient.track(TRACK_USAGE_AGENT_CONFIG_TEMPLATE, context, key, 1);
+    return (await this._evaluate(
+      key,
+      context,
+      defaultValue ?? disabledAIConfig,
+      'agent',
+      undefined,
+      undefined,
+      defaultAiProvider,
+      true,
+    )) as LDAIAgentConfig;
+  }
+
+  async judgeConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIJudgeConfigDefault,
+  ): Promise<LDAIJudgeConfig> {
+    this._ldClient.track(TRACK_USAGE_JUDGE_CONFIG_TEMPLATE, context, key, 1);
+    return (await this._evaluate(
+      key,
+      context,
+      defaultValue ?? disabledAIConfig,
+      'judge',
+      undefined,
+      undefined,
+      undefined,
+      true,
+    )) as LDAIJudgeConfig;
   }
 
   async agentConfigs<const T extends readonly LDAIAgentRequestConfig[]>(

--- a/packages/sdk/server-ai/src/LDAIClientImpl.ts
+++ b/packages/sdk/server-ai/src/LDAIClientImpl.ts
@@ -87,7 +87,7 @@ export class LDAIClientImpl implements LDAIClient {
     variables?: Record<string, unknown>,
     graphKey?: string,
     defaultAiProvider?: SupportedAIProvider,
-    skipInterpolation: boolean = false,
+    interpolate: boolean = true,
   ): Promise<LDAIConfigKind> {
     const ldFlagValue = LDAIConfigUtils.toFlagValue(defaultValue, mode);
 
@@ -131,7 +131,7 @@ export class LDAIClientImpl implements LDAIClient {
 
     const config = LDAIConfigUtils.fromFlagValue(key, value, trackerFactory, evaluator);
 
-    if (skipInterpolation) {
+    if (!interpolate) {
       return config;
     }
 
@@ -336,7 +336,7 @@ export class LDAIClientImpl implements LDAIClient {
       undefined,
       undefined,
       defaultAiProvider,
-      true,
+      false,
     )) as LDAICompletionConfig;
   }
 
@@ -355,7 +355,7 @@ export class LDAIClientImpl implements LDAIClient {
       undefined,
       undefined,
       defaultAiProvider,
-      true,
+      false,
     )) as LDAIAgentConfig;
   }
 
@@ -373,7 +373,7 @@ export class LDAIClientImpl implements LDAIClient {
       undefined,
       undefined,
       undefined,
-      true,
+      false,
     )) as LDAIJudgeConfig;
   }
 

--- a/packages/sdk/server-ai/src/api/LDAIClient.ts
+++ b/packages/sdk/server-ai/src/api/LDAIClient.ts
@@ -68,6 +68,65 @@ export interface LDAIClient {
   ): Promise<LDAICompletionConfig>;
 
   /**
+   * Retrieves a completion AI Config with Mustache placeholders left intact (no interpolation).
+   * Useful for displaying prompt previews or storing templates for later rendering.
+   *
+   * @param key The key of the AI Config.
+   * @param context The LaunchDarkly context object.
+   * @param defaultValue Optional fallback when the configuration is not available from LaunchDarkly.
+   * When omitted or null, a disabled default is used.
+   *
+   * @returns An {@link LDAICompletionConfig} identical to {@link completionConfig} except that
+   * `messages[].content` strings are stored verbatim from the flag variation — Mustache
+   * placeholders such as `{{variable}}` are preserved.
+   */
+  completionConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAICompletionConfigDefault,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<LDAICompletionConfig>;
+
+  /**
+   * Retrieves an agent AI Config with Mustache placeholders left intact (no interpolation).
+   * Useful for auditing instruction templates or building UI previews.
+   *
+   * @param key The key of the AI Config agent.
+   * @param context The LaunchDarkly context object.
+   * @param defaultValue Optional fallback when the configuration is not available from LaunchDarkly.
+   * When omitted or null, a disabled default is used.
+   *
+   * @returns An {@link LDAIAgentConfig} identical to {@link agentConfig} except that
+   * the `instructions` string is stored verbatim from the flag variation — Mustache
+   * placeholders such as `{{topic}}` are preserved.
+   */
+  agentConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIAgentConfigDefault,
+    defaultAiProvider?: SupportedAIProvider,
+  ): Promise<LDAIAgentConfig>;
+
+  /**
+   * Retrieves a judge AI Config with Mustache placeholders left intact (no interpolation).
+   * Useful for auditing judge prompt templates.
+   *
+   * @param key The key of the Judge AI Config.
+   * @param context The LaunchDarkly context object.
+   * @param defaultValue Optional fallback when the configuration is not available from LaunchDarkly.
+   * When omitted or null, a disabled default is used.
+   *
+   * @returns An {@link LDAIJudgeConfig} identical to {@link judgeConfig} except that
+   * `messages[].content` strings are stored verbatim from the flag variation — Mustache
+   * placeholders are preserved.
+   */
+  judgeConfigTemplate(
+    key: string,
+    context: LDContext,
+    defaultValue?: LDAIJudgeConfigDefault,
+  ): Promise<LDAIJudgeConfig>;
+
+  /**
    * Retrieves and processes a single AI Config agent based on the provided key, LaunchDarkly context,
    * and variables. This includes the model configuration and the customized instructions.
    *


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.atlassian.net/jira/software/c/projects/AIC/boards/2045?selectedIssue=AIC-2843

**Describe the solution you've provided**

Implements three methods:
- `completionConfigTemplate`
- `agentConfigTemplate`
- `judgeConfigTemplate`

To mirror the base names. Each of these retrieves the config without running the interpolation process.

**Describe alternatives you've considered**

Alternatively users can use the base `.variation` method to retrieve the config, but then things like typing are foisted onto the consumer rather than the SDK itself. We're opting to add a method so that users still receive the niceties (tracker, types). 

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API on the server-ai SDK; existing interpolated config paths are unchanged and coverage is added for the new methods.
> 
> **Overview**
> Adds **`completionConfigTemplate`**, **`agentConfigTemplate`**, and **`judgeConfigTemplate`** on `LDAIClient` / `LDAIClientImpl` so callers can load typed AI configs (including `createTracker`) while keeping Mustache placeholders like `{{name}}` and `{{ldctx.key}}` verbatim—useful for previews, auditing, and storing templates for later rendering.
> 
> Evaluation is extended with an **`interpolate`** flag on `_evaluate`; template methods call it with `interpolate: false` and emit separate **`$ld:ai:usage:*-config-template`** tracking events. Existing `completionConfig` / `agentConfig` / `judgeConfig` behavior is unchanged.
> 
> Tests cover placeholder preservation, tracking, disabled defaults, and no `ldctx` substitution for completion and agent templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c93e6fbd382133d24a4aa972b98dc37b63e6e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->