### PR TITLE
ci: update runners to test with node 22 instead of 20

### DIFF
--- a/.cursor/rules/development.mdc
+++ b/.cursor/rules/development.mdc
@@ -15,7 +15,7 @@ alwaysApply: true
   - Tooling packages (development tools)
 
 ## Build Requirements
-- Node environment version 20 required, this is a minimum.
+- Node environment version 22 required, this is a minimum.
 - yarn required
 - Some projects may have specific environment prerequisites
 

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [20, 22]
+        version: [22, 24]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,7 +34,7 @@ jobs:
           workspace_name: '@launchdarkly/js-client-sdk'
           workspace_path: packages/sdk/browser
       - name: Check package size
-        if: github.event_name == 'pull_request' && matrix.version == '22'
+        if: github.event_name == 'pull_request' && matrix.version == '24'
         uses: ./actions/package-size
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/combined-browser.yml
+++ b/.github/workflows/combined-browser.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [20, 22]
+        version: [22, 24]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,7 +34,7 @@ jobs:
           workspace_name: '@launchdarkly/browser'
           workspace_path: packages/sdk/combined-browser
       - name: Check package size
-        if: github.event_name == 'pull_request' && matrix.version == '22'
+        if: github.event_name == 'pull_request' && matrix.version == '24'
         uses: ./actions/package-size
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [20, 22]
+        version: [22, 24]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./actions/setup-yarn

--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # Node versions to run on.
-        version: [20, 22]
+        version: [22, 24]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./actions/setup-yarn
         with:
-          node-version: 20
+          node-version: 22
       # Installs and starts Dante directly on the runner rather than in a container - see
       # proxy/setup.sh.
       - name: Install and start Dante (SOCKS proxy)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
   - Tooling packages (development tools)
 
 ## Build Requirements
-- Node environment version 20 required (minimum)
+- Node environment version 22 required (minimum)
 - yarn required
 - Some projects may have specific environment prerequisites
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
 
 ### Prerequisites
 
-A node environment of version 20 and npm or yarn are required to develop in this repository.
+A node environment of version 22 and npm or yarn are required to develop in this repository.
 
 This monorepo may contain projects that are not suitable for execution using node, and those
 projects will have specific environment prerequisites.

--- a/packages/sdk/cloudflare/example/README.md
+++ b/packages/sdk/cloudflare/example/README.md
@@ -5,7 +5,7 @@ SDK. This app was created with wrangler v2.
 
 ## Prerequisites
 
-A node environment of version 16 and yarn are required to develop in this repository.
+A node environment of version 22 and yarn are required to develop in this repository.
 You will also need the wrangler cli installed and a Cloudflare account to setup
 the test data required by this example. See the [wrangler docs](https://developers.cloudflare.com/workers/wrangler/commands/#login)
 on how to login to your Cloudflare account. Make sure you are logged in before

--- a/packages/sdk/electron/example/README.md
+++ b/packages/sdk/electron/example/README.md
@@ -8,7 +8,7 @@ This example was scaffolded with [Electron Forge](https://www.electronforge.io/)
 
 ## Prerequisites
 
-- Node.js 16 or later
+- Node.js 22 or later
 - Yarn
 
 ## Build instructions

--- a/packages/sdk/fastly/example/README.md
+++ b/packages/sdk/fastly/example/README.md
@@ -15,7 +15,7 @@ Cat photo by [Sergey Semin](https://unsplash.com/@feneek?utm_content=creditCopyT
 
 ## Prerequisites
 
-A node environment of version 16 and yarn are required to develop in this repository.
+A node environment of version 22 and yarn are required to develop in this repository.
 You will also need the [Fastly CLI](https://developer.fastly.com/learning/tools/cli) installed and a Fastly account to setup
 the test data required by this example. If you don't have a Fastly account, you can sign up for a free developer account [here](https://www.fastly.com/signup?tier=free).
 

--- a/packages/sdk/fastly/example/package.json
+++ b/packages/sdk/fastly/example/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^16 || >=18"
+    "node": ">=22"
   },
   "devDependencies": {
     "@fastly/cli": "^10.19.0",

--- a/packages/sdk/vercel/examples/route-handler/README.md
+++ b/packages/sdk/vercel/examples/route-handler/README.md
@@ -7,7 +7,7 @@ Most of the LaunchDarkly-related code can be found in [src/app/api/hello/route.t
 
 ## Prerequisites
 
-A node environment of version 16 and yarn are required to develop in this repository.
+A node environment of version 22 and yarn are required to develop in this repository.
 You will also need the [Vercel CLI](https://vercel.com/docs/cli) installed and a Vercel account to setup
 the test data required by this example. See the [Vercel docs](https://vercel.com/docs/storage/edge-config/get-started) on how to setup your Edge Config store.
 


### PR DESCRIPTION
This PR will update the node version matrix to a supported version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI matrix changes only; no SDK runtime or application logic is modified.
> 
> **Overview**
> Raises the repo’s **minimum Node version from 20 to 22** in contributor docs (`.cursor/rules/development.mdc`, `CLAUDE.md`, `CONTRIBUTING.md`) and aligns several example READMEs (Cloudflare, Electron, Fastly, Vercel) with that requirement.
> 
> **CI** now runs the browser, combined-browser, React, and server-node workflows on **Node 22 and 24** instead of 20 and 22. PR package-size checks for browser and combined-browser run on **Node 24** (previously 22). The server-node custom SOCKS proxy example job uses **Node 22** instead of 20.
> 
> The Fastly example’s `package.json` **`engines.node`** is tightened from `^16 || >=18` to **`>=22`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b04a14a2a5dc536016f162b72115a801583d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->