### PR TITLE
perf: Import only used crypto-js submodules in Fastly SDK

### DIFF
--- a/packages/sdk/fastly/src/platform/crypto/cryptoJSHasher.ts
+++ b/packages/sdk/fastly/src/platform/crypto/cryptoJSHasher.ts
@@ -1,8 +1,3 @@
-// Import only the crypto-js submodules we use. Importing the crypto-js entry point
-// pulls in the entire cipher suite (AES, DES, Rabbit, MD5, SHA3, PBKDF2, ...), which
-// bloats the Wasm bundle and cold-start parse time. The type namespace comes from
-// 'crypto-js/core'; the algorithm and encoder submodules register themselves on it at
-// runtime (enc.Hex is part of core).
 import CryptoJS from 'crypto-js/core';
 import 'crypto-js/sha1';
 import 'crypto-js/sha256';

--- a/packages/sdk/fastly/src/platform/crypto/cryptoJSHasher.ts
+++ b/packages/sdk/fastly/src/platform/crypto/cryptoJSHasher.ts
@@ -1,4 +1,12 @@
-import CryptoJS from 'crypto-js';
+// Import only the crypto-js submodules we use. Importing the crypto-js entry point
+// pulls in the entire cipher suite (AES, DES, Rabbit, MD5, SHA3, PBKDF2, ...), which
+// bloats the Wasm bundle and cold-start parse time. The type namespace comes from
+// 'crypto-js/core'; the algorithm and encoder submodules register themselves on it at
+// runtime (enc.Hex is part of core).
+import CryptoJS from 'crypto-js/core';
+import 'crypto-js/sha1';
+import 'crypto-js/sha256';
+import 'crypto-js/enc-base64';
 
 import { Hasher as LDHasher } from '@launchdarkly/js-server-sdk-common';
 

--- a/packages/sdk/fastly/src/platform/crypto/cryptoJSHmac.ts
+++ b/packages/sdk/fastly/src/platform/crypto/cryptoJSHmac.ts
@@ -1,4 +1,13 @@
-import CryptoJS from 'crypto-js';
+// Import only the crypto-js submodules we use. Importing the crypto-js entry point
+// pulls in the entire cipher suite (AES, DES, Rabbit, MD5, SHA3, PBKDF2, ...), which
+// bloats the Wasm bundle and cold-start parse time. The type namespace comes from
+// 'crypto-js/core'; the algorithm and encoder submodules register themselves on it at
+// runtime (enc.Hex is part of core).
+import CryptoJS from 'crypto-js/core';
+import 'crypto-js/sha1';
+import 'crypto-js/sha256';
+import 'crypto-js/hmac';
+import 'crypto-js/enc-base64';
 
 import { Hmac as LDHmac } from '@launchdarkly/js-server-sdk-common';
 

--- a/packages/sdk/fastly/src/platform/crypto/cryptoJSHmac.ts
+++ b/packages/sdk/fastly/src/platform/crypto/cryptoJSHmac.ts
@@ -1,8 +1,3 @@
-// Import only the crypto-js submodules we use. Importing the crypto-js entry point
-// pulls in the entire cipher suite (AES, DES, Rabbit, MD5, SHA3, PBKDF2, ...), which
-// bloats the Wasm bundle and cold-start parse time. The type namespace comes from
-// 'crypto-js/core'; the algorithm and encoder submodules register themselves on it at
-// runtime (enc.Hex is part of core).
 import CryptoJS from 'crypto-js/core';
 import 'crypto-js/sha1';
 import 'crypto-js/sha256';

--- a/packages/sdk/fastly/src/platform/crypto/index.ts
+++ b/packages/sdk/fastly/src/platform/crypto/index.ts
@@ -5,8 +5,12 @@ import CryptoJSHmac from './cryptoJSHmac';
 import { SupportedHashAlgorithm } from './types';
 
 /**
- * Uses crypto-js as substitute to node:crypto because the latter
- * is not yet supported in some runtimes.
+ * Uses crypto-js to implement hashing and HMAC.
+ *
+ * Fastly Compute exposes a native WebCrypto (crypto.subtle), but its digest/sign
+ * operations are asynchronous, and the SDK's Crypto contract requires a synchronous
+ * digest() (used on the synchronous flag-bucketing path). crypto-js provides the
+ * synchronous hashing the contract needs.
  * https://cryptojs.gitbook.io/docs/
  */
 export default class EdgeCrypto implements Crypto {


### PR DESCRIPTION
## Summary

The Fastly SDK's crypto files imported the `crypto-js` entry point, which eagerly requires ~35 modules (AES, TripleDES, Rabbit, Blowfish, RC4, MD5, SHA3, RIPEMD160, PBKDF2, all cipher modes/paddings, etc.). The SDK only uses SHA1, SHA256, HMAC, Base64, Hex, and core.

- Import `crypto-js/core` for the typed namespace, plus side-effect imports of only the `sha1`, `sha256`, `hmac`, and `enc-base64` submodules (hex is part of core).
- Correct the stale justification comment in `crypto/index.ts`: native WebCrypto (`crypto.subtle`) does exist on Fastly Compute, but its digest/sign are async-only, while the SDK's `Crypto` contract requires a synchronous `digest()` (used on the flag-bucketing path) -- which is the actual reason crypto-js is retained.

### Impact

`crypto-js` is external to the SDK's own published bundle (tsup's `noExternal` only bundles `@launchdarkly/js-server-sdk-common`), so `dist/index.js` size is unchanged. The win is downstream: a consumer's `@fastly/js-compute` build now pulls far less crypto-js into their Compute Wasm, and cold-start module load drops from ~35 requires to ~5.

Measured by building `packages/sdk/fastly/example` both ways with `js-compute-runtime`:

| Variant | `bin/main.wasm` |
|---|---|
| Before (`import 'crypto-js'`) | 16,749,643 bytes |
| After (submodule imports) | 15,242,918 bytes |
| **Saved** | **1,506,725 bytes (~1.44 MB, ~9.0%)** |

Part of the Fastly refresh epic (SDK-2643). Fixes SDK-2647.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with unchanged hash/HMAC logic; main risk is a missed crypto-js submodule at runtime, mitigated by existing tests and the example Wasm measurement.
> 
> **Overview**
> **Reduces Fastly Compute Wasm footprint** by replacing the monolithic `crypto-js` entry import with `crypto-js/core` plus side-effect imports for only **SHA1**, **SHA256**, **HMAC**, and **Base64** encoding—the pieces the hasher and HMAC wrappers actually use.
> 
> Hasher/HMAC behavior is unchanged; this is an import-graph optimization so `@fastly/js-compute` consumers pull far fewer crypto-js modules at build time (~1.4 MB smaller example Wasm per the PR).
> 
> The `EdgeCrypto` module comment is updated to state that **WebCrypto exists on Fastly** but stays unused because **`digest()` must be synchronous** for flag bucketing, which is why **crypto-js** remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95bd2d50086031148c96fe82d4a9dda0aa0d61a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->