### PR TITLE
fix(server-ai): unpin peer depedency reference

### DIFF
--- a/packages/sdk/server-ai/package.json
+++ b/packages/sdk/server-ai/package.json
@@ -60,6 +60,6 @@
     "typescript-eslint": "^8.0.0"
   },
   "peerDependencies": {
-    "@launchdarkly/js-server-sdk-common": "2.19.2"
+    "@launchdarkly/js-server-sdk-common": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR will unpin the sdk-server-common package from the peer deps of server-ai

The server common package seems to be only used for typing. I chose a more conservative floor of 2.0.0 to match more versions. We will reassess if there are any issues with this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `package.json` peer range change with no runtime code; low risk unless older 2.x common releases break the typing surface server-ai relies on.
> 
> **Overview**
> **`@launchdarkly/server-sdk-ai`** no longer requires an exact **`@launchdarkly/js-server-sdk-common`** peer version. The peer range changes from **`2.19.2`** to **`^2.0.0`**, so apps can pair server-ai with any 2.x server common release instead of being locked to one patch.
> 
> The **devDependency** on **`2.19.2`** is unchanged; only install-time peer resolution is affected. Server-ai still imports shared types such as **`LDContext`** and **`LDLogger`** from that package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1907b45d63e3514910b009df41e9a93c5875f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->