### PR TITLE
feat: Add FDv2 data system support to NodeClient

### DIFF
--- a/.github/workflows/node-client.yml
+++ b/.github/workflows/node-client.yml
@@ -46,4 +46,12 @@ jobs:
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
+          stop_service: 'false'
           extra_params: '--skip-from=${{ github.workspace }}/packages/sdk/node-client/contract-tests/testharness-suppressions.txt'
+      - name: Run contract tests (FDv2)
+        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
+        with:
+          test_service_port: 8000
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v3.1.1-alpha.6
+          extra_params: '--skip-from=${{ github.workspace }}/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt'

--- a/.github/workflows/node-client.yml
+++ b/.github/workflows/node-client.yml
@@ -53,5 +53,6 @@ jobs:
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.1.1-alpha.6
+          version: v3
+          branch: v3
           extra_params: '--skip-from=${{ github.workspace }}/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt'

--- a/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
@@ -296,13 +296,13 @@ it('duplicate-mode setConnectionMode awaits an in-flight transition to the same 
     localStoragePath: tmpRoot,
   });
 
-  // Keeps the queue draining when p3 is issued, making the race deterministic.
+  // flush() must not reject during the offline leg so p1 does not poison the queue.
   const flushSpy = jest
     .spyOn(LDClientImpl.prototype, 'flush')
     .mockImplementation(() => Promise.resolve({ result: true }));
 
-  // p3 hits the idempotency guard because p2 sets _connectionMode synchronously,
-  // before p2's queued task runs. Without the await, p3 resolves too early.
+  // p3 queues behind p2; by the time p3's task runs, p2 has already committed
+  // _connectionMode to 'streaming', so the idempotency check fires and p3 no-ops.
   const p1 = client.setConnectionMode('offline');
   const p2 = client.setConnectionMode('streaming');
   const p3 = client.setConnectionMode('streaming');
@@ -348,9 +348,9 @@ it('setConnectionMode with an invalid mode logs a warning and does not delegate 
   expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid-mode'));
 });
 
-// ------ Mode rollback on failed transition ------
+// ------ Failed offline transition ------
 
