### PR TITLE
fix: Bump vercel SDK to latest 

### DIFF
--- a/packages/sdk/react/examples/vercel-edge/package.json
+++ b/packages/sdk/react/examples/vercel-edge/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@launchdarkly/react-sdk": "4.1.9",
     "@launchdarkly/vercel-server-sdk": "1.3.53",
-    "@vercel/edge-config": "^1.1.0",
+    "@vercel/edge-config": "^1.5.0",
     "next": "^16",
     "react": "^19",
     "react-dom": "^19"

--- a/packages/sdk/vercel/examples/complete/package.json
+++ b/packages/sdk/vercel/examples/complete/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@launchdarkly/vercel-server-sdk": "1.3.53",
-    "@vercel/edge-config": "^1.1.0",
+    "@vercel/edge-config": "^1.5.0",
     "launchdarkly-js-client-sdk": "^3.1.3",
     "launchdarkly-react-client-sdk": "^3.0.6",
     "next": "15.5.18",

--- a/packages/sdk/vercel/examples/route-handler/package.json
+++ b/packages/sdk/vercel/examples/route-handler/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@launchdarkly/vercel-server-sdk": "workspace:^",
-    "@vercel/edge-config": "^1.1.0",
+    "@vercel/edge-config": "^1.5.0",
     "next": "15.5.18",
     "react": "^18.2.0",
     "react-dom": "18.2.0"

--- a/packages/sdk/vercel/package.json
+++ b/packages/sdk/vercel/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@launchdarkly/js-server-sdk-common-edge": "2.6.27",
-    "@vercel/edge-config": "^1.1.0"
+    "@vercel/edge-config": "^1.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.slack.com/archives/C0A8848NH40/p1785352354944209?thread_ts=1785142569.399029&cid=C0A8848NH40

**Describe the solution you've provided**

Vercel said this is the likely cause to the issues I saw in the slack thread linked above. tl;dr one flow of the marketplace integration is blocked because our sdk is on an older version that their new sdk updates don't support. 

**Describe alternatives you've considered**

I could downgrade Vercel's templates, but i figured this would be an easy change for us. And its probably better to be on the latest anyways. 

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no logic changes; main risk is minor breakage if edge-config 1.5.x changes APIs used by the SDK (mitigated by existing tests).
> 
> **Overview**
> Bumps **`@vercel/edge-config`** from **`^1.1.0`** to **`^1.5.0`** on `@launchdarkly/vercel-server-sdk` and the Vercel-related example apps (complete, route-handler, react vercel-edge).
> 
> There are **no application or SDK source changes**—only dependency version updates in `package.json` files. This aligns the SDK with Vercel’s current Edge Config client so marketplace / integration flows that expect the newer package aren’t blocked by an outdated transitive dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430b2710904701acd26f8f23dff86474289d714f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->