### PR TITLE
feat: Wire packages/sdk/vue into release-please as an active prerelease

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -608,6 +608,8 @@ jobs:
         with:
           workspace_path: packages/sdk/vue
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          # Vue SDK is publishing as a prerelease; remove this once it reaches GA so npm's `latest` tag starts tracking it.
+          prerelease: true
 
   manual-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -599,9 +599,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    # if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-vue-released == 'true'}}
-    # TODO: Uncomment this when the package is ready to be released.
-    if: false
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-vue-released == 'true'}}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: release-vue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,7 @@ flowchart LR
     react[sdk/react]
     shopify-oxygen[sdk/shopify-oxygen]
     openfeature-node-server[sdk/openfeature-node-server]
+    vue[sdk/vue]
 
     %% Store packages
     redis[store/node-server-sdk-redis]
@@ -192,6 +193,7 @@ flowchart LR
     sdk-client --> browser
     sdk-client --> react-native
     browser --> react
+    browser --> vue
     sdk-server --> react
     
     sdk-server --> server-node
@@ -219,7 +221,7 @@ flowchart LR
     react-native -.-> jest
     
     class common,sdk-client,sdk-server,sdk-server-edge,akamai-edgeworker,openfeature-server-common shared
-    class server-node,cloudflare,fastly,react-native,browser,vercel,akamai-base,akamai-edgekv,server-ai,react,shopify-oxygen,openfeature-node-server sdk
+    class server-node,cloudflare,fastly,react-native,browser,vercel,akamai-base,akamai-edgekv,server-ai,react,shopify-oxygen,openfeature-node-server,vue sdk
     class redis,dynamodb store
     class node-otel telemetry
     class jest tooling

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/server-sdk-ai](packages/sdk/server-ai/README.md)                | [![NPM][sdk-server-ai-npm-badge]][sdk-server-ai-npm-link]         | [server-ai][package-sdk-server-ai-issues]         | [![Actions Status][sdk-server-ai-ci-badge]][sdk-server-ai-ci]         |
 | [@launchdarkly/shopify-oxygen-sdk](packages/sdk/shopify-oxygen/README.md)      | [![NPM][sdk-shopify-oxygen-npm-badge]][sdk-shopify-oxygen-npm-link] | [Shopify Oxygen][package-sdk-shopify-oxygen-issues] | [![Actions Status][sdk-shopify-oxygen-ci-badge]][sdk-shopify-oxygen-ci] |
 | [@launchdarkly/react-sdk](packages/sdk/react/README.md)                       | [![NPM][sdk-react-npm-badge]][sdk-react-npm-link]                   | [React][package-sdk-react-issues]                   | [![Actions Status][sdk-react-ci-badge]][sdk-react-ci]                   |
+| [@launchdarkly/vue-client-sdk](packages/sdk/vue/README.md)                     | [![NPM][sdk-vue-npm-badge]][sdk-vue-npm-link]                       | [Vue][package-sdk-vue-issues]                       | [![Actions Status][sdk-vue-ci-badge]][sdk-vue-ci]                       |
 | [@launchdarkly/openfeature-node-server](packages/sdk/openfeature-node-server/README.md) | [![NPM][sdk-openfeature-node-server-npm-badge]][sdk-openfeature-node-server-npm-link] | [OpenFeature Node Server][package-sdk-openfeature-node-server-issues] | [![Actions Status][sdk-openfeature-node-server-ci-badge]][sdk-openfeature-node-server-ci] |
 <!--| [@launchdarkly/browser](packages/sdk/combined-browser/README.md)                  | [![NPM][sdk-combined-browser-npm-badge]][sdk-browser-npm-link]             | [Combined Browser][package-sdk-combined-browser-issues]             | [![Actions Status][sdk-combined-browser-ci-badge]][sdk-combined-browser-ci]             |-->
 
