### PR TITLE
chore: Declare the hook-environment-id contract test capability

### DIFF
--- a/packages/sdk/server-node/contract-tests/src/index.ts
+++ b/packages/sdk/server-node/contract-tests/src/index.ts
@@ -39,6 +39,7 @@ app.get('/', (req: Request, res: Response) => {
       'inline-context-all',
       'anonymous-redaction',
       'evaluation-hooks',
+      'hook-environment-id',
       'wrapper',
       'client-prereq-events',
       'event-gzip',


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Depends on launchdarkly/sdk-test-harness#410, which adds the `hook-environment-id` capability and a test asserting `evaluationSeriesContext.environmentId`.

**Describe the solution you've provided**

The node server contract-test service only needed to declare the capability: `TestHook` forwards the whole `EvaluationSeriesContext` to the callback, so `environmentId` is already in the payload, and `HookRunner` gets it from `getInitMetaData()`.

Verified with a local build of the harness branch: `hooks/evaluation/provides the environment ID` passes.

**Describe alternatives you've considered**

None; no code change is required beyond the capability.

**Additional context**

The capability only takes effect once the harness change is released; until then it is ignored by the harness.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Registers the **`hook-environment-id`** contract-test capability on the Node server contract-test service so the harness can run the evaluation-hook test that checks **`evaluationSeriesContext.environmentId`**.
> 
> No SDK logic changes in this PR—the service already forwards the full evaluation series context (including environment ID from init metadata) to hook callbacks; this only advertises support to the test harness once the harness change is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd61913cbfd47ec9b5d42aacf89206a7b029be0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->