-it('restores connection mode when an FDv2 offline transition task throws', async () => {
+it('setConnectionMode rejects and does not change connection mode when flush fails in FDv2', async () => {
   const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
     dataSystem: {},
     diagnosticOptOut: true,
@@ -358,25 +358,21 @@ it('restores connection mode when an FDv2 offline transition task throws', async
     logger,
     localStoragePath: tmpRoot,
   });
-  // flush() is the first async step, so a reject here means setConnectionMode
-  // on the data manager is never reached.
+  // flush() throws before _connectionMode is written or the data manager is notified.
   const flushSpy = jest
     .spyOn(LDClientImpl.prototype, 'flush')
     .mockRejectedValueOnce(new Error('flush failed'));
 
   await expect(client.setConnectionMode('offline')).rejects.toThrow('flush failed');
 
-  // The synchronously-set 'offline' is rolled back: the data manager is still
-  // streaming, so isOffline() reflects actual state.
   expect(client.getConnectionMode()).toBe('streaming');
   expect(client.isOffline()).toBe(false);
-  // The data manager was never told to go offline.
   expect(mockSetConnectionMode).not.toHaveBeenCalled();
 
   flushSpy.mockRestore();
 });
 
-it('keeps the FDv2 transition queue alive for subsequent calls after a failed transition', async () => {
+it('setConnectionMode queue stays alive after a failed offline transition in FDv2', async () => {
   const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
     dataSystem: {},
     diagnosticOptOut: true,
@@ -391,7 +387,7 @@ it('keeps the FDv2 transition queue alive for subsequent calls after a failed tr
   await expect(client.setConnectionMode('offline')).rejects.toThrow('flush failed');
   flushSpy.mockRestore();
 
-  // A subsequent transition must still work; the queue was not poisoned.
+  // task.catch() keeps _fdv2ConnectionModeQueue alive; the next call must succeed.
   await client.setConnectionMode('polling');
   expect(client.getConnectionMode()).toBe('polling');
   expect(mockSetConnectionMode).toHaveBeenCalledWith('polling');

--- a/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
@@ -56,6 +56,8 @@ jest.mock('@launchdarkly/js-client-sdk-common', () => ({
   }),
 }));
 
+import { LDClientImpl } from '@launchdarkly/js-client-sdk-common';
+
 import { createClient } from '../src';
 
 const DEFAULT_INITIAL_CONTEXT = { kind: 'user' as const, key: 'bob' };
@@ -285,6 +287,43 @@ it('setConnectionMode is a no-op when called with the current mode in FDv2', asy
   expect(client.getConnectionMode()).toBe('streaming');
 });
 
+it('duplicate-mode setConnectionMode awaits an in-flight transition to the same mode in FDv2', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+
+  // Make the offline transition's flush() defer to a later microtask so the
+  // offline -> streaming queue is still draining when the duplicate streaming
+  // call is issued. This exposes the early-return race deterministically.
+  const flushSpy = jest
+    .spyOn(LDClientImpl.prototype, 'flush')
+    .mockImplementation(() => Promise.resolve({ result: true }));
+
+  // Sequence: initial mode is 'streaming'. Go offline, then streaming, then
+  // streaming again (the duplicate). The third call's _connectionMode is already
+  // 'streaming' (set synchronously by the second call), so the idempotency guard
+  // fires. Without the await fix, p3 resolves before the second call's queued
+  // task has delegated 'streaming' to the data manager.
+  const p1 = client.setConnectionMode('offline');
+  const p2 = client.setConnectionMode('streaming');
+  const p3 = client.setConnectionMode('streaming');
+
+  // Awaiting only the duplicate call must guarantee the queued streaming
+  // transition has completed (mockSetConnectionMode called with 'streaming').
+  await p3;
+  expect(mockSetConnectionMode).toHaveBeenCalledWith('streaming');
+
+  await Promise.all([p1, p2]);
+  expect(client.getConnectionMode()).toBe('streaming');
+  expect(client.isOffline()).toBe(false);
+
+  flushSpy.mockRestore();
+});
+
 // ------ Post-close guard ------
 
 it('setConnectionMode after close is a no-op in FDv2', async () => {
@@ -314,4 +353,52 @@ it('setConnectionMode with an invalid mode logs a warning and does not delegate 
   await client.setConnectionMode('invalid-mode');
   expect(mockSetConnectionMode).not.toHaveBeenCalled();
   expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid-mode'));
+});
+
+// ------ Mode rollback on failed transition ------
+
+it('restores connection mode when an FDv2 offline transition task throws', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  // Force the queued offline transition task to throw by making flush() reject.
+  const flushSpy = jest
+    .spyOn(LDClientImpl.prototype, 'flush')
+    .mockRejectedValueOnce(new Error('flush failed'));
+
+  await expect(client.setConnectionMode('offline')).rejects.toThrow('flush failed');
+
+  // The synchronously-set 'offline' must be rolled back to the prior mode so
+  // isOffline() does not lie while the data manager is still streaming.
+  expect(client.getConnectionMode()).toBe('streaming');
+  expect(client.isOffline()).toBe(false);
+  // The data manager was never told to go offline.
+  expect(mockSetConnectionMode).not.toHaveBeenCalled();
+
+  flushSpy.mockRestore();
+});
+
+it('keeps the FDv2 transition queue alive for subsequent calls after a failed transition', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  const flushSpy = jest
+    .spyOn(LDClientImpl.prototype, 'flush')
+    .mockRejectedValueOnce(new Error('flush failed'));
+
+  await expect(client.setConnectionMode('offline')).rejects.toThrow('flush failed');
+  flushSpy.mockRestore();
+
+  // A subsequent transition must still work; the queue was not poisoned.
+  await client.setConnectionMode('polling');
+  expect(client.getConnectionMode()).toBe('polling');
+  expect(mockSetConnectionMode).toHaveBeenCalledWith('polling');
 });

--- a/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
@@ -296,24 +296,17 @@ it('duplicate-mode setConnectionMode awaits an in-flight transition to the same 
     localStoragePath: tmpRoot,
   });
 
-  // Make the offline transition's flush() defer to a later microtask so the
-  // offline -> streaming queue is still draining when the duplicate streaming
-  // call is issued. This exposes the early-return race deterministically.
+  // Keeps the queue draining when p3 is issued, making the race deterministic.
   const flushSpy = jest
     .spyOn(LDClientImpl.prototype, 'flush')
     .mockImplementation(() => Promise.resolve({ result: true }));
 
-  // Sequence: initial mode is 'streaming'. Go offline, then streaming, then
-  // streaming again (the duplicate). The third call's _connectionMode is already
-  // 'streaming' (set synchronously by the second call), so the idempotency guard
-  // fires. Without the await fix, p3 resolves before the second call's queued
-  // task has delegated 'streaming' to the data manager.
+  // p3 hits the idempotency guard because p2 sets _connectionMode synchronously,
+  // before p2's queued task runs. Without the await, p3 resolves too early.
   const p1 = client.setConnectionMode('offline');
   const p2 = client.setConnectionMode('streaming');
   const p3 = client.setConnectionMode('streaming');
 
-  // Awaiting only the duplicate call must guarantee the queued streaming
-  // transition has completed (mockSetConnectionMode called with 'streaming').
   await p3;
   expect(mockSetConnectionMode).toHaveBeenCalledWith('streaming');
 
@@ -365,15 +358,16 @@ it('restores connection mode when an FDv2 offline transition task throws', async
     logger,
     localStoragePath: tmpRoot,
   });
-  // Force the queued offline transition task to throw by making flush() reject.
+  // flush() is the first async step, so a reject here means setConnectionMode
+  // on the data manager is never reached.
   const flushSpy = jest
     .spyOn(LDClientImpl.prototype, 'flush')
     .mockRejectedValueOnce(new Error('flush failed'));
 
   await expect(client.setConnectionMode('offline')).rejects.toThrow('flush failed');
 