@@ -253,6 +254,12 @@ We encourage pull requests and other contributions from the community. Check out
 [sdk-react-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/react-sdk.svg?style=flat-square
 [sdk-react-npm-link]: https://www.npmjs.com/package/@launchdarkly/react-sdk
 [package-sdk-react-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Freact%22+
+[//]: # 'sdk/vue'
+[sdk-vue-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml/badge.svg
+[sdk-vue-ci]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml
+[sdk-vue-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/vue-client-sdk.svg?style=flat-square
+[sdk-vue-npm-link]: https://www.npmjs.com/package/@launchdarkly/vue-client-sdk
+[package-sdk-vue-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fvue%22+
 [//]: # 'shared/openfeature-server-common'
 [openfeature-js-server-common-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-js-server-common.svg?style=flat-square
 [openfeature-js-server-common-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-js-server-common

--- a/packages/sdk/vue/README.md
+++ b/packages/sdk/vue/README.md
@@ -1,17 +1,14 @@
 # LaunchDarkly Vue SDK
 
-[![Actions Status][vue-sdk-ci-badge]][vue-sdk-ci]
-<!-- Badges below are commented out until the package is published to npm and docs are deployed.
 [![NPM][vue-sdk-npm-badge]][vue-sdk-npm-link]
+[![Actions Status][vue-sdk-ci-badge]][vue-sdk-ci]
 [![Documentation][vue-sdk-ghp-badge]][vue-sdk-ghp-link]
 [![NPM][vue-sdk-dm-badge]][vue-sdk-npm-link]
 [![NPM][vue-sdk-dt-badge]][vue-sdk-npm-link]
--->
 
 > [!CAUTION]
-> This SDK is experimental and should NOT be considered ready for production use.
-> It may change or be removed without notice and is not subject to backwards
-> compatibility guarantees.
+> This SDK is in pre-release and not subject to backwards compatibility
+> guarantees. The API may change based on feedback.
 >
 > Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
 

--- a/packages/sdk/vue/README.md
+++ b/packages/sdk/vue/README.md
@@ -37,11 +37,11 @@ LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply
 
 [vue-sdk-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml/badge.svg
 [vue-sdk-ci]: https://github.com/launchdarkly/js-core/actions/workflows/vue.yml
-<!-- Badge link definitions below are commented out until the package is published.
+
 [vue-sdk-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/vue-client-sdk.svg?style=flat-square
 [vue-sdk-npm-link]: https://www.npmjs.com/package/@launchdarkly/vue-client-sdk
 [vue-sdk-ghp-badge]: https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8
 [vue-sdk-ghp-link]: https://launchdarkly.github.io/js-core/packages/sdk/vue/docs/
 [vue-sdk-dm-badge]: https://img.shields.io/npm/dm/@launchdarkly/vue-client-sdk.svg?style=flat-square
 [vue-sdk-dt-badge]: https://img.shields.io/npm/dt/@launchdarkly/vue-client-sdk.svg?style=flat-square
--->
+

--- a/packages/sdk/vue/package.json
+++ b/packages/sdk/vue/package.json
@@ -37,7 +37,7 @@
     "check": "yarn lint && yarn build && yarn test"
   },
   "dependencies": {
-    "@launchdarkly/js-client-sdk": "workspace:^"
+    "@launchdarkly/js-client-sdk": "4.9.4"
   },
   "peerDependencies": {
     "vue": "^3.3.0"

--- a/packages/sdk/vue/src/client/LDVueClient.ts
+++ b/packages/sdk/vue/src/client/LDVueClient.ts
@@ -47,7 +47,7 @@ export function createClient(
   const baseClientOptions: LDOptions = {
     ...options,
     wrapperName: options.wrapperName ?? 'vue-client-sdk',
-    wrapperVersion: options.wrapperVersion ?? '0.1.0', // x-release-please-version
+    wrapperVersion: options.wrapperVersion ?? '0.1.4', // x-release-please-version
   };
 
   const baseClient = createBaseClient(clientSideID, context, baseClientOptions);

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -421,7 +421,12 @@
       ]
     },
     "packages/sdk/vue": {
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "prerelease": true,
+      "prerelease-type": "beta",
+      "extra-files": [
+        "src/client/LDVueClient.ts"
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
This PR will enable publishing the prereleased version of vue client sdk v3 to npm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Enables automated **prerelease** publishing of `@launchdarkly/vue-client-sdk` instead of leaving the release job disabled.
> 
> The `release-vue` workflow job now runs when release-please creates a Vue release and passes `prerelease: true` to `full-release` so npm’s `latest` tag is not moved until GA. **release-please** for `packages/sdk/vue` is configured with `prerelease`, `prerelease-type: beta`, and version bumps in `LDVueClient.ts`.
> 
> Package metadata is aligned for a public npm package: Vue is listed in the root **README** and **CONTRIBUTING** dependency diagram; the Vue **README** shows npm/docs badges and describes pre-release expectations instead of “experimental / not published.” The published dependency on `@launchdarkly/js-client-sdk` is pinned to `4.9.4` (replacing `workspace:^`), and the default `wrapperVersion` is bumped to `0.1.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852796380a4d89ee1baed17e16225dddf98af979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->