### PR TITLE
ci: fixing svelte build

### DIFF
--- a/packages/sdk/svelte/package.json
+++ b/packages/sdk/svelte/package.json
@@ -70,7 +70,7 @@
     "typedoc": "0.25.0",
     "typescript": "5.1.6",
     "typescript-eslint": "^8.0.0",
-    "vite": "^8.0.16",
+    "vite": "8.0.16",
     "vitest": "^4.1.8"
   }
 }


### PR DESCRIPTION
Something broke with `vite` 8.1.0 (which pulls in `rolldown` 1.1.2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes to tsconfig and Vitest/Vite config; no runtime SDK behavior changes.
> 
> **Overview**
> Repairs the Svelte SDK **build/check pipeline** broken by the Vite 8 bump (SvelteKit source resolution and Vitest pre-bundling).
> 
> **`tsconfig.json`** closes `compilerOptions` correctly and adds an explicit **`include`** list so TypeScript covers SvelteKit-generated types, Vite config, `src/**`, and **`__tests__/**`**.
> 
> **`vite.config.ts`** adds a **`__vitest__`** environment override that **`optimizeDeps.exclude`s `svelte`**, avoiding vite-plugin-svelte/Rolldown pre-bundling that fails to resolve `node:module` from a virtual `\0rolldown/runtime.js` path (a global exclude is insufficient because each Vite environment resolves `optimizeDeps` separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14414166f3d801b041bcbc31e8327d93ec924637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->