### PR TITLE
ci: remove release-please `release-as` directive on already released packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -353,11 +353,8 @@
         }
       ]
     },
-    "packages/tooling/jest": {
-      "release-as": "1.0.0"
-    },
+    "packages/tooling/jest": {},
     "packages/tooling/client-testing-plugin": {
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",
@@ -409,11 +406,8 @@
         }
       ]
     },
-    "packages/shared/openfeature-server-common": {
-      "release-as": "1.0.0"
-    },
+    "packages/shared/openfeature-server-common": {},
     "packages/sdk/openfeature-node-server": {
-      "release-as": "1.3.0",
       "extra-files": [
         "src/LaunchDarklyProvider.ts",
         {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/release tooling only; no runtime SDK or application code changes, though incorrect release-please config could affect future version bumps.
> 
> **Overview**
> Cleans up **release-please** configuration for packages that have already shipped by dropping the **`release-as`** pins that were forcing specific next versions.
> 
> **`packages/tooling/jest`** and **`packages/shared/openfeature-server-common`** go from `release-as` (1.0.0) to empty config objects, keeping them in the release graph without a fixed version. **`packages/tooling/client-testing-plugin`** loses `release-as: 1.0.0` but keeps its `extra-files` bumps. **`packages/sdk/openfeature-node-server`** loses `release-as: 1.3.0` while unchanged `extra-files` (e.g. `LaunchDarklyProvider.ts` and example `package.json` paths) remain.
> 
> After this change, release-please should infer versions from each package's current version and changelog instead of overriding with one-off release targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0caf577a916f09babf2c0ef67669992b7b03ab22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->