### PR TITLE
fix: custom featureStores in FDv2 does not get wrapped as TransactionalFeatureStore.

### DIFF
--- a/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
+++ b/packages/shared/sdk-server/__tests__/options/Configuration.test.ts
@@ -1,4 +1,10 @@
-import { DataSourceOptions, isStandardOptions, LDFeatureStore, LDOptions } from '../../src';
+import {
+  DataSourceOptions,
+  isStandardOptions,
+  LDFeatureStore,
+  LDOptions,
+  LDTransactionalFeatureStore,
+} from '../../src';
 import Configuration from '../../src/options/Configuration';
 import InMemoryFeatureStore from '../../src/store/InMemoryFeatureStore';
 import TestLogger, { LogLevel } from '../Logger';
@@ -451,6 +457,107 @@ describe('when setting different options', () => {
         matches: /Config option "persistentStore" should be of type LDFeatureStore/,
       },
     ]);
+  });
+
+  // A minimal object implementing only the FDv1 LDFeatureStore interface - no
+  // applyChanges. Structurally identical to the shape of the Redis/DynamoDB
+  // persistent store integrations.
+  function makeFDv1OnlyStore(): LDFeatureStore {
+    return {
+      get: (_kind, _key, callback) => callback(null),
+      all: (_kind, callback) => callback({}),
+      init: (_allData, callback) => callback(),
+      delete: (_kind, _key, _version, callback) => callback(),
+      upsert: (_kind, _data, callback) => callback(),
+      initialized: (callback) => callback(false),
+      close: () => {},
+    };
+  }
+
+  it('wraps an FDv1-only persistent store so applyChanges does not crash', () => {
+    const config = new Configuration(
+      withLogger({
+        dataSystem: {
+          persistentStore: makeFDv1OnlyStore(),
+        },
+      }),
+    );
+
+    // @ts-ignore - the test only needs an object here; the object-form persistent
+    // store path does not read clientContext.
+    const store = config.dataSystem!.featureStoreFactory({});
+
+    // Before the fix, the raw FDv1 store is returned and this throws
+    // "TypeError: store.applyChanges is not a function".
+    expect(() =>
+      (store as LDTransactionalFeatureStore).applyChanges(true, {}, () => {}),
+    ).not.toThrow();
+    expect(logger(config).getCount()).toEqual(0);
+  });
+
+  it('passes a native transactional persistent store through without wrapping', () => {
+    const applyChanges = jest.fn(
+      (
+        _basis: boolean,
+        _data: Record<string, unknown>,
+        callback: () => void,
+      ) => {
+        callback();
+      },
+    );
+
+    // A store that already implements LDTransactionalFeatureStore (has a native
+    // applyChanges). It must be returned as the same object reference - not
+    // decorated - so its native transactional path is preserved.
+    const nativeStore: LDTransactionalFeatureStore = {
+      get: (_kind, _key, callback) => callback(null),
+      all: (_kind, callback) => callback({}),
+      init: (_allData, callback) => callback(),
+      delete: (_kind, _key, _version, callback) => callback(),
+      upsert: (_kind, _data, callback) => callback(),
+      initialized: (callback) => callback(false),
+      close: () => {},
+      applyChanges,
+    };
+
+    const config = new Configuration(
+      withLogger({
+        dataSystem: {
+          persistentStore: nativeStore,
+        },
+      }),
+    );
+
+    // @ts-ignore - object-form persistent store path does not read clientContext.
+    const store = config.dataSystem!.featureStoreFactory({});
+
+    // Same object reference: the store was not wrapped in a decorator.
+    expect(store).toBe(nativeStore);
+
+    // Its native applyChanges runs directly, not decomposed into init/upsert
+    // calls by a decorator.
+    (store as LDTransactionalFeatureStore).applyChanges(true, {}, () => {});
+    expect(applyChanges).toHaveBeenCalledTimes(1);
+    expect(logger(config).getCount()).toEqual(0);
+  });
+
+  it('wraps an FDv1-only persistent store supplied as a factory', () => {
+    const config = new Configuration(
+      withLogger({
+        dataSystem: {
+          persistentStore: () => makeFDv1OnlyStore(),
+        },
+      }),
+    );
+
+    // @ts-ignore - factory receives clientContext; an empty object is sufficient
+    // because makeFDv1OnlyStore ignores it.
+    const store = config.dataSystem!.featureStoreFactory({});
+
+    expect(() =>
+      (store as LDTransactionalFeatureStore).applyChanges(true, {}, () => {}),
+    ).not.toThrow();
+    expect(logger(config).getCount()).toEqual(0);
   });
 
   it('provides reasonable defaults when datasystem is provided, but some options are missing', () => {

--- a/packages/shared/sdk-server/__tests__/store/TransactionalFeatureStore.test.ts
+++ b/packages/shared/sdk-server/__tests__/store/TransactionalFeatureStore.test.ts
@@ -158,4 +158,60 @@ describe('given a non transactional store', () => {
       },
     });
   });
