### PR TITLE
feat: wire fdv1-fallback capability into node-client, browser, and react-native contract-test entities

### DIFF
--- a/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
@@ -77,7 +77,7 @@ function translateModeDefinition(
     .map(translateSynchronizer)
     .filter((x): x is SynchronizerEntry => x !== undefined);
 
-  if (fdv1Fallback?.baseUri) {
+  if (fdv1Fallback) {
     return {
       initializers,
       synchronizers,
@@ -85,7 +85,9 @@ function translateModeDefinition(
         ...(fdv1Fallback.pollIntervalMs != null && {
           pollInterval: fdv1Fallback.pollIntervalMs / 1000,
         }),
-        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        ...(fdv1Fallback.baseUri && {
+          endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        }),
       },
     };
   }
@@ -145,9 +147,10 @@ function makeSdkConfig(options: SDKConfigParams, tag: string) {
         : false;
 
       if (connMode.customConnectionModes) {
+        const { fdv1Fallback } = options.dataSystem;
         const connectionModes: Record<string, any> = {};
         Object.entries(connMode.customConnectionModes).forEach(([modeName, modeDef]) => {
-          connectionModes[modeName] = translateModeDefinition(modeDef);
+          connectionModes[modeName] = translateModeDefinition(modeDef, fdv1Fallback);
           applyEndpointOverrides(modeDef);
         });
         dataSystem.connectionModes = connectionModes;

--- a/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/ClientEntity.ts
@@ -16,6 +16,7 @@ import {
   SDKConfigDataSynchronizer,
   SDKConfigModeDefinition,
   SDKConfigParams,
+  SDKConfigPollingParams,
   ClientSideTestHook as TestHook,
   ValueType,
 } from '@launchdarkly/js-contract-test-utils/client';
@@ -64,7 +65,10 @@ function translateSynchronizer(sync: SDKConfigDataSynchronizer): SynchronizerEnt
   return undefined;
 }
 
-function translateModeDefinition(modeDef: SDKConfigModeDefinition): ModeDefinition {
+function translateModeDefinition(
+  modeDef: SDKConfigModeDefinition,
+  fdv1Fallback?: SDKConfigPollingParams | null,
+): ModeDefinition {
   const initializers: InitializerEntry[] = (modeDef.initializers ?? [])
     .map(translateInitializer)
     .filter((x): x is InitializerEntry => x !== undefined);
@@ -72,6 +76,19 @@ function translateModeDefinition(modeDef: SDKConfigModeDefinition): ModeDefiniti
   const synchronizers: SynchronizerEntry[] = (modeDef.synchronizers ?? [])
     .map(translateSynchronizer)
     .filter((x): x is SynchronizerEntry => x !== undefined);
+
+  if (fdv1Fallback?.baseUri) {
+    return {
+      initializers,
+      synchronizers,
+      fdv1Fallback: {
+        ...(fdv1Fallback.pollIntervalMs != null && {
+          pollInterval: fdv1Fallback.pollIntervalMs / 1000,
+        }),
+        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+      },
+    };
+  }
 
   return { initializers, synchronizers };
 }
@@ -147,7 +164,7 @@ function makeSdkConfig(options: SDKConfigParams, tag: string) {
         initialConnectionMode: 'streaming',
       };
       dataSystem.connectionModes = {
-        streaming: translateModeDefinition(modeDef),
+        streaming: translateModeDefinition(modeDef, options.dataSystem.fdv1Fallback),
       };
       applyEndpointOverrides(modeDef);
     }

--- a/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -46,7 +46,6 @@ export default class TestHarnessWebSocket {
             'client-per-context-summaries',
             'track-hooks',
             'fdv1-fallback',
-            'client-event-source-http-errors',
           ];
 
           break;

--- a/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/browser/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -45,6 +45,8 @@ export default class TestHarnessWebSocket {
             'client-prereq-cycle-detection',
             'client-per-context-summaries',
             'track-hooks',
+            'fdv1-fallback',
+            'client-event-source-http-errors',
           ];
 
           break;

--- a/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
+++ b/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
@@ -2,6 +2,14 @@
 # connection, so it can never observe the directive this test relies on.
 tags/FDv1 fallback directive requests
 
+# Same root cause as above: DefaultBrowserEventSource reports headers: false
+# unconditionally on both open and error events, so none of the FDv1 fallback
+# directive scenarios below can be observed on browser, not just the error path.
+streaming/fdv2/FDv1 fallback directive/directive on streaming error engages FDv1 fallback
+streaming/fdv2/FDv1 fallback directive/directive on streaming success applies payload then engages FDv1
+streaming/fdv2/FDv1 fallback directive/directive without FDv1 fallback configured halts the data system
+streaming/fdv2/FDv1 fallback directive/directed fallback is terminal and does not revisit FDv2 sources
+
 streaming/requests/method and headers/REPORT/http
 streaming/requests/URL path is computed correctly/no environment filter/base URI has no trailing slash/REPORT
 streaming/requests/URL path is computed correctly/no environment filter/base URI has a trailing slash/REPORT

--- a/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
+++ b/packages/sdk/browser/contract-tests/suppressions_datamode_changes.txt
@@ -1,3 +1,7 @@
+# Browser's native EventSource cannot read response headers/status on the streaming
+# connection, so it can never observe the directive this test relies on.
+tags/FDv1 fallback directive requests
+
 streaming/requests/method and headers/REPORT/http
 streaming/requests/URL path is computed correctly/no environment filter/base URI has no trailing slash/REPORT
 streaming/requests/URL path is computed correctly/no environment filter/base URI has a trailing slash/REPORT

--- a/packages/sdk/node-client/contract-tests/src/index.ts
+++ b/packages/sdk/node-client/contract-tests/src/index.ts
@@ -41,10 +41,8 @@ app.get('/', (req: Request, res: Response) => {
       'tls:skip-verify-peer',
       'tls:custom-ca',
       'wrapper',
+      'fdv1-fallback',
       'client-event-source-http-errors',
-      // NOTE: this needs additional fixes to the shared
-      // SDK code to support
-      // 'fdv1-fallback',
     ],
   });
 });

