### PR TITLE
ci(node-client-sdk): post release clean up

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -159,7 +159,6 @@
       ]
     },
     "packages/sdk/node-client": {
-      "release-as": "4.0.0",
       "extra-files": [
         "src/platform/NodeInfo.ts",
         {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release automation config only; no runtime SDK or dependency behavior changes.
> 
> **Overview**
> Removes the **`release-as": "4.0.0"`** override from the `packages/sdk/node-client` entry in `release-please-config.json`, leaving only the existing `extra-files` configuration.
> 
> This is post-release cleanup after the node client SDK 4.0.0 ship: the pin forced that version during release; without it, **release-please** will version future changes from conventional commits and the package changelog as usual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382c3867fcda584c019c221e8b11fab041dd784b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->