### PR TITLE
test: fix browser contract test to check start() status

### DIFF
--- a/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
@@ -334,18 +334,8 @@ export async function newSdkClientEntity(options: CreateInstanceParams) {
     initialContext,
     sdkConfig,
   );
-  let failed = false;
-  try {
-    await Promise.race([
-      client.start(),
-      new Promise((_resolve, reject) => {
-        setTimeout(reject, timeout);
-      }),
-    ]);
-  } catch (_) {
-    // we get here if waitForInitialization() rejects or if we timed out
-    failed = true;
-  }
+  const { status } = await client.start({ timeout: timeout / 1000 });
+  const failed = status !== 'complete';
   if (failed && !options.configuration.initCanFail) {
     client.close();
     throw new Error('client initialization failed');

--- a/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -49,12 +49,15 @@ export default class TestHarnessWebSocket {
 
           break;
         case 'createClient':
-          {
+          try {
+            const entity = await newSdkClientEntity(data.body);
             resData.resourceUrl = `/clients/${this._clientCounter}`;
             resData.status = 201;
-            const entity = await newSdkClientEntity(data.body);
             this._entities[this._clientCounter] = entity;
             this._clientCounter += 1;
+          } catch (e: any) {
+            resData.status = 500;
+            resData.error = e?.message ?? String(e);
           }
           break;
         case 'runCommand':


### PR DESCRIPTION
This PR is a quick fix on how browser contract test behaves where we were not testing the initialization status.

This change does not fix any tests at the moment, but _should_ make more nuanced initialization tests easier to implement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Browser contract test client setup now uses **`client.start({ timeout })`** and treats initialization as failed when **`status !== 'complete'`**, instead of racing `start()` against a manual timeout and treating any rejection as failure.
> 
> The test harness **`createClient`** handler wraps **`newSdkClientEntity`** in **try/catch** and returns **HTTP 500** with an error message when client creation/initialization fails, so harness failures surface explicitly rather than only via thrown errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3759d46690fc87d4962d24c18564112b23baa42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->