### PR TITLE
feat!: release @launchdarkly/node-client-sdk@4.0.0

### DIFF
--- a/packages/sdk/node-client/README.md
+++ b/packages/sdk/node-client/README.md
@@ -6,12 +6,6 @@
 [![NPM][node-client-dm-badge]][node-client-npm-link]
 [![NPM][node-client-dt-badge]][node-client-npm-link]
 
-> [!CAUTION]
-> This SDK is in pre-release and not subject to backwards compatibility
-> guarantees. The API may change based on feedback.
->
-> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
-
 ## Getting started
 
 Refer to the [SDK documentation](https://launchdarkly.com/docs/sdk/client-side/node-js#getting-started) for instructions on getting started with using the SDK.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -159,8 +159,7 @@
       ]
     },
     "packages/sdk/node-client": {
-      "bump-minor-pre-major": true,
-      "prerelease": true,
+      "release-as": "4.0.0",
       "extra-files": [
         "src/platform/NodeInfo.ts",
         {


### PR DESCRIPTION
This release ports launchdarkly-node-client-sdk onto js-core. The package
moves to @launchdarkly/node-client-sdk and rebases on
@launchdarkly/js-client-sdk-common, picking up the shared client-side
foundation used by the browser and combined-browser SDKs. Consumers
should follow the migration guide for the new initialization flow,
extension surfaces (hooks, inspectors, plugins), and the on-disk cache
format change. See https://launchdarkly.com/docs/sdk/client-side/node-js
for full SDK documentation.

BEGIN_COMMIT_OVERRIDE
BREAKING-CHANGE: The package name changed from `launchdarkly-node-client-sdk` to `@launchdarkly/node-client-sdk`.
BREAKING-CHANGE: Initialization is now done with `createClient` and `start` (see docs).
BREAKING-CHANGE: Minimum Node version is now `>=18`.
BREAKING-CHANGE: The on-disk persistent cache format changed; v3 cache data will not be read by v4 and the anonymous key will be regenerated on first identify.

feat!: `identify()` resolves an identify result and no longer throws
feat: Evaluation, identify, and track hooks
feat: Inspector support for flag and context state
feat: Plugin extension surface with `applicationInfo` metadata
feat: Runtime connection-mode control via `setConnectionMode`
feat: Storage configuration with file-backed default and custom-implementation override
feat: TLS configuration via `tlsParams`
feat: support client side secure mode with client side id
feat: support wrapper header
feat: Add useMobileKey option to NodeOptions
END_COMMIT_OVERRIDE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release tooling only; no runtime SDK code changes in this diff.
> 
> **Overview**
> Prepares **`@launchdarkly/node-client-sdk`** for a **4.0.0** GA release by updating release automation and package docs.
> 
> **`release-please-config.json`** stops treating `packages/sdk/node-client` as a prerelease (`bump-minor-pre-major` / `prerelease`) and pins the next release with **`release-as`: `4.0.0`**.
> 
> The **node-client README** drops the pre-release **CAUTION** block that warned about API instability and pinning to minor versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467b7ba968faf36b0e5e850c971f7fe561d8207e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->