### PR TITLE
test: declare client-prereq-cycle-detection capability in wrappers

### DIFF
--- a/packages/sdk/electron/contract-tests/entity/src/main.ts
+++ b/packages/sdk/electron/contract-tests/entity/src/main.ts
@@ -21,6 +21,7 @@ const capabilities = [
   'anonymous-redaction',
   'strongly-typed',
   'client-prereq-events',
+  'client-prereq-cycle-detection',
   'client-per-context-summaries',
   'track-hooks',
   'tls:skip-verify-peer',

--- a/packages/sdk/node-client/contract-tests/src/index.ts
+++ b/packages/sdk/node-client/contract-tests/src/index.ts
@@ -29,6 +29,7 @@ app.get('/', (req: Request, res: Response) => {
       'inline-context',
       'inline-context-all',
       'client-prereq-events',
+      'client-prereq-cycle-detection',
       'client-per-context-summaries',
       'evaluation-hooks',
       'track-hooks',

--- a/packages/sdk/react-native/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/react-native/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -55,6 +55,7 @@ export default class TestHarnessWebSocket {
             'anonymous-redaction',
             'strongly-typed',
             'client-prereq-events',
+            'client-prereq-cycle-detection',
             'client-per-context-summaries',
             'track-hooks',
           ];

--- a/packages/sdk/react/contract-tests/app/TestHarnessWebSocket.ts
+++ b/packages/sdk/react/contract-tests/app/TestHarnessWebSocket.ts
@@ -46,6 +46,7 @@ export default class TestHarnessWebSocket {
             'anonymous-redaction',
             'strongly-typed',
             'client-prereq-events',
+            'client-prereq-cycle-detection',
             'client-per-context-summaries',
             'track-hooks',
           ];


### PR DESCRIPTION
## Summary

Adds the `client-prereq-cycle-detection` capability to each wrapper's contract-test service so the [sdk-test-harness](https://github.com/launchdarkly/sdk-test-harness) exercises cycle scenarios against them. This closes the wrapper subtasks under the parent cycle-protection effort.

Tracker: [SDK-2711](https://launchdarkly.atlassian.net/browse/SDK-2711) (React), [SDK-2712](https://launchdarkly.atlassian.net/browse/SDK-2712) (React Native), [SDK-2713](https://launchdarkly.atlassian.net/browse/SDK-2713) (Electron), [SDK-2714](https://launchdarkly.atlassian.net/browse/SDK-2714) (Node client), [SDK-2715](https://launchdarkly.atlassian.net/browse/SDK-2715) (Vue). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695).

## Context

The defensive prerequisite-cycle guard lives in the shared `@launchdarkly/js-client-sdk-common` package. It shipped as v1.30.0 in release [#1805](https://github.com/launchdarkly/js-core/pull/1805) (merged 2026-07-21), which cascaded fresh releases to every wrapper that depends on it:

| Package | Version | Depends on |
|---|---|---|
| `@launchdarkly/js-client-sdk-common` | 1.30.0 | — (contains the fix) |
| `@launchdarkly/js-client-sdk` | 4.9.2 | js-client-sdk-common 1.30.0 |
| `@launchdarkly/node-client-sdk` | 0.4.2 | js-client-sdk-common 1.30.0 |
| `@launchdarkly/react-native-client-sdk` | 10.19.2 | js-client-sdk-common 1.30.0 |
| `@launchdarkly/react-sdk` | 4.1.6 | js-client-sdk 4.9.2 → 1.30.0 |
| `@launchdarkly/vue-client-sdk` | 0.1.2 | js-client-sdk 4.9.2 → 1.30.0 |

Users installing the latest wrapper from npm get the cycle-guarded shared library transitively, so no dependency bumps are needed in this PR — release-please's `node-workspace` plugin already handled the cascade. `@launchdarkly/electron-client-sdk` is pre-release (0.0.1, unpublished); when it first publishes, its `workspace:^` reference resolves to the current shared version.

Each wrapper's `variation()` is a direct passthrough to the shared `LDClientImpl`, so the guard flows through unchanged. Wrappers only need to declare the harness capability so the matching contract tests activate.

## Changes

Four one-line additions, one per wrapper contract-test service:

- `packages/sdk/react/contract-tests/app/TestHarnessWebSocket.ts`
- `packages/sdk/react-native/contract-tests/entity/src/TestHarnessWebSocket.ts`
- `packages/sdk/electron/contract-tests/entity/src/main.ts`
- `packages/sdk/node-client/contract-tests/src/index.ts`

Vue is omitted intentionally: its wrapper package has no contract-test service (jest-only unit tests). Its coverage is provided algorithmically by the shared library.

## Test plan

- [x] `yarn install` clean.
- [x] Topological builds (all 5 wrappers + shared deps) clean.
- [x] Unit tests: **react** 208/208, **react-native** 85/85, **electron** 215/215, **node-client** 144/144, **vue** 81/81.
- [x] Lint clean across all 5 (node-client has pre-existing warnings, 0 errors).
- [x] **node-client contract tests**: 888 total, 15 skipped, 873 ran, all passed — including every `events/summary events/prerequisites/handles cycles/*` and `events/prerequisite events handle cycles/*` scenario.
- [ ] react / electron contract tests: will run in CI (require Playwright / Electron binaries not installed locally).
- [ ] react-native contract tests: will run in CI (require Android emulator + adb).

[SDK-2711]: https://launchdarkly.atlassian.net/browse/SDK-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2712]: https://launchdarkly.atlassian.net/browse/SDK-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2713]: https://launchdarkly.atlassian.net/browse/SDK-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2714]: https://launchdarkly.atlassian.net/browse/SDK-2714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2715]: https://launchdarkly.atlassian.net/browse/SDK-2715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness capability strings only; no production SDK or evaluation logic changes.
> 
> **Overview**
> Adds **`client-prereq-cycle-detection`** to the capability lists returned by the React, React Native, Electron, and Node client **contract-test** services so the sdk-test-harness runs prerequisite **cycle** scenarios against those wrappers.
> 
> This is harness metadata only; cycle handling remains in shared `@launchdarkly/js-client-sdk-common`. Vue is unchanged (no contract-test service).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bceb02acb15caeca28cd569e787c9070a630e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->