### PR TITLE
fix(openfeature-node-server): identify floor for node server sdk peer dep

### DIFF
--- a/packages/sdk/openfeature-node-server/package.json
+++ b/packages/sdk/openfeature-node-server/package.json
@@ -47,7 +47,7 @@
     "@launchdarkly/openfeature-js-server-common": "1.0.0"
   },
   "peerDependencies": {
-    "@launchdarkly/node-server-sdk": "9.11.3",
+    "@launchdarkly/node-server-sdk": "^9.0.0",
     "@openfeature/server-sdk": "^1.16.0"
   },
   "devDependencies": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -424,7 +424,7 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "updatePeerDependencies": true
+      "updatePeerDependencies": false
     }
   ]
 }


### PR DESCRIPTION
This PR will make the minimum version of node server sdk for openfeature node server provider `9.0.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and release tooling only; no runtime or API changes in the provider.
> 
> **Overview**
> Relaxes the **`@launchdarkly/node-server-sdk`** peer dependency on `@launchdarkly/openfeature-node-server` from a **pinned** `9.11.3` to **`^9.0.0`**, so consumers on any 9.x release satisfy the peer requirement instead of being forced to that exact version. **Dev** dependency on `9.11.3` is unchanged for CI/tests.
> 
> **Release Please**’s `node-workspace` plugin is updated with **`updatePeerDependencies: false`**, so automated releases will no longer rewrite peer dependency ranges—keeping this floor/range policy under manual control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f881e6c75dbf8a76a305144dc225ad4292339c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->