### PR TITLE
fix: Only redact anonymous contexts in custom events for server SDKs

### DIFF
--- a/packages/sdk/electron/contract-tests/entity/src/main.ts
+++ b/packages/sdk/electron/contract-tests/entity/src/main.ts
@@ -24,7 +24,6 @@ const capabilities = [
   'client-per-context-summaries',
   'track-hooks',
   'tls:skip-verify-peer',
-  'secure-mode-hash',
   'event-gzip',
 
   /// ////////////////////////////

--- a/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
+++ b/packages/shared/common/__tests__/internal/events/EventProcessor.test.ts
@@ -472,8 +472,17 @@ describe('given an event processor', () => {
     const userObj = { key: 'user-key', kind: 'user', name: 'Example user', anonymous: true };
     const context = Context.fromLDContext(userObj);
 
+    // Migration events are server-only; servers set redactAnonymousAllEvents: true so anonymous
+    // contexts are redacted.
+    const serverEventProcessor = new EventProcessor(
+      { ...eventProcessorConfig, redactAnonymousAllEvents: true },
+      clientContext,
+      {},
+      new ContextDeduplicator(),
+    );
+
     Date.now = jest.fn(() => 1000);
-    eventProcessor.sendEvent({
+    serverEventProcessor.sendEvent({
       kind: 'migration_op',
       operation: 'read',
       creationDate: 1000,
@@ -488,7 +497,8 @@ describe('given an event processor', () => {
       samplingRatio: 1,
     });
 
-    await eventProcessor.flush();
+    await serverEventProcessor.flush();
+    serverEventProcessor.close();
 
     const redactedContext = {
       kind: 'user',
@@ -737,8 +747,46 @@ describe('given an event processor', () => {
 
     await eventProcessor.flush();
 
-    // The custom event inlines the context, so an anonymous context's attributes are redacted.
-    // The index event is not subject to anonymous redaction and keeps the full context.
+    // By default (redactAnonymousAllEvents unset -> false, the client-side behavior) custom events
+    // do NOT redact an anonymous context's attributes; the full context is sent.
+    expect(mockSendEventData).toBeCalledWith(LDEventType.AnalyticsEvents, [
+      {
+        kind: 'index',
+        creationDate: 1000,
+        context: { ...anonUser, kind: 'user' },
+      },
+      {
+        kind: 'custom',
+        key: 'eventkey',
+        data: { thing: 'stuff' },
+        creationDate: 1000,
+        context: { ...anonUser, kind: 'user' },
+      },
+    ]);
+  });
+
+  it('redacts anonymous context in custom event when redactAnonymousAllEvents is true', async () => {
+    // Server-side SDKs set redactAnonymousAllEvents: true so custom events redact an anonymous
+    // context's attributes, just like feature events.
+    const serverEventProcessor = new EventProcessor(
+      { ...eventProcessorConfig, redactAnonymousAllEvents: true },
+      clientContext,
+      {},
+      new ContextDeduplicator(),
+    );
+
+    serverEventProcessor.sendEvent({
+      kind: 'custom',
+      creationDate: 1000,
+      context: Context.fromLDContext(anonUser),
+      key: 'eventkey',
+      data: { thing: 'stuff' },
+      samplingRatio: 1,
+    });
+
+    await serverEventProcessor.flush();
+    serverEventProcessor.close();
+
     const redactedAnonUser = {
       key: 'anon-user',
       kind: 'user',

--- a/packages/shared/common/src/internal/events/EventProcessor.ts
+++ b/packages/shared/common/src/internal/events/EventProcessor.ts
@@ -109,6 +109,11 @@ export interface EventProcessorOptions {
   eventsCapacity: number;
   flushInterval: number;
   diagnosticRecordingInterval: number;
+  // Whether anonymous context attributes are redacted across all inlined events (custom and
+  // migration op events), in addition to feature events which always redact them. Defaults to
+  // false (redact only feature events, the client-side behavior); server-side SDKs set this to
+  // true so anonymous contexts are redacted on every event kind.
+  redactAnonymousAllEvents?: boolean;
 }
 
 function isMultiEventSummarizer(summarizer: unknown): summarizer is LDMultiEventSummarizer {
@@ -264,7 +269,10 @@ export default class EventProcessor implements LDEventProcessor {
         const migrationEvent: MigrationOutputEvent = {
           ...inputEvent,
           context: inputEvent.context
-            ? this._contextFilter.filter(inputEvent.context, true)
+            ? this._contextFilter.filter(
+                inputEvent.context,
+                this._config.redactAnonymousAllEvents ?? false,
+              )
             : undefined,
         };
         if (migrationEvent.samplingRatio === 1) {
@@ -361,7 +369,10 @@ export default class EventProcessor implements LDEventProcessor {
           kind: 'custom',
           creationDate: event.creationDate,
           key: event.key,
-          context: this._contextFilter.filter(event.context, true),
+          context: this._contextFilter.filter(
+            event.context,
+            this._config.redactAnonymousAllEvents ?? false,
+          ),
         };
 
         if (event.samplingRatio !== 1) {

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -166,7 +166,9 @@ function constructFDv1(
     eventProcessor = new NullEventProcessor();
   } else {
     eventProcessor = new internal.EventProcessor(
-      config,
+      // Server-side SDKs redact anonymous context attributes on all inlined events (feature,
+      // custom, migration op), not just feature events.
+      { ...config, redactAnonymousAllEvents: true },
       clientContext,
       baseHeaders,
       new ContextDeduplicator(config),
@@ -312,7 +314,9 @@ function constructFDv2(
     eventProcessor = new NullEventProcessor();
   } else {
     eventProcessor = new internal.EventProcessor(
-      config,
+      // Server-side SDKs redact anonymous context attributes on all inlined events (feature,
+      // custom, migration op), not just feature events.
+      { ...config, redactAnonymousAllEvents: true },
       clientContext,
       baseHeaders,
       new ContextDeduplicator(config),


### PR DESCRIPTION
## Summary

PR #1809 made custom (and migration op) events redact anonymous context attributes for all SDKs built on this monorepo. However, an audit of the other LaunchDarkly client/mobile SDKs (.NET, Flutter, iOS, C++, Roku, Android) shows they redact anonymous contexts **only in feature events** -- custom events keep the full context. Client-side js-core SDKs should match that.

This adds `EventProcessorOptions.redactAnonymousAllEvents`, defaulting to `false` (redact anonymous contexts only in feature events -- the client-side behavior). Server-side SDKs (`sdk-server` `LDClientImpl`, and edge SDKs via it) set it to `true`, so their custom and migration op events continue to redact anonymous contexts. Feature-event redaction (non-debug) is unchanged for both, and client SDKs need no change -- they inherit the default.

Regression tests cover: default (custom not redacted), `redactAnonymousAllEvents: true` (custom redacted), and migration op (server, redacted).

Verified against the SDK contract test harness: node-client passes with custom events unredacted; server-node passes with custom + migration op events redacted.

Relates to SDK-2722.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what PII is sent in analytics for anonymous users on client custom events (more data than the regression), while preserving server behavior; behavior is contract-tested but affects event payloads.
> 
> **Overview**
> Reverts the **client-side** behavior introduced in PR #1809 where **custom** and **migration op** events always redacted anonymous context attributes. Other LaunchDarkly client/mobile SDKs only redact anonymous contexts in **feature** events; this change aligns js-core clients with that.
> 
> Adds optional **`redactAnonymousAllEvents`** on `EventProcessorOptions` (default **`false`**). **Custom** and **migration op** inlined contexts now call `ContextFilter.filter` with that flag instead of always passing `true`. **Feature** event redaction is unchanged (non-debug feature events still always redact).
> 
> **Server** SDKs (`LDClientImpl` for FDv1 and FDv2) pass **`redactAnonymousAllEvents: true`**, so server custom and migration op events keep full anonymous redaction. Client SDKs need no code changes.
> 
> Tests now assert the default (anonymous custom events **not** redacted), server mode (custom redacted), and migration op under server config. Electron contract harness drops the unused **`secure-mode-hash`** capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7daead6e7b769e5e401902084f425b07cf745ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->