### PR TITLE
fix: Accept eventsUri option in Fastly SDK init()

### DIFF
--- a/packages/sdk/fastly/__tests__/index.test.ts
+++ b/packages/sdk/fastly/__tests__/index.test.ts
@@ -39,6 +39,15 @@ describe('init', () => {
     ldClient.close();
   });
 
+  it('does not throw when initialized with a custom eventsUri', () => {
+    expect(() =>
+      init(sdkKey, mockKVStore, {
+        eventsUri: 'https://custom-events.example.com',
+        eventsBackendName: 'custom-backend',
+      }),
+    ).not.toThrow();
+  });
+
   describe('flag tests', () => {
     it('evaluates a boolean flag with a variation call', async () => {
       const value = await ldClient.variation(flagKey1, context, false);

--- a/packages/sdk/fastly/__tests__/index.test.ts
+++ b/packages/sdk/fastly/__tests__/index.test.ts
@@ -40,12 +40,16 @@ describe('init', () => {
   });
 
   it('does not throw when initialized with a custom eventsUri', () => {
-    expect(() =>
-      init(sdkKey, mockKVStore, {
+    let client: LDClient | undefined;
+    expect(() => {
+      client = init(sdkKey, mockKVStore, {
         eventsUri: 'https://custom-events.example.com',
         eventsBackendName: 'custom-backend',
-      }),
-    ).not.toThrow();
+      });
+    }).not.toThrow();
+    // Close the client so its event processor's flush timer does not keep the
+    // runtime (and the jest process) alive.
+    client?.close();
   });
 
   describe('flag tests', () => {

--- a/packages/sdk/fastly/__tests__/utils/validateOptions.test.ts
+++ b/packages/sdk/fastly/__tests__/utils/validateOptions.test.ts
@@ -32,6 +32,18 @@ describe('validateOptions', () => {
     ).toBeTruthy();
   });
 
+  test('success with eventsUri and eventsBackendName', () => {
+    expect(
+      validateOptions('test-sdk-key', {
+        featureStore: mockFeatureStore,
+        logger: BasicLogger.get(),
+        sendEvents: true,
+        eventsUri: 'https://custom-events.example.com',
+        eventsBackendName: 'custom-backend',
+      }),
+    ).toBeTruthy();
+  });
+
   test('throws with invalid options', () => {
     expect(() => {
       validateOptions('test-sdk-key', {

--- a/packages/sdk/fastly/src/utils/validateOptions.ts
+++ b/packages/sdk/fastly/src/utils/validateOptions.ts
@@ -24,7 +24,7 @@ const validators = {
 };
 
 const validateOptions = (clientSideId: string, options: LDOptionsInternal) => {
-  const { eventsBackendName, featureStore, logger, sendEvents, ...rest } = options;
+  const { eventsBackendName, eventsUri, featureStore, logger, sendEvents, ...rest } = options;
   if (!clientSideId || !validators.clientSideId.is(clientSideId)) {
     throw new Error('You must configure the client with a client-side id');
   }
@@ -37,8 +37,9 @@ const validateOptions = (clientSideId: string, options: LDOptionsInternal) => {
     throw new Error('You must configure the client with a logger');
   }
 
-  if (JSON.stringify(rest) !== '{}') {
-    throw new Error(`Invalid configuration: ${Object.keys(rest).toString()} not supported`);
+  const unsupported = Object.keys(rest);
+  if (unsupported.length !== 0) {
+    throw new Error(`Invalid configuration: ${unsupported.toString()} not supported`);
   }
 
   return true;


### PR DESCRIPTION
## Summary

`validateOptions` in the Fastly Compute SDK omitted `eventsUri` from its destructure, so a supported, documented option fell through to the unsupported-keys guard and made `init()` throw `Invalid configuration: eventsUri not supported`. Any customer routing events through a proxy or custom host via `init(clientSideId, kvStore, { eventsUri })` could not construct a client at all.

- Add `eventsUri` to the `validateOptions` destructure so it is no longer treated as an unsupported key.
- Replace the `JSON.stringify(rest) !== '{}'` guard with an `Object.keys(rest).length` check. This also fixes two latent bugs in the same guard: unsupported keys with an `undefined` value were silently accepted (`JSON.stringify` drops them), and non-serializable values (BigInt, circular refs) threw an opaque `TypeError` instead of the intended configuration error.
- Add regression tests. The existing `eventsUri` success test constructed `LDClient` directly and bypassed `validateOptions`; the new tests drive `eventsUri` through `init()` and through `validateOptions` directly.

Part of the Fastly refresh epic (SDK-2643). Fixes SDK-2644.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation and test changes in the Fastly SDK; no auth, data, or runtime behavior changes beyond accepting a previously documented option.
> 
> **Overview**
> **Fixes `init()` rejecting the documented `eventsUri` option** by including `eventsUri` in the `validateOptions` destructure so it no longer lands in the unsupported-keys check and triggers `Invalid configuration: eventsUri not supported`.
> 
> **Hardens unsupported-option detection** by replacing `JSON.stringify(rest) !== '{}'` with `Object.keys(rest).length`, so keys with `undefined` values are still rejected and non-serializable values no longer surface as opaque `TypeError`s.
> 
> **Adds regression coverage** for `eventsUri` / `eventsBackendName` via `validateOptions` and via `init()` (with client teardown to avoid Jest hanging on the event flush timer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d557fcf9e1924706e13c1cadc7a20e5b2bf7b7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->