### PR TITLE
fix: client side fdv2 payload type

### DIFF
--- a/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv1PollingSynchronizer.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/fdv2/FDv1PollingSynchronizer.test.ts
@@ -63,7 +63,7 @@ it('produces a changeSet with full payload from a successful poll', async () => 
 
     const flagAUpdate = result.payload.updates.find((u) => u.key === 'flagA');
     expect(flagAUpdate).toEqual({
-      kind: 'flag',
+      kind: 'flag-eval',
       key: 'flagA',
       version: 5,
       object: { version: 5, value: 'yes' },
@@ -71,7 +71,7 @@ it('produces a changeSet with full payload from a successful poll', async () => 
 
     const flagBUpdate = result.payload.updates.find((u) => u.key === 'flagB');
     expect(flagBUpdate).toEqual({
-      kind: 'flag',
+      kind: 'flag-eval',
       key: 'flagB',
       version: 3,
       object: { version: 3, value: 42 },

--- a/packages/shared/sdk-client/src/datasource/fdv2/FDv1PollingSynchronizer.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/FDv1PollingSynchronizer.ts
@@ -22,7 +22,7 @@ import { Synchronizer } from './Synchronizer';
 
 function flagsToPayload(flags: Flags): internal.Payload {
   const updates: internal.Update[] = Object.entries(flags).map(([key, flag]) => ({
-    kind: 'flag',
+    kind: 'flag-eval',
     key,
     version: flag.version ?? 1,
     object: flag,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow payload-shape fix in the temporary FDv1→FDv2 polling adapter; no auth or broader behavioral changes beyond correct update kind labeling.
> 
> **Overview**
> Aligns **FDv1 polling** full payloads with the rest of the FDv2 client pipeline by setting each update’s `kind` to **`flag-eval`** instead of **`flag`**.
> 
> `flagsToPayload` in `FDv1PollingSynchronizer` is updated accordingly, and the FDv1 polling synchronizer tests now assert **`flag-eval`** on flag updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4b85fc3898bf85bcd827dd5b1d9f1d2fc810c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->