--- a/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
+++ b/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
@@ -8,6 +8,7 @@ import {
   SDKConfigDataSynchronizer,
   SDKConfigModeDefinition,
   SDKConfigParams,
+  SDKConfigPollingParams,
   ValueType,
 } from '@launchdarkly/js-contract-test-utils';
 import { ClientSideTestHook as TestHook } from '@launchdarkly/js-contract-test-utils/client';
@@ -68,7 +69,10 @@ function translateSynchronizer(sync: SDKConfigDataSynchronizer): SynchronizerEnt
   return undefined;
 }
 
-function translateModeDefinition(modeDef: SDKConfigModeDefinition): ModeDefinition {
+function translateModeDefinition(
+  modeDef: SDKConfigModeDefinition,
+  fdv1Fallback?: SDKConfigPollingParams | null,
+): ModeDefinition {
   const initializers: InitializerEntry[] = (modeDef.initializers ?? [])
     .map(translateInitializer)
     .filter((x): x is InitializerEntry => x !== undefined);
@@ -76,6 +80,19 @@ function translateModeDefinition(modeDef: SDKConfigModeDefinition): ModeDefiniti
   const synchronizers: SynchronizerEntry[] = (modeDef.synchronizers ?? [])
     .map(translateSynchronizer)
     .filter((x): x is SynchronizerEntry => x !== undefined);
+
+  if (fdv1Fallback?.baseUri) {
+    return {
+      initializers,
+      synchronizers,
+      fdv1Fallback: {
+        ...(fdv1Fallback.pollIntervalMs != null && {
+          pollInterval: fdv1Fallback.pollIntervalMs / 1000,
+        }),
+        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+      },
+    };
+  }
 
   return { initializers, synchronizers };
 }
@@ -151,7 +168,7 @@ function makeSdkConfig(options: SDKConfigParams, tag: string): LDOptions {
         initialConnectionMode: 'streaming',
       };
       dataSystem.connectionModes = {
-        streaming: translateModeDefinition(modeDef),
+        streaming: translateModeDefinition(modeDef, options.dataSystem.fdv1Fallback),
       };
       applyEndpointOverrides(modeDef);
     }