-  // The synchronously-set 'offline' must be rolled back to the prior mode so
-  // isOffline() does not lie while the data manager is still streaming.
+  // The synchronously-set 'offline' is rolled back: the data manager is still
+  // streaming, so isOffline() reflects actual state.
   expect(client.getConnectionMode()).toBe('streaming');
   expect(client.isOffline()).toBe(false);
   // The data manager was never told to go offline.

--- a/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
+++ b/packages/sdk/node-client/__tests__/NodeClientFDv2.test.ts
@@ -1,0 +1,317 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import NodeCrypto from '../src/platform/NodeCrypto';
+import NodeEncoding from '../src/platform/NodeEncoding';
+import NodeInfo from '../src/platform/NodeInfo';
+import { resetNodeStorage } from '../src/platform/NodeStorage';
+import { createMockLogger } from './testHelpers';
+
+jest.mock('../src/platform/NodePlatform', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    crypto: new NodeCrypto(),
+    info: new NodeInfo(),
+    requests: {
+      createEventSource: jest.fn(),
+      fetch: jest.fn(),
+      getEventSourceCapabilities: jest.fn(),
+    },
+    encoding: new NodeEncoding(),
+    storage: {
+      clear: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
+    },
+  })),
+}));
+
+// Tracks the mode last passed to the mock FDv2 data manager's setConnectionMode.
+// Seeded from opts.foregroundMode when createFDv2DataManagerBase is called.
+// Used only to verify delegation; NodeClient now tracks requested mode itself.
+let mockCurrentMode = 'streaming';
+
+// Captures the opts passed to createFDv2DataManagerBase so tests can invoke
+// buildQueryParams directly.
+let capturedFDv2Opts:
+  | { buildQueryParams: (opts?: { hash?: string }) => { key: string; value: string }[] }
+  | undefined;
+
+const mockSetConnectionMode = jest.fn((mode: string) => {
+  mockCurrentMode = mode;
+});
+
+jest.mock('@launchdarkly/js-client-sdk-common', () => ({
+  ...jest.requireActual('@launchdarkly/js-client-sdk-common'),
+  createFDv2DataManagerBase: jest.fn((opts: any) => {
+    capturedFDv2Opts = opts;
+    mockCurrentMode = opts.foregroundMode ?? 'streaming';
+    return {
+      identify: jest.fn(),
+      close: jest.fn(),
+      setConnectionMode: mockSetConnectionMode,
+      getCurrentMode: () => mockCurrentMode,
+    };
+  }),
+}));
+
+import { createClient } from '../src';
+
+const DEFAULT_INITIAL_CONTEXT = { kind: 'user' as const, key: 'bob' };
+let tmpRoot: string;
+let logger: ReturnType<typeof createMockLogger>;
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  capturedFDv2Opts = undefined;
+  mockCurrentMode = 'streaming';
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'node-client-fdv2-test-'));
+  resetNodeStorage();
+  logger = createMockLogger();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+it('setConnectionMode does not throw in FDv2 mode', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  await expect(client.setConnectionMode('offline')).resolves.toBeUndefined();
+});
+
+it('getConnectionMode returns the mode set via setConnectionMode in FDv2 mode', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  await client.setConnectionMode('offline');
+  expect(client.getConnectionMode()).toBe('offline');
+  expect(client.isOffline()).toBe(true);
+});
+
+it('isOffline returns false after switching back to streaming in FDv2 mode', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  await client.setConnectionMode('offline');
+  await client.setConnectionMode('streaming');
+  expect(client.getConnectionMode()).toBe('streaming');
+  expect(client.isOffline()).toBe(false);
+});
+
+it('setConnectionMode delegates to the FDv2 data manager', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  await client.setConnectionMode('offline');
+  expect(mockSetConnectionMode).toHaveBeenCalledWith('offline');
+});
+
+// ------ FDv2 initial mode reconciliation ------
+
+it('isOffline returns true initially when FDv2 dataSystem configures offline mode', () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: { automaticModeSwitching: { type: 'manual', initialConnectionMode: 'offline' } },
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(client.isOffline()).toBe(true);
+  expect(client.getConnectionMode()).toBe('offline');
+});
+
+it('getConnectionMode reflects FDv2 manual polling mode at construction', () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: { automaticModeSwitching: { type: 'manual', initialConnectionMode: 'polling' } },
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(client.getConnectionMode()).toBe('polling');
+  expect(client.isOffline()).toBe(false);
+});
+
+// ------ buildQueryParams coverage ------
+
+it('buildQueryParams returns [] in FDv2 mobile key mode', () => {
+  createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams()).toEqual([]);
+});
+
+it('buildQueryParams ignores and warns when per-identify hash is set in FDv2 mobile key mode', () => {
+  createClient('mobile-key-123', DEFAULT_INITIAL_CONTEXT, {
+    useMobileKey: true,
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams({ hash: 'should-not-leak' })).toEqual([]);
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('hash'));
+});
+
+it('buildQueryParams returns auth param in FDv2 client-side ID mode', () => {
+  createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams()).toEqual([{ key: 'auth', value: 'client-side-id' }]);
+});
+
+it('buildQueryParams includes hash param when hash is set in client-side ID mode', () => {
+  createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    hash: 'secure-hash-abc',
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams()).toEqual([
+    { key: 'auth', value: 'client-side-id' },
+    { key: 'h', value: 'secure-hash-abc' },
+  ]);
+});
+
+it('buildQueryParams per-identify hash overrides construction-time hash in FDv2', () => {
+  createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    hash: 'construction-hash',
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams({ hash: 'per-identify-hash' })).toEqual([
+    { key: 'auth', value: 'client-side-id' },
+    { key: 'h', value: 'per-identify-hash' },
+  ]);
+});
+
+it('buildQueryParams uses construction-time hash when no per-identify hash is provided in FDv2', () => {
+  createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    hash: 'construction-hash',
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  expect(capturedFDv2Opts).toBeDefined();
+  expect(capturedFDv2Opts!.buildQueryParams({})).toEqual([
+    { key: 'auth', value: 'client-side-id' },
+    { key: 'h', value: 'construction-hash' },
+  ]);
+});
+
+// ------ Concurrent setConnectionMode serialization ------
+
+it('concurrent setConnectionMode calls are serialized in call order', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  // Fire offline then streaming concurrently. Without serialization the offline
+  // branch's await flush() lets streaming complete first, reversing the order.
+  const p1 = client.setConnectionMode('offline');
+  const p2 = client.setConnectionMode('streaming');
+  await Promise.all([p1, p2]);
+  // Serialization ensures the calls execute in issue order: offline then streaming.
+  expect(mockSetConnectionMode.mock.calls).toEqual([['offline'], ['streaming']]);
+  expect(client.getConnectionMode()).toBe('streaming');
+  expect(client.isOffline()).toBe(false);
+});
+
+// ------ Idempotency ------
+
+it('setConnectionMode is a no-op when called with the current mode in FDv2', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  // Initial mode is streaming; calling streaming again should be a no-op.
+  await client.setConnectionMode('streaming');
+  expect(mockSetConnectionMode).not.toHaveBeenCalled();
+  expect(client.getConnectionMode()).toBe('streaming');
+});
+
+// ------ Post-close guard ------
+
+it('setConnectionMode after close is a no-op in FDv2', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  await client.close();
+  await client.setConnectionMode('offline');
+  expect(mockSetConnectionMode).not.toHaveBeenCalled();
+});
+
+// ------ Invalid mode validation ------
+
+it('setConnectionMode with an invalid mode logs a warning and does not delegate in FDv2', async () => {
+  const client = createClient('client-side-id', DEFAULT_INITIAL_CONTEXT, {
+    dataSystem: {},
+    diagnosticOptOut: true,
+    sendEvents: false,
+    logger,
+    localStoragePath: tmpRoot,
+  });
+  // @ts-ignore testing JS callers passing an invalid value
+  await client.setConnectionMode('invalid-mode');
+  expect(mockSetConnectionMode).not.toHaveBeenCalled();
+  expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid-mode'));
+});

