### PR TITLE
ci: configure RN to release as a prerelease version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -248,6 +248,12 @@ jobs:
         with:
           workspace_path: packages/sdk/react-native
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          # React Native SDK v11 is a breaking major version currently released as a
+          # prerelease, so npm publishes it under the generic `prerelease` dist-tag
+          # rather than `latest`, which keeps pointing at v10 until GA. Remove this
+          # line, and the matching `prerelease` entries in release-please-config.json,
+          # once v11 goes GA.
+          prerelease: true
 
   release-browser:
     runs-on: ubuntu-latest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -144,6 +144,8 @@
       ]
     },
     "packages/sdk/react-native": {
+      "prerelease": true,
+      "prerelease-type": "beta",
       "extra-files": [
         "src/platform/PlatformInfo.ts",
         {


### PR DESCRIPTION
This is to prep a major version update of RN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and release-please config only; no runtime SDK code changes, with explicit revert path at GA.
> 
> **Overview**
> Configures **React Native SDK** automated releases for the upcoming **v11** major so versions ship as **beta prereleases** instead of updating npm **`latest`** (still on v10 until GA).
> 
> **release-please-config.json** now sets `prerelease: true` and `prerelease-type: beta` for `packages/sdk/react-native`, so release-please bumps with beta suffixes. The **release-react-native** workflow passes `prerelease: true` into `full-release`, which publishes without moving the `latest` dist-tag. Comments note removing both once v11 is GA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa69d17f1277b896977e4964ef3508d23a4ddc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->