--- a/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
+++ b/packages/sdk/node-client/contract-tests/src/sdkClientEntity.ts
@@ -81,7 +81,7 @@ function translateModeDefinition(
     .map(translateSynchronizer)
     .filter((x): x is SynchronizerEntry => x !== undefined);
 
-  if (fdv1Fallback?.baseUri) {
+  if (fdv1Fallback) {
     return {
       initializers,
       synchronizers,
@@ -89,7 +89,9 @@ function translateModeDefinition(
         ...(fdv1Fallback.pollIntervalMs != null && {
           pollInterval: fdv1Fallback.pollIntervalMs / 1000,
         }),
-        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        ...(fdv1Fallback.baseUri && {
+          endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        }),
       },
     };
   }
@@ -151,9 +153,10 @@ function makeSdkConfig(options: SDKConfigParams, tag: string): LDOptions {
         : false;
 
       if (connMode.customConnectionModes) {
+        const { fdv1Fallback } = options.dataSystem;
         const connectionModes: Record<string, ModeDefinition> = {};
         Object.entries(connMode.customConnectionModes).forEach(([modeName, modeDef]) => {
-          connectionModes[modeName] = translateModeDefinition(modeDef);
+          connectionModes[modeName] = translateModeDefinition(modeDef, fdv1Fallback);
           applyEndpointOverrides(modeDef);
         });
         dataSystem.connectionModes = connectionModes;

--- a/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
+++ b/packages/sdk/node-client/contract-tests/testharness-suppressions-fdv2.txt
@@ -1,5 +1,5 @@
-# Tests in this file will be skipped by the LaunchDarkly SDK test harness running
-# the FDv2-feature branch against the Node.js client-side SDK. Add a path per line.
+# Tests in this file will be skipped by the LaunchDarkly SDK test harness FDv2
+# (v3) release line against the Node.js client-side SDK. Add a path per line.
 # Lines beginning with '#' are comments.
 streaming/fdv2/reconnection state management/saves previously known state
 streaming/fdv2/reconnection state management/replaces previously known state
@@ -13,3 +13,11 @@ streaming/fdv2/can discard partial events on errors
 # endpoints, but the test checks the primary's Synchronizers[0] endpoint which never
 # receives a request. This is a harness-level design issue; the SDK behavior is correct.
 wrapper/stream requests/wrapper name and version
+
+# Client SDKs always configure an FDv1 fallback synchronizer when the platform
+# provides FDv1 endpoints, regardless of whether a fallback config is present
+# (see FDv2DataManagerBase.ts's fdv1Endpoints && synchronizerSlots.length > 0
+# check). The "not configured" state this test exercises is unreachable, so it
+# currently passes for the wrong reason while also making the SDK fall back to
+# polling the default production endpoint.
+streaming/fdv2/FDv1 fallback directive/directive without FDv1 fallback configured halts the data system

--- a/packages/sdk/react-native/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/react-native/contract-tests/entity/src/ClientEntity.ts
@@ -73,7 +73,7 @@ function translateModeDefinition(
     .map(translateSynchronizer)
     .filter((x) => x !== undefined);
 
-  if (fdv1Fallback?.baseUri) {
+  if (fdv1Fallback) {
     return {
       initializers,
       synchronizers,
@@ -81,7 +81,9 @@ function translateModeDefinition(
         ...(fdv1Fallback.pollIntervalMs != null && {
           pollInterval: fdv1Fallback.pollIntervalMs / 1000,
         }),
-        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        ...(fdv1Fallback.baseUri && {
+          endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+        }),
       },
     };
   }
@@ -144,9 +146,10 @@ function makeSdkConfig(options: SDKConfigParams, tag: string) {
         : false;
 
       if (connMode.customConnectionModes) {
+        const { fdv1Fallback } = options.dataSystem;
         const connectionModes: Record<string, any> = {};
         Object.entries(connMode.customConnectionModes).forEach(([modeName, modeDef]) => {
-          connectionModes[modeName] = translateModeDefinition(modeDef);
+          connectionModes[modeName] = translateModeDefinition(modeDef, fdv1Fallback);
           applyEndpointOverrides(modeDef);
         });
         dataSystem.connectionModes = connectionModes;

--- a/packages/sdk/react-native/contract-tests/entity/src/ClientEntity.ts
+++ b/packages/sdk/react-native/contract-tests/entity/src/ClientEntity.ts
@@ -7,6 +7,7 @@ import {
   SDKConfigDataSynchronizer,
   SDKConfigModeDefinition,
   SDKConfigParams,
+  SDKConfigPollingParams,
   ClientSideTestHook as TestHook,
   ValueType,
 } from '@launchdarkly/js-contract-test-utils/client';
@@ -60,7 +61,10 @@ function translateSynchronizer(sync: SDKConfigDataSynchronizer): any | undefined
   return undefined;
 }
 
-function translateModeDefinition(modeDef: SDKConfigModeDefinition): any {
+function translateModeDefinition(
+  modeDef: SDKConfigModeDefinition,
+  fdv1Fallback?: SDKConfigPollingParams | null,
+): any {
   const initializers = (modeDef.initializers ?? [])
     .map(translateInitializer)
     .filter((x) => x !== undefined);
@@ -68,6 +72,19 @@ function translateModeDefinition(modeDef: SDKConfigModeDefinition): any {
   const synchronizers = (modeDef.synchronizers ?? [])
     .map(translateSynchronizer)
     .filter((x) => x !== undefined);
+
+  if (fdv1Fallback?.baseUri) {
+    return {
+      initializers,
+      synchronizers,
+      fdv1Fallback: {
+        ...(fdv1Fallback.pollIntervalMs != null && {
+          pollInterval: fdv1Fallback.pollIntervalMs / 1000,
+        }),
+        endpoints: { pollingBaseUri: fdv1Fallback.baseUri },
+      },
+    };
+  }
 
   return { initializers, synchronizers };
 }
@@ -146,7 +163,7 @@ function makeSdkConfig(options: SDKConfigParams, tag: string) {
         initialConnectionMode: 'streaming',
       };
       dataSystem.connectionModes = {
-        streaming: translateModeDefinition(modeDef),
+        streaming: translateModeDefinition(modeDef, options.dataSystem.fdv1Fallback),
       };
       applyEndpointOverrides(modeDef);
     }

--- a/packages/sdk/react-native/contract-tests/entity/src/TestHarnessWebSocket.ts
+++ b/packages/sdk/react-native/contract-tests/entity/src/TestHarnessWebSocket.ts
@@ -58,6 +58,8 @@ export default class TestHarnessWebSocket {
             'client-prereq-cycle-detection',
             'client-per-context-summaries',
             'track-hooks',
+            'fdv1-fallback',
+            'client-event-source-http-errors',
           ];
 
           break;

--- a/packages/sdk/react-native/contract-tests/run-contract-tests.sh
+++ b/packages/sdk/react-native/contract-tests/run-contract-tests.sh
@@ -114,6 +114,10 @@ echo ""
 echo "=== Running test harness ==="
 cd "$TEST_HARNESS_PATH"
 
+# Only applies suppressions.txt (the FDv1 skip list). If SDK_TEST_HARNESS_PATH
+# points at a v3 (FDv2) harness checkout, the FDv2 scenarios this script runs
+# are not filtered by suppressions-fdv2.txt -- pass --skip-from manually with
+# that file (or a concatenation of both) if you need parity with CI's FDv2 run.
 SUPPRESSIONS="$SCRIPT_DIR/suppressions.txt"
 EXTRA_ARGS=""
 if [ -s "$SUPPRESSIONS" ]; then

--- a/packages/sdk/react-native/contract-tests/suppressions-fdv2.txt
+++ b/packages/sdk/react-native/contract-tests/suppressions-fdv2.txt
@@ -1,12 +1,15 @@
-# Tests in this file will be skipped by the LaunchDarkly SDK test harness running
-# the FDv2-feature branch against the React Native client-side SDK. Add a path per line.
-# Lines beginning with '#' are comments.
+# Tests in this file will be skipped by the LaunchDarkly SDK test harness FDv2
+# (v3) release line against the React Native client-side SDK. Add a path per
+# line. Lines beginning with '#' are comments.
 
-# RN's forked EventSource (react-native-sse) fires `open` too late (from
-# onreadystatechange at readyState DONE, not from onprogress at LOADING) and never
-# populates headers on error events, so FDv1 fallback directives carried on stream
-# response headers don't reach the SDK in time (or at all, on the error path).
+# RN's forked EventSource (react-native-sse) never populates response headers
+# on `open` or `error` events (only status), so FDv1 fallback directives
+# carried on stream response headers never reach the SDK. On a healthy
+# long-lived stream, `open` is also effectively never dispatched until the
+# stream terminates, since it fires from onreadystatechange at readyState
+# DONE rather than from onprogress at LOADING.
 streaming/fdv2/FDv1 fallback directive/directive on streaming error engages FDv1 fallback
 streaming/fdv2/FDv1 fallback directive/directive on streaming success applies payload then engages FDv1
 streaming/fdv2/FDv1 fallback directive/directive without FDv1 fallback configured halts the data system
+streaming/fdv2/FDv1 fallback directive/directed fallback is terminal and does not revisit FDv2 sources
 tags/FDv1 fallback directive requests

--- a/packages/sdk/react-native/contract-tests/suppressions-fdv2.txt
+++ b/packages/sdk/react-native/contract-tests/suppressions-fdv2.txt
@@ -1,0 +1,12 @@
+# Tests in this file will be skipped by the LaunchDarkly SDK test harness running
+# the FDv2-feature branch against the React Native client-side SDK. Add a path per line.
+# Lines beginning with '#' are comments.
+
+# RN's forked EventSource (react-native-sse) fires `open` too late (from
+# onreadystatechange at readyState DONE, not from onprogress at LOADING) and never
+# populates headers on error events, so FDv1 fallback directives carried on stream
+# response headers don't reach the SDK in time (or at all, on the error path).
+streaming/fdv2/FDv1 fallback directive/directive on streaming error engages FDv1 fallback
+streaming/fdv2/FDv1 fallback directive/directive on streaming success applies payload then engages FDv1
+streaming/fdv2/FDv1 fallback directive/directive without FDv1 fallback configured halts the data system
+tags/FDv1 fallback directive requests

--- a/packages/tooling/contract-test-utils/src/types/ConfigParams.ts
+++ b/packages/tooling/contract-test-utils/src/types/ConfigParams.ts
@@ -27,6 +27,7 @@ export interface SDKConfigDataSystem {
   useDefaultDataSystem?: boolean;
   initializers?: SDKConfigDataInitializer[];
   synchronizers?: SDKConfigDataSynchronizer[];
+  fdv1Fallback?: SDKConfigPollingParams;
   payloadFilter?: string;
   connectionModeConfig?: SDKConfigConnectionModeConfig;
 }


### PR DESCRIPTION
## Summary

Wires the harness's `dataSystem.fdv1Fallback.baseUri` into the node-client, browser, and react-native contract-test entities so the FDv1 fallback synchronizer connects to the harness's dedicated FDv1 polling endpoint instead of the polling initializer's endpoint (which `applyEndpointOverrides` otherwise overwrites it with).

Completes contract-test coverage for the FDv1 fallback/recovery behavior built across this stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`dataSystem.fdv1Fallback`** to contract-test config types and maps it through **`translateModeDefinition`** on browser, Node client, and React Native harness entities so each connection mode can set **`fdv1Fallback`** polling interval and **`pollingBaseUri`** from the harness (instead of inheriting the wrong endpoint from initializer overrides).
> 
> **Node** advertises the **`fdv1-fallback`** capability (previously commented out). **Browser** and **React Native** harnesses do the same; RN also reports **`client-event-source-http-errors`**.
> 
> **Suppressions** document platform gaps: browser/RN cannot observe FDv1 fallback **stream header directives** (EventSource / RN SSE limitations), so related FDv2 scenarios are skipped. **Node** skips one “fallback not configured halts data system” case where client SDKs always wire an FDv1 synchronizer when endpoints exist. RN adds **`suppressions-fdv2.txt`** and a note in **`run-contract-tests.sh`** about which skip lists apply to local FDv2 harness runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c48ca2e8af85343edfe8842e806587d2ba4512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->