### PR TITLE
fix: Do not cache rejected KV loads in Fastly EdgeFeatureStore

### DIFF
--- a/packages/sdk/fastly/__tests__/api/EdgeFeatureStore.test.ts
+++ b/packages/sdk/fastly/__tests__/api/EdgeFeatureStore.test.ts
@@ -113,6 +113,30 @@ describe('EdgeFeatureStore', () => {
     });
   });
 
+  describe('load caching', () => {
+    it('does not cache a rejected load and retries on the next call', async () => {
+      mockGet.mockRejectedValueOnce(new Error('transient KV error'));
+
+      // The first read hits the transient error and falls back to null.
+      const first = await asyncFeatureStore.get({ namespace: 'features' }, 'testFlag1');
+      expect(first).toBeNull();
+
+      // A later read must retry the provider (the beforeEach success impl) rather
+      // than reuse the cached rejected promise, and should succeed.
+      const second = await asyncFeatureStore.get({ namespace: 'features' }, 'testFlag1');
+      expect(second).toMatchObject(testData.flags.testFlag1);
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches a successful load and reuses it across calls', async () => {
+      await asyncFeatureStore.get({ namespace: 'features' }, 'testFlag1');
+      await asyncFeatureStore.get({ namespace: 'segments' }, 'testSegment1');
+      await asyncFeatureStore.all({ namespace: 'features' });
+
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('init & getDescription', () => {
     it('can initialize', (done) => {
       const cb = jest.fn(() => {

--- a/packages/sdk/fastly/src/api/EdgeFeatureStore.ts
+++ b/packages/sdk/fastly/src/api/EdgeFeatureStore.ts
@@ -32,7 +32,7 @@ export class EdgeFeatureStore implements LDFeatureStore {
    */
   private async _getKVData(): Promise<LDFeatureStoreDataStorage | null> {
     if (!this._deserializedPromise) {
-      this._deserializedPromise = (async (): Promise<LDFeatureStoreDataStorage | null> => {
+      const promise = (async (): Promise<LDFeatureStoreDataStorage | null> => {
         this._logger.debug('No cached data found, loading from KV store');
         const kvData = await this._edgeProvider.get(this._rootKey);
         if (!kvData) {
@@ -56,6 +56,20 @@ export class EdgeFeatureStore implements LDFeatureStore {
 
         return deserializedData;
       })();
+
+      // Do not cache a rejected load. If the KV read throws (for example a
+      // transient backend error), clear the cached promise so the next call
+      // retries instead of reusing the rejected promise for the rest of the
+      // request, which would make every flag evaluation fall back to defaults.
+      // A successful load that resolves to null (missing or undeserializable
+      // data) is still cached, since that is a stable state within a request.
+      promise.catch(() => {
+        if (this._deserializedPromise === promise) {
+          this._deserializedPromise = null;
+        }
+      });
+
+      this._deserializedPromise = promise;
     } else {
       this._logger.debug('Using cached deserialized data');
     }


### PR DESCRIPTION
## Summary

`EdgeFeatureStore._getKVData` cached its load promise for the lifetime of the store instance and never reset it. If the KV read rejected -- for example a transient Fastly backend error, exactly the failure this cache should survive -- the rejected promise stayed cached, and every subsequent `get`/`all`/`initialized` reused it. The result: a single transient error made *all* flag evaluations (and `allFlagsState`) fall back to defaults for the rest of the request, not just the read that hit the error.

- Attach a `catch` to the load promise that clears the cached promise when the load rejects (guarded by an identity check), so the next call retries instead of reusing the rejected promise.
- The single-flight-per-request design -- motivated by Fastly's 32-backend-request limit -- is preserved. A successful load that resolves to `null` (missing or undeserializable data) is still cached, since that is a stable state within a request.
- Add regression tests: a transient rejection followed by a successful retry (provider called twice, second read succeeds), and confirmation that a successful load is cached and reused across calls (provider called once).

### Note

The shared `sdk-server-edge` `EdgeFeatureStore` (used by Cloudflare/Vercel) uses a different model -- it fetches per call and caches only successful payloads via an optional TTL cache. Converging the Fastly store onto that shared implementation is a larger, behavior-changing refactor and is intentionally out of scope here; this change is the minimal fix for the caching bug.

Part of the Fastly refresh epic (SDK-2643). Fixes SDK-2646.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Fastly edge feature-store caching with regression tests; improves resilience after transient KV errors without altering successful-load behavior.
> 
> **Overview**
> Fixes a caching bug in Fastly **`EdgeFeatureStore._getKVData`**: a **rejected** KV read used to leave the load promise cached for the rest of the request, so every later **`get`**, **`all`**, and **`initialized`** kept failing and evaluations fell back to defaults after a single transient backend error.
> 
> The load promise is still single-flight per request (for Fastly’s backend limit), but a **`catch`** now clears **`_deserializedPromise`** when that promise rejects (with an identity guard). **Successful** loads that resolve to **`null`** (missing or bad data) stay cached as before.
> 
> Adds **`load caching`** tests: retry after a one-shot rejection (two provider calls, second read succeeds) and one KV fetch shared across multiple reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f9a13638866ad13bbef248dab099b947023f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->