+
+  it('exposes the selector tracked by the memory store before a basis is provided', async () => {
+    // non-basis changes still flow through the memory store, so its tracked selector should
+    // update even though the active store (used for reads) is still the persistence store
+    await transactionalFacade.applyChanges(
+      false,
+      {
+        features: {
+          key1: {
+            version: 1,
+          },
+        },
+      },
+      undefined,
+      'selector-before-basis',
+    );
+
+    expect(transactionalStore.getSelector()).toEqual('selector-before-basis');
+  });
+
+  it('does not expose init metadata set directly on the persistence store before a basis is provided', async () => {
+    // metadata set directly on the persistence store (the active store pre-basis) should not
+    // be visible through the transactional wrapper, which always reads from the memory store
+    await nonTransactionalFacade.init(
+      {
+        features: {
+          key1: {
+            version: 1,
+          },
+        },
+      },
+      { environmentId: 'env-on-persistence-store' },
+    );
+
+    expect(transactionalStore.getInitMetaData()).toBeUndefined();
+  });
+
+  it('exposes selector and init metadata from the memory store after a basis is provided', async () => {
+    const initMetadata = { environmentId: 'env-after-basis' };
+
+    await transactionalFacade.applyChanges(
+      true,
+      {
+        features: {
+          key1: {
+            version: 1,
+          },
+        },
+      },
+      initMetadata,
+      'selector-after-basis',
+    );
+
+    expect(transactionalStore.getSelector()).toEqual('selector-after-basis');
+    expect(transactionalStore.getInitMetaData()).toEqual(initMetadata);
+  });
 });

--- a/packages/shared/sdk-server/src/options/Configuration.ts
+++ b/packages/shared/sdk-server/src/options/Configuration.ts
@@ -32,6 +32,7 @@ import {
   LDTransactionalFeatureStore,
 } from '../api/subsystems';
 import InMemoryFeatureStore from '../store/InMemoryFeatureStore';
+import TransactionalFeatureStore from '../store/TransactionalFeatureStore';
 import { ServerInternalOptions } from './ServerInternalOptions';
 import { ValidatedOptions } from './ValidatedOptions';
 
@@ -464,16 +465,27 @@ export default class Configuration {
         dataSource: validatedDSOptions.dataSource,
         useLdd: validatedDSOptions.useLdd,
         fdv1Fallback: validatedDSOptions.fdv1Fallback,
-        // @ts-ignore
-        featureStoreFactory: (clientContext) => {
-          if (validatedDSOptions.persistentStore === undefined) {
+        featureStoreFactory: (clientContext): LDTransactionalFeatureStore => {
+          const { persistentStore } = validatedDSOptions;
+          let store: LDFeatureStore;
+          if (persistentStore === undefined) {
             // the persistent store provided was either undefined or invalid, default to memory store
-            return new InMemoryFeatureStore();
+            store = new InMemoryFeatureStore();
+          } else if (TypeValidators.Function.is(persistentStore)) {
+            store = (persistentStore as (clientContext: LDClientContext) => LDFeatureStore)(
+              clientContext,
+            );
+          } else {
+            store = persistentStore as LDFeatureStore;
           }
-          if (TypeValidators.Function.is(validatedDSOptions.persistentStore)) {
-            return validatedDSOptions.persistentStore(clientContext);
+
+          // FDv2 always calls applyChanges, so the returned store must support it. A
+          // store that already implements LDTransactionalFeatureStore is used as-is to
+          // preserve its native transactional path.
+          if (TypeValidators.Function.is((store as LDTransactionalFeatureStore).applyChanges)) {
+            return store as LDTransactionalFeatureStore;
           }
-          return validatedDSOptions.persistentStore;
+          return new TransactionalFeatureStore(store);
         },
       };
       dsErrors.forEach((error) => {

--- a/packages/shared/sdk-server/src/store/TransactionalFeatureStore.ts
+++ b/packages/shared/sdk-server/src/store/TransactionalFeatureStore.ts
@@ -128,4 +128,15 @@ export default class TransactionalFeatureStore implements LDTransactionalFeature
   getDescription(): string {
     return 'transactional persistent store';
   }
+
+  // applyChanges always writes here first, so the memory store has the latest
+  // metadata/selector even while _activeStore still points at the persistence
+  // store; the plain LDFeatureStore contract has no equivalent to read them from
+  getInitMetaData(): internal.InitMetadata | undefined {
+    return this._memoryStore.getInitMetaData?.();
+  }
+
+  getSelector(): string | undefined {
+    return this._memoryStore.getSelector?.();
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core feature-store wiring for FDv2 data system configs; incorrect wrapping could affect flag payload consistency for custom persistent stores.
> 
> **Overview**
> **FDv2 `dataSystem.persistentStore` handling** now always returns an `LDTransactionalFeatureStore`. FDv1-only stores (e.g. Redis/Dynamo integrations without `applyChanges`) are wrapped in `TransactionalFeatureStore` so FDv2 updates no longer throw `applyChanges is not a function`. Stores that already expose `applyChanges` are returned unchanged so native transactional behavior is preserved. The same logic applies when the store is provided as a factory.
> 
> **`TransactionalFeatureStore`** forwards `getSelector` and `getInitMetaData` from its in-memory layer so selector/init metadata stay correct before and after a basis, without surfacing metadata written only on the underlying persistence store pre-basis.
> 
> Tests cover Configuration wrapping/pass-through and transactional metadata/selector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2125f36f870a3957de86f23a48b7202652b491a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->