### PR TITLE
chore: Add Vue SDK getting-started example

### DIFF
--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -23,8 +23,23 @@ jobs:
           workspace_name: '@launchdarkly/vue-client-sdk'
           workspace_path: packages/sdk/vue
           should_build_docs: false
+      - name: Build example
+        run: |
+          yarn workspaces focus @launchdarkly/vue-client-sdk-example-getting-started
+          yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/vue-client-sdk-example-getting-started' run build
 
-  # TODO(scaffold): run-example job arrives when examples/getting-started lands
+  run-example:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./actions/setup-yarn
+      - uses: ./actions/run-example
+        with:
+          workspace_name: '@launchdarkly/vue-client-sdk-example-getting-started'
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          before_test: 'yarn workspace @launchdarkly/vue-client-sdk-example-getting-started playwright install --with-deps chromium'
 
   contract-tests:
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default tseslint.config(
       '**/electron/example/**',
       '**/svelte/.svelte-kit/**',
       '**/svelte/example/**',
+      '**/vue/examples/**',
       '**/fastly/example/build/**',
       '**/server-ai/examples/chat-judge/**',
       '**/server-ai/examples/direct-judge/**',

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "packages/sdk/openfeature-node-server",
     "packages/sdk/openfeature-node-server/examples/getting-started",
     "packages/sdk/vue",
-    "packages/sdk/vue/contract-tests"
+    "packages/sdk/vue/contract-tests",
+    "packages/sdk/vue/examples/getting-started"
   ],
   "private": true,
   "scripts": {

--- a/packages/sdk/vue/examples/README.md
+++ b/packages/sdk/vue/examples/README.md
@@ -1,0 +1,7 @@
+# LaunchDarkly Vue SDK — Examples
+
+This directory contains example applications demonstrating the LaunchDarkly Vue SDK (`@launchdarkly/vue-client-sdk`).
+
+| Example | Description |
+|---------|-------------|
+| [getting-started](./getting-started/) | Minimal Vite + Vue app that evaluates a boolean feature flag and reactively displays the result with real-time updates. This is the recommended starting point. |

--- a/packages/sdk/vue/examples/getting-started/.env.example
+++ b/packages/sdk/vue/examples/getting-started/.env.example
@@ -1,0 +1,3 @@
+# Set when running yarn start / yarn build (e.g. LAUNCHDARKLY_CLIENT_SIDE_ID=xxx yarn start).
+
+LAUNCHDARKLY_CLIENT_SIDE_ID=

--- a/packages/sdk/vue/examples/getting-started/.gitignore
+++ b/packages/sdk/vue/examples/getting-started/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.env

--- a/packages/sdk/vue/examples/getting-started/README.md
+++ b/packages/sdk/vue/examples/getting-started/README.md
@@ -1,0 +1,44 @@
+# LaunchDarkly sample Vue application
+
+We've built a simple Vue application that demonstrates how the LaunchDarkly Vue SDK works.
+
+Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Vue SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/vue).
+
+This demo requires Node.js v18 or later.
+
+## Build instructions
+
+1. Set the value of the `LAUNCHDARKLY_CLIENT_SIDE_ID` environment variable to your client-side ID. You can copy `.env.example` to `.env` and fill it in:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   ```
+   LAUNCHDARKLY_CLIENT_SIDE_ID=my-client-side-id
+   ```
+
+   Alternatively, export the variable directly:
+
+   ```bash
+   export LAUNCHDARKLY_CLIENT_SIDE_ID="my-client-side-id"
+   ```
+
+2. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `LAUNCHDARKLY_FLAG_KEY` to the flag key:
+
+   ```bash
+   export LAUNCHDARKLY_FLAG_KEY="my-flag-key"
+   ```
+
+   Otherwise, `sample-feature` will be used by default.
+
+3. Install dependencies and start the app:
+
+   ```bash
+   yarn && yarn start
+   ```
+
+   You should see the message:
+   > "The sample-feature feature flag evaluates to false."
+
+The application will run continuously and react to flag changes in LaunchDarkly: the background turns green (#00844B) when the flag evaluates to true and dark gray (#373841) when it evaluates to false.

--- a/packages/sdk/vue/examples/getting-started/e2e/verify.spec.ts
+++ b/packages/sdk/vue/examples/getting-started/e2e/verify.spec.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expect, test as it } from '@playwright/test';
+
+it('evaluates the feature flag to true', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('body')).toContainText('feature flag evaluates to true', {
+    timeout: 20_000,
+  });
+});

--- a/packages/sdk/vue/examples/getting-started/index.html
+++ b/packages/sdk/vue/examples/getting-started/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LaunchDarkly Vue hello app</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/packages/sdk/vue/examples/getting-started/package.json
+++ b/packages/sdk/vue/examples/getting-started/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@launchdarkly/vue-client-sdk-example-getting-started",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@launchdarkly/vue-client-sdk": "workspace:^",
+    "vue": "^3.2.36"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@vitejs/plugin-vue": "^5.1.2",
+    "playwright": "^1.49.1",
+    "vite": "^5.4.1"
+  }
+}

