### PR TITLE
fix(react-sdk): `basicLogger` was not re-exported causing compile time errors

### DIFF
--- a/packages/sdk/react/examples/features/bootstrap/src/index.tsx
+++ b/packages/sdk/react/examples/features/bootstrap/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import {
+  basicLogger,
   createLDReactProvider,
   LDContext,
   LDReactProviderOptions,
@@ -40,7 +41,13 @@ if (!bootstrapData || !context) {
 } else {
   // Pass the server-evaluated payload as `bootstrap` so the client renders real flag values
   // on first paint instead of waiting for the SDK to fetch them.
-  const options: LDReactProviderOptions = { bootstrap: bootstrapData };
+  //
+  // basicLogger is used here instead of the default logger so this example doubles as an
+  // example on how to override the default logger.
+  const options: LDReactProviderOptions = {
+    bootstrap: bootstrapData,
+    ldOptions: { logger: basicLogger({ level: 'info', destination: console.log }) },
+  };
   const LDReactProvider = createLDReactProvider(clientSideId, context, options);
 
   root.render(

--- a/packages/sdk/react/src/client/index.ts
+++ b/packages/sdk/react/src/client/index.ts
@@ -1,4 +1,5 @@
-export * from '@launchdarkly/js-client-sdk';
+export type * from '@launchdarkly/js-client-sdk';
+export { basicLogger } from '@launchdarkly/js-client-sdk';
 export * from './LDClient';
 export * from './LDOptions';
 

--- a/packages/sdk/react/src/client/index.ts
+++ b/packages/sdk/react/src/client/index.ts
@@ -1,4 +1,4 @@
-export type * from '@launchdarkly/js-client-sdk';
+export * from '@launchdarkly/js-client-sdk';
 export * from './LDClient';
 export * from './LDOptions';
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/launchdarkly/js-core/issues/1842

**Describe the solution you've provided**
re-export `baseLogger` from base package

**Describe alternatives you've considered**
The following considerations were rejected:
- remove problematic type exports (eg `baseLogger`) - rejected because this would technically be a breaking change to the API
- re-export the full base package - we opted to go for a more conservative approach. For the most part, there shouldn't be too many use cases where `react-sdk` users will need to use something from the base `js-client-sdk`.

**Additional context**
I've added an import of `baseLogger` in an example which would serve as a regression test.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single public re-export and example-only usage; no runtime behavior change for existing consumers unless they adopt the new import.
> 
> **Overview**
> **Re-exports `basicLogger`** from `@launchdarkly/js-client-sdk` on the React SDK’s public entry (`packages/sdk/react/src/client/index.ts`), so apps can import it from `@launchdarkly/react-sdk` without compile errors (issue #1842).
> 
> The **bootstrap example** now imports `basicLogger` from the React package and passes it via `ldOptions.logger`, documenting logger override and acting as a regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0559003fe4f0e48cbdf2fddb422d2af1884930ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->