### PR TITLE
fix(oxygen-sdk): document event sending and align event sending logic with other edge sdks

### DIFF
--- a/packages/sdk/shopify-oxygen/README.md
+++ b/packages/sdk/shopify-oxygen/README.md
@@ -65,7 +65,24 @@ Basic SDK usage example
 const ldClient = await init(sdkKey, options);
 await ldClient.waitForInitialization({timeout: 10});
 const flagValue = await ldClient.variation(flagKey, context, defaultValue);
+
+// Flush events and close the client before returning your response.
+await ldClient.flush();
+ldClient.close();
 ```
+
+This SDK is designed to be created per request: call `init()` inside your request handler. Oxygen runs each
+request in its own execution context, and that execution context ends when your handler returns the response.
+The SDK therefore cannot use a periodic background flush to deliver analytics events, so how events are
+delivered is a decision you make in your handler:
+
+- **Do not call `flush()`.** Any events the SDK buffered during the request are discarded when the execution
+  context ends. This is a legitimate choice, and it is functionally equivalent to setting `sendEvents: false`.
+  The only difference is that the SDK still does the work of buffering events during the request.
+- **Call `flush()` before you return the response.** This is required for flag evaluation and identify
+  events to reach LaunchDarkly: call `await ldClient.flush()` at the end of every request that evaluates a
+  flag, as shown above. `close()` releases the client's timers but does not flush, so `close()` on its own
+  does not deliver events.
 
 Options
 -----------

--- a/packages/sdk/shopify-oxygen/__tests__/index.test.ts
+++ b/packages/sdk/shopify-oxygen/__tests__/index.test.ts
@@ -1,7 +1,27 @@
-import { LDClient, LDContext } from '@launchdarkly/js-server-sdk-common';
+import { internal, LDClient, LDContext } from '@launchdarkly/js-server-sdk-common';
 
-import { init, OxygenLDOptions } from '../src/index';
+import { init } from '../src/index';
 import { setupTestEnvironment } from './setup';
+
+jest.mock('@launchdarkly/js-sdk-common', () => {
+  const actual = jest.requireActual('@launchdarkly/js-sdk-common');
+  return {
+    ...actual,
+    ...{
+      internal: {
+        ...actual.internal,
+        DiagnosticsManager: jest.fn(),
+        // Other tests in this file exercise variation()/allFlagsState()/close() against a real
+        // client, so the mock must still behave like a usable event processor.
+        EventProcessor: jest.fn().mockImplementation(() => ({
+          close: jest.fn(),
+          sendEvent: jest.fn(),
+          flush: jest.fn().mockResolvedValue(undefined),
+        })),
+      },
+    },
+  };
+});
 
 const sdkKey = 'test-sdk-key';
 const flagKey1 = 'testFlag1';
@@ -11,8 +31,12 @@ const context: LDContext = { kind: 'user', key: 'test-user-key-1' };
 
 describe('Shopify Oxygen SDK', () => {
   describe('initialization tests', () => {
+    let mockEventProcessor = internal.EventProcessor as jest.Mock;
+
     beforeEach(async () => {
       await setupTestEnvironment();
+      mockEventProcessor = internal.EventProcessor as jest.Mock;
+      mockEventProcessor.mockClear();
     });
 
     it('will initialize successfully with default options', async () => {
@@ -28,7 +52,7 @@ describe('Shopify Oxygen SDK', () => {
         cache: {
           enabled: false,
         },
-      } as OxygenLDOptions);
+      });
       await ldClient.waitForInitialization();
       expect(ldClient).toBeDefined();
       ldClient.close();
@@ -36,6 +60,18 @@ describe('Shopify Oxygen SDK', () => {
 
     it('will fail to initialize if there is no SDK key', () => {
       expect(() => init(null as any)).toThrow();
+    });
+
+    it('constructs the event processor without background flush timers', async () => {
+      const ldClient = init(sdkKey, { sendEvents: true });
+      await ldClient.waitForInitialization();
+
+      // EventProcessor's 6th positional argument is `start`; asserting it's false confirms
+      // disableBackgroundEventFlush actually reaches the underlying processor.
+      expect(mockEventProcessor).toHaveBeenCalled();
+      expect(mockEventProcessor.mock.calls[0][5]).toBe(false);
+
+      ldClient.close();
     });
   });
 
@@ -53,7 +89,7 @@ describe('Shopify Oxygen SDK', () => {
           cache: {
             enabled: false,
           },
-        } as OxygenLDOptions);
+        });
         await ldClient.waitForInitialization();
       });
 

--- a/packages/sdk/shopify-oxygen/src/index.ts
+++ b/packages/sdk/shopify-oxygen/src/index.ts
@@ -1,4 +1,8 @@
-import { LDClientImpl, LDOptions } from '@launchdarkly/js-server-sdk-common';
+import {
+  LDClientImpl,
+  LDOptions,
+  ServerInternalOptions,
+} from '@launchdarkly/js-server-sdk-common';
 
 import Platform from './platform';
 import platformInfo from './platform/OxygenInfo';
@@ -10,9 +14,13 @@ export * from '@launchdarkly/js-server-sdk-common';
 export type { OxygenLDOptions };
 
 class LDClient extends LDClientImpl {
-  // sdkKey is only used to query featureStore, not to initialize with LD servers
   constructor(sdkKey: string, platform: Platform, options: LDOptions) {
-    super(sdkKey, platform, options, createCallbacks(options.logger));
+    const internalOptions: ServerInternalOptions = {
+      // Oxygen's execution context ends when the response is returned, which makes keeping a
+      // background flush loop meaningless.
+      disableBackgroundEventFlush: true,
+    };
+    super(sdkKey, platform, options, createCallbacks(options.logger), internalOptions);
   }
 }
 

--- a/packages/sdk/shopify-oxygen/src/utils/createOptions.ts
+++ b/packages/sdk/shopify-oxygen/src/utils/createOptions.ts
@@ -2,20 +2,20 @@ import { BasicLogger, LDOptions } from '@launchdarkly/js-server-sdk-common';
 
 import { OxygenLDOptions } from './validateOptions';
 
-// Most limitations could be explained in the following references:
+// The defaults below follow from Oxygen's platform constraints, documented here:
 // - https://shopify.dev/docs/storefronts/headless/hydrogen/fundamentals
 // - https://shopify.dev/docs/storefronts/headless/hydrogen/deployments/oxygen-runtime
 export const defaultOptions: LDOptions & OxygenLDOptions = {
-  // Streaming does not make sense for Oxygen worker environments as they are not designed to be long-lived.
-  // Specifically "Outbound API requests must complete within 2 minutes"
+  // Streaming doesn't fit Oxygen workers: they aren't long-lived, and outbound requests
+  // must complete within 2 minutes.
   stream: false,
 
-  // TODO: make sure this is necessary
+  // Diagnostics send an un-awaited POST per client, and Oxygen creates one client per
+  // request, so this stays off, this is consistent with our general edge sdk paradigm.
   diagnosticOptOut: true,
 
-  // 2 minutes is the maximum allowed time for outbound API requests
-  // so we set this to anything above that since we only want to have 1
-  // poll request per request handler execution.
+  // pollInterval only needs to clear that 2-minute limit, which caps this at one poll per
+  // request handler execution.
   pollInterval: 300,
 
   logger: new BasicLogger({ name: 'Shopify Oxygen SDK' }),

--- a/packages/sdk/shopify-oxygen/src/utils/validateOptions.ts
+++ b/packages/sdk/shopify-oxygen/src/utils/validateOptions.ts
@@ -1,15 +1,15 @@
 import { LDOptions as LDOptionsCommon } from '@launchdarkly/js-server-sdk-common';
 
 export type OxygenCacheOptions = {
-  // The time-to-live for the cache in seconds. The default is 30 seconds since that is the
-  // minimum allowed polling interval for other SDKs. If this SDK is too noisy, then we can
-  // enforce cache and a minimum ttl here.
+  // Defaults to 30 seconds, LaunchDarkly's floor for polling intervals, so caching below
+  // that buys nothing: a fresh poll couldn't arrive any faster anyway.
+  // TODO: enforce a minimum ttlSeconds here if real-world usage turns out too noisy.
   ttlSeconds?: number;
   name?: string;
   enabled?: boolean;
 };
 
-export type OxygenLDOptions = Pick<LDOptionsCommon, 'logger'> & {
+export type OxygenLDOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents'> & {
   cache?: OxygenCacheOptions;
 };
 


### PR DESCRIPTION
This PR will align the event sending configurations for Oxygen SDK with the other edge sdks:
- allow `sendEvent` option
- configure `disableBackgroundEventFlush` to `true`

This PR also adds more documentation and comments to clarify event sending behavior and options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Aligns the Shopify Oxygen SDK with other edge runtimes by passing **`disableBackgroundEventFlush: true`** into the server client so periodic flush timers are not started when each request spins up its own client.
> 
> **`OxygenLDOptions`** now includes **`sendEvents`**, and the README explains the per-request lifecycle: init in the handler, optional **`await ldClient.flush()`** before returning (required for analytics to reach LaunchDarkly), and that **`close()`** does not flush. Inline comments in default options and cache types are tightened for the same platform constraints.
> 
> Tests mock **`EventProcessor`** and assert the processor is constructed with background flush disabled (`start` / 6th argument `false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0287c90fdc09eefec5982760603c4b2102c8877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->