### PR TITLE
fix(sdk-client-common): `identify()` bootstrap does not set flagstore in FDv2

### DIFF
--- a/packages/shared/sdk-client/__tests__/datasource/FDv2DataManagerBase.test.ts
+++ b/packages/shared/sdk-client/__tests__/datasource/FDv2DataManagerBase.test.ts
@@ -84,6 +84,7 @@ function makeFlagManager() {
     init: jest.fn(),
     upsert: jest.fn(),
     applyChanges: jest.fn().mockResolvedValue(undefined),
+    setBootstrap: jest.fn(),
     get: jest.fn(),
     getAll: jest.fn(),
     on: jest.fn(),
@@ -216,6 +217,51 @@ it('resolves identify immediately when bootstrap is provided', async () => {
   const { resolve } = await identifyManager(manager, { bootstrap: {} });
 
   expect(resolve).toHaveBeenCalledTimes(1);
+
+  manager.close();
+});
+
+it('applies bootstrap data to the flag manager on identify', async () => {
+  const flagManager = makeFlagManager();
+  const manager = createFDv2DataManagerBase(makeBaseConfig({ flagManager }));
+  const bootstrap = {
+    'string-flag': 'is bob',
+    $flagsState: { 'string-flag': { variation: 1, version: 3 } },
+    $valid: true,
+  };
+
+  await identifyManager(manager, { bootstrap });
+
+  expect(flagManager.setBootstrap).toHaveBeenCalledWith(expect.anything(), {
+    'string-flag': { version: 3, flag: { version: 3, variation: 1, value: 'is bob' } },
+  });
+
+  manager.close();
+});
+
+it('applies new bootstrap data to the flag manager on re-identify', async () => {
+  const flagManager = makeFlagManager();
+  const manager = createFDv2DataManagerBase(makeBaseConfig({ flagManager }));
+
+  await identifyManager(manager, {
+    bootstrap: {
+      'string-flag': 'is bob',
+      $flagsState: { 'string-flag': { variation: 1, version: 3 } },
+      $valid: true,
+    },
+  });
+  await identifyManager(manager, {
+    bootstrap: {
+      'string-flag': 'is alice',
+      $flagsState: { 'string-flag': { variation: 0, version: 4 } },
+      $valid: true,
+    },
+  });
+
+  expect(flagManager.setBootstrap).toHaveBeenCalledTimes(2);
+  expect(flagManager.setBootstrap).toHaveBeenLastCalledWith(expect.anything(), {
+    'string-flag': { version: 4, flag: { version: 4, variation: 0, value: 'is alice' } },
+  });
 
   manager.close();
 });

--- a/packages/shared/sdk-client/src/datasource/FDv2DataManagerBase.ts
+++ b/packages/shared/sdk-client/src/datasource/FDv2DataManagerBase.ts
@@ -15,6 +15,7 @@ import {
 import { LDIdentifyOptions } from '../api/LDIdentifyOptions';
 import { Configuration } from '../configuration/Configuration';
 import { DataManager } from '../DataManager';
+import { readFlagsFromBootstrap } from '../flag-manager/bootstrap';
 import { FlagManager } from '../flag-manager/FlagManager';
 import LDEmitter from '../LDEmitter';
 import { namespaceForEnvironment } from '../storage/namespaceUtils';
@@ -559,10 +560,14 @@ export function createFDv2DataManagerBase(
       bootstrapped = identifyOptions?.bootstrap !== undefined;
 
       if (bootstrapped) {
-        // Bootstrap data was already applied to the flag store by the
-        // caller (BrowserClient.start → presetFlags) before identify
-        // was called. Resolve immediately — flag evaluations will use
-        // the bootstrap data synchronously.
+        let { bootstrapParsed } = identifyOptions!;
+        if (!bootstrapParsed) {
+          bootstrapParsed = readFlagsFromBootstrap(logger, identifyOptions!.bootstrap);
+        }
+        flagManager.setBootstrap(context, bootstrapParsed);
+
+        // Resolve immediately - flag evaluations will use the bootstrap
+        // data right away.
         initialized = true;
         statusManager.requestStateUpdate('VALID');
         // selector remains undefined — bootstrap data has no selector.


### PR DESCRIPTION
This PR will fix per-context bootstrap behavior for FDv2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identify/bootstrap flag-store wiring for FDv2; incorrect parsing or context mapping would break per-context evaluations, but scope is limited and covered by new tests.
> 
> **Overview**
> **FDv2 `identify()` now loads bootstrap into the per-context flag store** instead of assuming the caller already applied it (e.g. via `presetFlags` before identify).
> 
> When `identifyOptions.bootstrap` is present, `FDv2DataManagerBase` parses it with `readFlagsFromBootstrap` (or uses pre-parsed `bootstrapParsed`) and calls **`flagManager.setBootstrap(context, …)`** for the identified context, then resolves identify immediately as before.
> 
> Tests cover **`setBootstrap` on first identify and on re-identify** with updated bootstrap payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17186eaf11252c420b6d1a0310a6d7472da7f537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->