--- a/packages/sdk/vue/examples/getting-started/package.json
+++ b/packages/sdk/vue/examples/getting-started/package.json
@@ -11,7 +11,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@launchdarkly/vue-client-sdk": "workspace:^",
+    "@launchdarkly/vue-client-sdk": "0.2.0",
     "vue": "^3.2.36"
   },
   "devDependencies": {

--- a/packages/sdk/vue/examples/getting-started/playwright.config.ts
+++ b/packages/sdk/vue/examples/getting-started/playwright.config.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://localhost:4173',
+  },
+  webServer: {
+    command: 'npx vite preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/packages/sdk/vue/examples/getting-started/src/App.vue
+++ b/packages/sdk/vue/examples/getting-started/src/App.vue
@@ -1,0 +1,48 @@
+<script setup>
+import { useBoolVariation, useInitializationStatus } from '@launchdarkly/vue-client-sdk';
+import { computed } from 'vue';
+
+// Set flagKey to the feature flag key you want to evaluate.
+const flagKey = import.meta.env.LAUNCHDARKLY_FLAG_KEY || 'sample-feature';
+
+const status = useInitializationStatus();
+const flagValue = useBoolVariation(flagKey, false);
+
+const ready = computed(() => status.value.status !== 'initializing');
+
+const statusMessage = computed(() => {
+  if (status.value.status === 'complete') {
+    return 'SDK successfully initialized!';
+  }
+  if (status.value.status === 'failed' || status.value.status === 'timeout') {
+    return 'SDK failed to initialize. Please check your internet connection and SDK credential for any typo.';
+  }
+  return 'Initializing…';
+});
+
+// LaunchDarkly dark-mode toggle colors: off (#373841) when false, on (#00844B) when true.
+const backgroundColor = computed(() => (ready.value && flagValue.value ? '#00844B' : '#373841'));
+</script>
+
+<template>
+  <main class="hello" :style="{ backgroundColor }">
+    <p>{{ statusMessage }}</p>
+    <p v-if="ready">The {{ flagKey }} feature flag evaluates to {{ flagValue }}.</p>
+  </main>
+</template>
+
+<style>
+body {
+  margin: 0;
+}
+
+.hello {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  color: #ffffff;
+}
+</style>

--- a/packages/sdk/vue/examples/getting-started/src/main.js
+++ b/packages/sdk/vue/examples/getting-started/src/main.js
@@ -1,0 +1,16 @@
+import { createLDProvider } from '@launchdarkly/vue-client-sdk';
+import { createApp, h } from 'vue';
+
+import App from './App.vue';
+
+// Set clientSideID to your LaunchDarkly client-side ID.
+const clientSideID = import.meta.env.LAUNCHDARKLY_CLIENT_SIDE_ID || '';
+
+// Set up the evaluation context. This context should appear on your LaunchDarkly contexts dashboard soon after you run the demo.
+const context = { kind: 'user', key: 'example-user-key', name: 'Sandy' };
+
+const LDProvider = createLDProvider(clientSideID, context, { ldOptions: { streaming: true } });
+
+createApp({
+  render: () => h(LDProvider, null, { default: () => h(App) }),
+}).mount('#app');

--- a/packages/sdk/vue/examples/getting-started/vite.config.js
+++ b/packages/sdk/vue/examples/getting-started/vite.config.js
@@ -1,0 +1,7 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [vue()],
+  envPrefix: ['VITE_', 'LAUNCHDARKLY_'],
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -425,7 +425,12 @@
       "prerelease": true,
       "prerelease-type": "beta",
       "extra-files": [
-        "src/client/LDVueClient.ts"
+        "src/client/LDVueClient.ts",
+        {
+          "type": "json",
+          "path": "examples/getting-started/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/vue-client-sdk']"
+        }
       ]
     }
   },


### PR DESCRIPTION
This PR will add a getting started example for vue client sdk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds a **minimal Vite + Vue getting-started example** under `packages/sdk/vue/examples/getting-started` that wires `createLDProvider`, `useBoolVariation`, and `useInitializationStatus` to show SDK init status and a boolean flag (with reactive background color).
> 
> **Monorepo integration:** registers the example workspace in root `package.json`, ignores `**/vue/examples/**` in ESLint, and extends **release-please** so the example’s `@launchdarkly/vue-client-sdk` dependency version bumps with the Vue package.
> 
> **CI:** extends `.github/workflows/vue.yml` with a **Build example** step on the main job and a new **`run-example`** job (shared `run-example` action, AWS role, Playwright Chromium install) to validate the demo against LaunchDarkly in CI—replacing the prior TODO for when the example lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3083f34444173e85fa3287a686de209ce25967d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->