--- a/packages/sdk/node-client/contract-tests/src/index.ts
+++ b/packages/sdk/node-client/contract-tests/src/index.ts
@@ -39,6 +39,10 @@ app.get('/', (req: Request, res: Response) => {
       'tls:skip-verify-peer',
       'tls:custom-ca',
       'wrapper',
+      'client-event-source-http-errors',
+      // NOTE: this needs additional fixes to the shared
+      // SDK code to support
+      // 'fdv1-fallback',
     ],
   });
 });

--- a/packages/sdk/node-client/contract-tests/src/index.ts
+++ b/packages/sdk/node-client/contract-tests/src/index.ts
@@ -23,6 +23,7 @@ app.get('/', (req: Request, res: Response) => {
   res.json({
     capabilities: [
       'client-side',
+      'mobile',
       'service-endpoints',
       'tags',
       'user-type',

--- a/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
+++ b/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
@@ -94,6 +94,7 @@ function makeSdkConfig(options: SDKConfigParams, tag: string): LDOptions {
     withReasons: options.clientSide.evaluationReasons,
     useReport: options.clientSide.useReport ?? undefined,
     disableCache: true,
+    useMobileKey: true,
   };
 
   if (options.serviceEndpoints) {

--- a/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
+++ b/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
@@ -5,3 +5,8 @@ streaming/fdv2/reconnection state management/saves previously known state
 streaming/fdv2/reconnection state management/replaces previously known state
 streaming/fdv2/reconnection state management/updates previously known state
 streaming/fdv2/can discard partial events on errors
+
+# Looks like an issue in the test harness where client SDKs are assumed to have a
+# one-shot polling connection established before establishing a streaming connection.
+# Will need to investigate more, but manual testing seems fine.
+wrapper/stream requests/wrapper name and version

--- a/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
+++ b/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
@@ -6,7 +6,10 @@ streaming/fdv2/reconnection state management/replaces previously known state
 streaming/fdv2/reconnection state management/updates previously known state
 streaming/fdv2/can discard partial events on errors
 
-# Looks like an issue in the test harness where client SDKs are assumed to have a
-# one-shot polling connection established before establishing a streaming connection.
-# Will need to investigate more, but manual testing seems fine.
+# The harness adds a secondary SDKDataSystem for all client-side SDKs in the streaming
+# wrapper test (to satisfy the poll-before-stream assumption). Both data systems share the
+# same "streaming" connection mode name, so the secondary's Configure call overwrites the
+# primary's endpoints in the entity config. The SDK correctly connects to the secondary's
+# endpoints, but the test checks the primary's Synchronizers[0] endpoint which never
+# receives a request. This is a harness-level design issue; the SDK behavior is correct.
 wrapper/stream requests/wrapper name and version

--- a/packages/sdk/node-client/src/LDCommon.ts
+++ b/packages/sdk/node-client/src/LDCommon.ts
@@ -49,3 +49,8 @@ export type {
   LDWaitForInitializationFailed,
   LDWaitForInitializationTimeout,
 } from '@launchdarkly/js-client-sdk-common';
+
+/**
+ * The subset of FDv2 connection modes supported by the Node.js client SDK.
+ */
+export type FDv2ConnectionMode = 'streaming' | 'polling' | 'offline';

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -36,15 +36,13 @@ import NodePlatform from './platform/NodePlatform';
 
 export class NodeClient extends LDClientImpl {
   private readonly _plugins: LDPlugin[];
-  // Tracks the current connection mode for both FDv1 (NodeDataManager) and
-  // FDv2 paths. Updated synchronously so getConnectionMode()/isOffline()
-  // reflect the caller's intent without waiting for async data manager work.
+  // Connection mode for both paths. FDv2 updates this inside the
+  // serialized queue task; FDv1 reads it back from the data manager after each
+  // transition.
   private _connectionMode: ConnectionMode;
-  // Serializes FDv2 connection-mode transitions so concurrent calls cannot
-  // reorder flush/event-sending around the await in the offline branch.
+  // Serializes FDv2 mode transitions so concurrent callers cannot interleave
+  // flush() and setEventSendingEnabled() across the offline branch's await.
   private _fdv2ConnectionModeQueue: Promise<void> = Promise.resolve();
-  // Set to true when close() is called so post-close setConnectionMode calls
-  // are no-ops in the FDv2 path.
   private _closed: boolean = false;
 
   constructor(envKey: string, initialContext: LDContext, options: NodeOptions = {}) {
@@ -180,8 +178,7 @@ export class NodeClient extends LDClientImpl {
 
   async setConnectionMode(mode: ConnectionMode): Promise<void> {
     if (this.isFDv2) {
-      // Validate mode before forwarding to prevent a runtime crash inside the
-      // debounce timer when an invalid value is passed from JavaScript.
+      // JS callers can pass arbitrary strings; validate before the debounce timer fires.
       if (mode !== 'offline' && mode !== 'streaming' && mode !== 'polling') {
         this.logger.warn(`[NodeClient] Unknown connection mode "${mode}", ignoring.`);
         return;
@@ -189,41 +186,22 @@ export class NodeClient extends LDClientImpl {
       if (this._closed) {
         return;
       }
-      if (mode === this._connectionMode) {
-        // Await without appending: an earlier call may still be transitioning to
-        // this same mode, and we must not resolve until it has finished.
-        await this._fdv2ConnectionModeQueue;
-        return;
-      }
-      // Without serialization, concurrent calls can interleave flush() and
-      // setEventSendingEnabled() across an offline await, corrupting order.
-      // Capture the prior mode so a failed transition can be rolled back:
-      // otherwise isOffline()/getConnectionMode() would report a state the
-      // data manager never actually entered.
-      const previousMode = this._connectionMode;
-      this._connectionMode = mode;
       const task = this._fdv2ConnectionModeQueue.then(async () => {
         // Re-check: close() may have been called while this task was queued.
         if (this._closed) {
           return;
         }
-        try {
-          if (mode === 'offline') {
-            await this.flush();
-            this.setEventSendingEnabled(false, false);
-          }
-          (this.dataManager as FDv2DataManagerControl).setConnectionMode(mode);
-          if (mode !== 'offline') {
-            this.setEventSendingEnabled(true, false);
-          }
-        } catch (e) {
-          // Only roll back if no later queued task has already moved past this
-          // mode; otherwise isOffline()/getConnectionMode() would drift from
-          // the state the data manager actually reached.
-          if (this._connectionMode === mode) {
-            this._connectionMode = previousMode;
-          }
-          throw e;
+        if (mode === this._connectionMode) {
+          return;
+        }
+        if (mode === 'offline') {
+          await this.flush();
+          this.setEventSendingEnabled(false, false);
+        }
+        (this.dataManager as FDv2DataManagerControl).setConnectionMode(mode);
+        this._connectionMode = mode;
+        if (mode !== 'offline') {
+          this.setEventSendingEnabled(true, false);
         }
       });
       this._fdv2ConnectionModeQueue = task.catch(() => {});

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -3,6 +3,11 @@ import {
   browserFdv1Endpoints,
   Configuration,
   ConnectionMode,
+  createDefaultSourceFactoryProvider,
+  createFDv2DataManagerBase,
+  DESKTOP_DATA_SYSTEM_DEFAULTS,
+  DESKTOP_TRANSITION_TABLE,
+  FDv2DataManagerControl,
   FlagManager,
   internal,
   LDClientImpl,
@@ -12,9 +17,12 @@ import {
   LDEmitterEventName,
   LDFlagValue,
   LDHeaders,
+  LDIdentifyOptions,
   LDIdentifyResult,
   LDPluginEnvironmentMetadata,
   mobileFdv1Endpoints,
+  MODE_TABLE,
+  resolveForegroundMode,
 } from '@launchdarkly/js-client-sdk-common';
 
 import basicLogger from './basicLogger';
@@ -28,6 +36,16 @@ import NodePlatform from './platform/NodePlatform';
 
 export class NodeClient extends LDClientImpl {
   private readonly _plugins: LDPlugin[];
+  // Tracks the current connection mode for both FDv1 (NodeDataManager) and
+  // FDv2 paths. Updated synchronously so getConnectionMode()/isOffline()
+  // reflect the caller's intent without waiting for async data manager work.
+  private _connectionMode: ConnectionMode;
+  // Serializes FDv2 connection-mode transitions so concurrent calls cannot
+  // reorder flush/event-sending around the await in the offline branch.
+  private _fdv2ConnectionModeQueue: Promise<void> = Promise.resolve();
+  // Set to true when close() is called so post-close setConnectionMode calls
+  // are no-ops in the FDv2 path.
+  private _closed: boolean = false;
 
   constructor(envKey: string, initialContext: LDContext, options: NodeOptions = {}) {
     const { logger: customLogger, debug } = options;
@@ -48,6 +66,7 @@ export class NodeClient extends LDClientImpl {
       credentialType: useMobileKey ? 'mobileKey' : 'clientSideId',
       requiresStart: true,
       initialContext,
+      dataSystemDefaults: DESKTOP_DATA_SYSTEM_DEFAULTS,
     };
 
     const platform = new NodePlatform(logger, validatedNodeOptions);
@@ -64,8 +83,46 @@ export class NodeClient extends LDClientImpl {
         baseHeaders: LDHeaders,
         emitter: LDEmitter,
         diagnosticsManager?: internal.DiagnosticsManager,
-      ) =>
-        new NodeDataManager(
+      ) => {
+        if (configuration.dataSystem) {
+          const foregroundMode = resolveForegroundMode(
+            configuration.dataSystem,
+            DESKTOP_DATA_SYSTEM_DEFAULTS,
+          );
+          return createFDv2DataManagerBase({
+            platform,
+            flagManager,
+            credential: envKey,
+            config: configuration,
+            baseHeaders,
+            emitter,
+            transitionTable: DESKTOP_TRANSITION_TABLE,
+            foregroundMode,
+            backgroundMode: undefined,
+            modeTable: MODE_TABLE,
+            sourceFactoryProvider: createDefaultSourceFactoryProvider(),
+            fdv1Endpoints: useMobileKey ? mobileFdv1Endpoints() : browserFdv1Endpoints(envKey),
+            buildQueryParams: (identifyOptions?: LDIdentifyOptions) => {
+              if (useMobileKey) {
+                // Mobile mode authenticates via Authorization header, not query params.
+                if ((identifyOptions as NodeIdentifyOptions | undefined)?.hash) {
+                  logger.warn('[NodeClient] \'hash\' is ignored in mobile key mode.');
+                }
+                return [];
+              }
+              const params: { key: string; value: string }[] = [{ key: 'auth', value: envKey }];
+              // Per-identify hash overrides the construction-time hash, mirroring FDv1 behavior.
+              const hash =
+                (identifyOptions as NodeIdentifyOptions | undefined)?.hash ||
+                validatedNodeOptions.hash;
+              if (hash) {
+                params.push({ key: 'h', value: hash });
+              }
+              return params;
+            },
+          });
+        }
+        return new NodeDataManager(
           platform,
           flagManager,
           envKey,
@@ -76,12 +133,30 @@ export class NodeClient extends LDClientImpl {
           baseHeaders,
           emitter,
           diagnosticsManager,
-        ),
+        );
+      },
       internalOptions,
     );
 
+    // Initialize _connectionMode for whichever path is active.
+    // FDv2ConnectionMode is a superset of ConnectionMode; map platform-only modes
+    // (e.g. 'one-shot', 'background') to 'streaming' since the source is active.
+    if (this.dataSystemConfig) {
+      const initialFdv2Mode = resolveForegroundMode(this.dataSystemConfig, DESKTOP_DATA_SYSTEM_DEFAULTS);
+      this._connectionMode =
+        initialFdv2Mode === 'offline' || initialFdv2Mode === 'polling'
+          ? initialFdv2Mode
+          : 'streaming';
+    } else {
+      this._connectionMode = validatedNodeOptions.initialConnectionMode;
+    }
     this._plugins = validatedNodeOptions.plugins;
     this.setEventSendingEnabled(!this.isOffline(), false);
+  }
+
+  override async close(): Promise<void> {
+    this._closed = true;
+    return super.close();
   }
 
   /**
@@ -104,22 +179,55 @@ export class NodeClient extends LDClientImpl {
   }
 
   async setConnectionMode(mode: ConnectionMode): Promise<void> {
-    const dataManager = this.dataManager as NodeDataManager;
-    await dataManager.setConnectionMode(
-      mode,
-      () => this.flush(),
-      (enabled) => this.setEventSendingEnabled(enabled, false),
-    );
+    if (this.isFDv2) {
+      // Validate mode before forwarding to prevent a runtime crash inside the
+      // debounce timer when an invalid value is passed from JavaScript.
+      if (mode !== 'offline' && mode !== 'streaming' && mode !== 'polling') {
+        this.logger.warn(`[NodeClient] Unknown connection mode "${mode}", ignoring.`);
+        return;
+      }
+      if (this._closed) {
+        return;
+      }
+      if (mode === this._connectionMode) {
+        return;
+      }
+      // FDv2 data manager: serialize transitions so concurrent calls cannot
+      // reorder flush/setEventSendingEnabled around the offline await.
+      this._connectionMode = mode;
+      const task = this._fdv2ConnectionModeQueue.then(async () => {
+        // Re-check after any preceding tasks have run — close() may have fired
+        // while this task was queued, matching the FDv1 NodeDataManager guard.
+        if (this._closed) {
+          return;
+        }
+        if (mode === 'offline') {
+          await this.flush();
+          this.setEventSendingEnabled(false, false);
+        }
+        (this.dataManager as FDv2DataManagerControl).setConnectionMode(mode);
+        if (mode !== 'offline') {
+          this.setEventSendingEnabled(true, false);
+        }
+      });
+      this._fdv2ConnectionModeQueue = task.catch(() => {});
+      await task;
+    } else {
+      await (this.dataManager as NodeDataManager).setConnectionMode(
+        mode,
+        () => this.flush(),
+        (enabled) => this.setEventSendingEnabled(enabled, false),
+      );
+      this._connectionMode = (this.dataManager as NodeDataManager).getConnectionMode();
+    }
   }
 
   getConnectionMode(): ConnectionMode {
-    const dataManager = this.dataManager as NodeDataManager;
-    return dataManager.getConnectionMode();
+    return this._connectionMode;
   }
 
   isOffline(): boolean {
-    const dataManager = this.dataManager as NodeDataManager;
-    return dataManager.getConnectionMode() === 'offline';
+    return this._connectionMode === 'offline';
   }
 }
 

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -190,26 +190,20 @@ export class NodeClient extends LDClientImpl {
         return;
       }
       if (mode === this._connectionMode) {
-        // The requested mode matches the optimistically-set _connectionMode, so
-        // no new transition is queued. But _connectionMode is set synchronously
-        // before the queued task runs, so an earlier call's transition to this
-        // same mode may still be in flight. Await the queue tail (without
-        // appending to it) so the caller's promise resolves only after that
-        // transition has actually completed. If nothing is in flight,
-        // _fdv2ConnectionModeQueue is already resolved, so this is a no-op.
+        // Await without appending: an earlier call may still be transitioning to
+        // this same mode, and we must not resolve until it has finished.
         await this._fdv2ConnectionModeQueue;
         return;
       }
-      // FDv2 data manager: serialize transitions so concurrent calls cannot
-      // reorder flush/setEventSendingEnabled around the offline await.
-      // Capture the prior mode so a failed transition can be rolled back -
+      // Without serialization, concurrent calls can interleave flush() and
+      // setEventSendingEnabled() across an offline await, corrupting order.
+      // Capture the prior mode so a failed transition can be rolled back:
       // otherwise isOffline()/getConnectionMode() would report a state the
       // data manager never actually entered.
       const previousMode = this._connectionMode;
       this._connectionMode = mode;
       const task = this._fdv2ConnectionModeQueue.then(async () => {
-        // Re-check after any preceding tasks have run — close() may have fired
-        // while this task was queued, matching the FDv1 NodeDataManager guard.
+        // Re-check: close() may have been called while this task was queued.
         if (this._closed) {
           return;
         }
@@ -223,10 +217,9 @@ export class NodeClient extends LDClientImpl {
             this.setEventSendingEnabled(true, false);
           }
         } catch (e) {
-          // The transition did not complete; restore the requested-mode marker
-          // so isOffline()/getConnectionMode() stay consistent with the data
-          // manager. Only roll back if no later queued task has already moved
-          // us on from this transition's target mode.
+          // Only roll back if no later queued task has already moved past this
+          // mode; otherwise isOffline()/getConnectionMode() would drift from
+          // the state the data manager actually reached.
           if (this._connectionMode === mode) {
             this._connectionMode = previousMode;
           }

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -190,10 +190,22 @@ export class NodeClient extends LDClientImpl {
         return;
       }
       if (mode === this._connectionMode) {
+        // The requested mode matches the optimistically-set _connectionMode, so
+        // no new transition is queued. But _connectionMode is set synchronously
+        // before the queued task runs, so an earlier call's transition to this
+        // same mode may still be in flight. Await the queue tail (without
+        // appending to it) so the caller's promise resolves only after that
+        // transition has actually completed. If nothing is in flight,
+        // _fdv2ConnectionModeQueue is already resolved, so this is a no-op.
+        await this._fdv2ConnectionModeQueue;
         return;
       }
       // FDv2 data manager: serialize transitions so concurrent calls cannot
       // reorder flush/setEventSendingEnabled around the offline await.
+      // Capture the prior mode so a failed transition can be rolled back -
+      // otherwise isOffline()/getConnectionMode() would report a state the
+      // data manager never actually entered.
+      const previousMode = this._connectionMode;
       this._connectionMode = mode;
       const task = this._fdv2ConnectionModeQueue.then(async () => {
         // Re-check after any preceding tasks have run — close() may have fired
@@ -201,13 +213,24 @@ export class NodeClient extends LDClientImpl {
         if (this._closed) {
           return;
         }
-        if (mode === 'offline') {
-          await this.flush();
-          this.setEventSendingEnabled(false, false);
-        }
-        (this.dataManager as FDv2DataManagerControl).setConnectionMode(mode);
-        if (mode !== 'offline') {
-          this.setEventSendingEnabled(true, false);
+        try {
+          if (mode === 'offline') {
+            await this.flush();
+            this.setEventSendingEnabled(false, false);
+          }
+          (this.dataManager as FDv2DataManagerControl).setConnectionMode(mode);
+          if (mode !== 'offline') {
+            this.setEventSendingEnabled(true, false);
+          }
+        } catch (e) {
+          // The transition did not complete; restore the requested-mode marker
+          // so isOffline()/getConnectionMode() stay consistent with the data
+          // manager. Only roll back if no later queued task has already moved
+          // us on from this transition's target mode.
+          if (this._connectionMode === mode) {
+            this._connectionMode = previousMode;
+          }
+          throw e;
         }
       });
       this._fdv2ConnectionModeQueue = task.catch(() => {});

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -136,15 +136,16 @@ export class NodeClient extends LDClientImpl {
       internalOptions,
     );
 
-    // Initialize _connectionMode for whichever path is active.
-    // FDv2ConnectionMode is a superset of ConnectionMode; map platform-only modes
-    // (e.g. 'one-shot', 'background') to 'streaming' since the source is active.
     if (this.dataSystemConfig) {
-      const initialFdv2Mode = resolveForegroundMode(this.dataSystemConfig, DESKTOP_DATA_SYSTEM_DEFAULTS);
-      this._connectionMode =
-        initialFdv2Mode === 'offline' || initialFdv2Mode === 'polling'
-          ? initialFdv2Mode
-          : 'streaming';
+      const rawMode = resolveForegroundMode(this.dataSystemConfig, DESKTOP_DATA_SYSTEM_DEFAULTS);
+      if (rawMode !== 'offline' && rawMode !== 'streaming' && rawMode !== 'polling') {
+        this.logger.warn(
+          `[NodeClient] Connection mode '${rawMode}' is not supported; defaulting to 'streaming'.`,
+        );
+        this._connectionMode = 'streaming';
+      } else {
+        this._connectionMode = rawMode;
+      }
     } else {
       this._connectionMode = validatedNodeOptions.initialConnectionMode;
     }

--- a/packages/sdk/node-client/src/NodeClient.ts
+++ b/packages/sdk/node-client/src/NodeClient.ts
@@ -83,10 +83,16 @@ export class NodeClient extends LDClientImpl {
         diagnosticsManager?: internal.DiagnosticsManager,
       ) => {
         if (configuration.dataSystem) {
-          const foregroundMode = resolveForegroundMode(
+          const rawForegroundMode = resolveForegroundMode(
             configuration.dataSystem,
             DESKTOP_DATA_SYSTEM_DEFAULTS,
           );
+          const foregroundMode =
+            rawForegroundMode === 'streaming' ||
+            rawForegroundMode === 'polling' ||
+            rawForegroundMode === 'offline'
+              ? rawForegroundMode
+              : 'streaming';
           return createFDv2DataManagerBase({
             platform,
             flagManager,


### PR DESCRIPTION
SDK-2468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flag data plumbing and connection/offline semantics, but FDv1 behavior is preserved behind the existing data manager when `dataSystem` is absent.
> 
> **Overview**
> When **`dataSystem`** is configured, **NodeClient** now wires **`createFDv2DataManagerBase`** (desktop defaults, transition table, query params for client-side ID vs mobile) instead of **`NodeDataManager`**, while leaving the FDv1 path unchanged.
> 
> **Connection mode** is tracked on the client (`_connectionMode`). In FDv2, **`setConnectionMode`** validates modes, no-ops after close or on duplicate mode, serializes concurrent transitions (flush before offline, then event sending + data manager), and **`getConnectionMode` / `isOffline`** read that state rather than the FDv1 data manager.
> 
> CI runs **FDv2 contract tests** (harness v3) against the same long-lived test service (`stop_service: 'false'`), with a new suppressions file and harness updates (**mobile**, **`useMobileKey`**, extra capabilities). Unit coverage is added in **`NodeClientFDv2.test.ts`**; **`FDv2ConnectionMode`** is exported from **`LDCommon`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ac80d956bbaf9dff2c3d88525633a6fe1df465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->