### PR TITLE
fix: server sdk could send user agent headers under a different header name

### DIFF
--- a/packages/sdk/shopify-oxygen/__tests__/index.test.ts
+++ b/packages/sdk/shopify-oxygen/__tests__/index.test.ts
@@ -73,6 +73,18 @@ describe('Shopify Oxygen SDK', () => {
 
       ldClient.close();
     });
+
+    it('sends the user-agent value under x-launchdarkly-user-agent, not user-agent', async () => {
+      const ldClient = init(sdkKey, { sendEvents: true });
+      await ldClient.waitForInitialization();
+
+      expect(mockEventProcessor).toHaveBeenCalled();
+      const baseHeaders = mockEventProcessor.mock.calls[0][2];
+      expect(baseHeaders).toHaveProperty('x-launchdarkly-user-agent');
+      expect(baseHeaders).not.toHaveProperty('user-agent');
+
+      ldClient.close();
+    });
   });
 
   describe('polling tests', () => {

--- a/packages/sdk/shopify-oxygen/src/index.ts
+++ b/packages/sdk/shopify-oxygen/src/index.ts
@@ -19,6 +19,7 @@ class LDClient extends LDClientImpl {
       // Oxygen's execution context ends when the response is returned, which makes keeping a
       // background flush loop meaningless.
       disableBackgroundEventFlush: true,
+      userAgentHeaderName: 'x-launchdarkly-user-agent',
     };
     super(sdkKey, platform, options, createCallbacks(options.logger), internalOptions);
   }

--- a/packages/shared/sdk-server/__tests__/LDClientImpl.userAgentHeaderName.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClientImpl.userAgentHeaderName.test.ts
@@ -3,107 +3,105 @@ import { createBasicPlatform } from './createBasicPlatform';
 import TestLogger from './Logger';
 import makeCallbacks from './makeCallbacks';
 
-describe('LDClientImpl user-agent header name', () => {
-  it('sends the user-agent value under the overridden header name on the events path', async () => {
-    const platform = createBasicPlatform();
-    platform.requests.fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, headers: new Headers() }),
-    );
+it('sends the user-agent value under the overridden header name on the events path', async () => {
+  const platform = createBasicPlatform();
+  platform.requests.fetch.mockImplementation(() =>
+    Promise.resolve({ status: 200, headers: new Headers() }),
+  );
 
-    const client = new LDClientImpl(
-      'sdk-key-user-agent-1',
-      platform,
-      { logger: new TestLogger(), stream: false },
-      makeCallbacks(false),
-      { userAgentHeaderName: 'x-launchdarkly-user-agent' },
-    );
+  const client = new LDClientImpl(
+    'sdk-key-user-agent-1',
+    platform,
+    { logger: new TestLogger(), stream: false },
+    makeCallbacks(false),
+    { userAgentHeaderName: 'x-launchdarkly-user-agent' },
+  );
 
-    client.identify({ key: 'user' });
-    await client.flush();
+  client.identify({ key: 'user' });
+  await client.flush();
 
-    expect(platform.requests.fetch).toHaveBeenCalledWith(
-      'https://events.launchdarkly.com/bulk',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'x-launchdarkly-user-agent': expect.anything(),
-        }),
+  expect(platform.requests.fetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/bulk',
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        'x-launchdarkly-user-agent': expect.anything(),
       }),
-    );
-    expect(platform.requests.fetch).toHaveBeenCalledWith(
-      'https://events.launchdarkly.com/bulk',
-      expect.objectContaining({
-        headers: expect.not.objectContaining({
-          'user-agent': expect.anything(),
-        }),
+    }),
+  );
+  expect(platform.requests.fetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/bulk',
+    expect.objectContaining({
+      headers: expect.not.objectContaining({
+        'user-agent': expect.anything(),
       }),
-    );
+    }),
+  );
 
-    client.close();
+  client.close();
+});
+
+it('sends the user-agent value under the overridden header name on the polling path', async () => {
+  const platform = createBasicPlatform();
+  platform.requests.fetch.mockImplementation(() =>
+    Promise.resolve({ status: 200, headers: new Headers(), body: '{}' }),
+  );
+
+  const client = new LDClientImpl(
+    'sdk-key-user-agent-2',
+    platform,
+    { logger: new TestLogger(), stream: false },
+    makeCallbacks(false),
+    { userAgentHeaderName: 'x-launchdarkly-user-agent' },
+  );
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
   });
 
-  it('sends the user-agent value under the overridden header name on the polling path', async () => {
-    const platform = createBasicPlatform();
-    platform.requests.fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, headers: new Headers(), body: '{}' }),
-    );
-
-    const client = new LDClientImpl(
-      'sdk-key-user-agent-2',
-      platform,
-      { logger: new TestLogger(), stream: false },
-      makeCallbacks(false),
-      { userAgentHeaderName: 'x-launchdarkly-user-agent' },
-    );
-
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-
-    expect(platform.requests.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/sdk/latest-all'),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'x-launchdarkly-user-agent': expect.anything(),
-        }),
+  expect(platform.requests.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/sdk/latest-all'),
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        'x-launchdarkly-user-agent': expect.anything(),
       }),
-    );
-    expect(platform.requests.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/sdk/latest-all'),
-      expect.objectContaining({
-        headers: expect.not.objectContaining({
-          'user-agent': expect.anything(),
-        }),
+    }),
+  );
+  expect(platform.requests.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/sdk/latest-all'),
+    expect.objectContaining({
+      headers: expect.not.objectContaining({
+        'user-agent': expect.anything(),
       }),
-    );
+    }),
+  );
 
-    client.close();
-  });
+  client.close();
+});
 
-  it('uses the default user-agent header name when no override is supplied', async () => {
-    const platform = createBasicPlatform();
-    platform.requests.fetch.mockImplementation(() =>
-      Promise.resolve({ status: 200, headers: new Headers() }),
-    );
+it('uses the default user-agent header name when no override is supplied', async () => {
+  const platform = createBasicPlatform();
+  platform.requests.fetch.mockImplementation(() =>
+    Promise.resolve({ status: 200, headers: new Headers() }),
+  );
 
-    const client = new LDClientImpl(
-      'sdk-key-user-agent-3',
-      platform,
-      { logger: new TestLogger(), stream: false },
-      makeCallbacks(false),
-    );
+  const client = new LDClientImpl(
+    'sdk-key-user-agent-3',
+    platform,
+    { logger: new TestLogger(), stream: false },
+    makeCallbacks(false),
+  );
 
-    client.identify({ key: 'user' });
-    await client.flush();
+  client.identify({ key: 'user' });
+  await client.flush();
 
-    expect(platform.requests.fetch).toHaveBeenCalledWith(
-      'https://events.launchdarkly.com/bulk',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'user-agent': expect.anything(),
-        }),
+  expect(platform.requests.fetch).toHaveBeenCalledWith(
+    'https://events.launchdarkly.com/bulk',
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        'user-agent': expect.anything(),
       }),
-    );
+    }),
+  );
 
-    client.close();
-  });
+  client.close();
 });

--- a/packages/shared/sdk-server/__tests__/LDClientImpl.userAgentHeaderName.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClientImpl.userAgentHeaderName.test.ts
@@ -1,0 +1,109 @@
+import { LDClientImpl } from '../src';
+import { createBasicPlatform } from './createBasicPlatform';
+import TestLogger from './Logger';
+import makeCallbacks from './makeCallbacks';
+
+describe('LDClientImpl user-agent header name', () => {
+  it('sends the user-agent value under the overridden header name on the events path', async () => {
+    const platform = createBasicPlatform();
+    platform.requests.fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, headers: new Headers() }),
+    );
+
+    const client = new LDClientImpl(
+      'sdk-key-user-agent-1',
+      platform,
+      { logger: new TestLogger(), stream: false },
+      makeCallbacks(false),
+      { userAgentHeaderName: 'x-launchdarkly-user-agent' },
+    );
+
+    client.identify({ key: 'user' });
+    await client.flush();
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      'https://events.launchdarkly.com/bulk',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-launchdarkly-user-agent': expect.anything(),
+        }),
+      }),
+    );
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      'https://events.launchdarkly.com/bulk',
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          'user-agent': expect.anything(),
+        }),
+      }),
+    );
+
+    client.close();
+  });
+
+  it('sends the user-agent value under the overridden header name on the polling path', async () => {
+    const platform = createBasicPlatform();
+    platform.requests.fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, headers: new Headers(), body: '{}' }),
+    );
+
+    const client = new LDClientImpl(
+      'sdk-key-user-agent-2',
+      platform,
+      { logger: new TestLogger(), stream: false },
+      makeCallbacks(false),
+      { userAgentHeaderName: 'x-launchdarkly-user-agent' },
+    );
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/sdk/latest-all'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-launchdarkly-user-agent': expect.anything(),
+        }),
+      }),
+    );
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/sdk/latest-all'),
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          'user-agent': expect.anything(),
+        }),
+      }),
+    );
+
+    client.close();
+  });
+
+  it('uses the default user-agent header name when no override is supplied', async () => {
+    const platform = createBasicPlatform();
+    platform.requests.fetch.mockImplementation(() =>
+      Promise.resolve({ status: 200, headers: new Headers() }),
+    );
+
+    const client = new LDClientImpl(
+      'sdk-key-user-agent-3',
+      platform,
+      { logger: new TestLogger(), stream: false },
+      makeCallbacks(false),
+    );
+
+    client.identify({ key: 'user' });
+    await client.flush();
+
+    expect(platform.requests.fetch).toHaveBeenCalledWith(
+      'https://events.launchdarkly.com/bulk',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'user-agent': expect.anything(),
+        }),
+      }),
+    );
+
+    client.close();
+  });
+});

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -116,6 +116,7 @@ function constructFDv1(
   dataSourceErrorHandler: (e: any) => void,
   hooks: Hook[],
   instanceId: string | undefined,
+  userAgentHeaderName: 'user-agent' | 'x-launchdarkly-user-agent' | undefined,
   startEventProcessor: boolean,
 ): {
   config: Configuration;
@@ -143,7 +144,7 @@ function constructFDv1(
     platform.info,
     config.tags,
     true,
-    'user-agent',
+    userAgentHeaderName,
     instanceId,
   );
 
@@ -276,6 +277,7 @@ function constructFDv2(
   initSuccess: () => void,
   hooks: Hook[],
   instanceId: string | undefined,
+  userAgentHeaderName: 'user-agent' | 'x-launchdarkly-user-agent' | undefined,
   startEventProcessor: boolean,
 ): {
   config: Configuration;
@@ -305,7 +307,7 @@ function constructFDv2(
     platform.info,
     config.tags,
     true,
-    'user-agent',
+    userAgentHeaderName,
     instanceId,
   );
 
@@ -675,6 +677,7 @@ export default class LDClientImpl implements LDClient {
         (e) => this._dataSourceErrorHandler(e),
         hooks,
         internalOptions?.instanceId,
+        internalOptions?.userAgentHeaderName,
         startEventProcessor,
       ));
 
@@ -713,6 +716,7 @@ export default class LDClientImpl implements LDClient {
         () => this._initSuccess(),
         hooks,
         internalOptions?.instanceId,
+        internalOptions?.userAgentHeaderName,
         startEventProcessor,
       ));
       this._featureStore = transactionalStore;


### PR DESCRIPTION
This PR will make it so that server side sdks can also determine the header name used to send user agent value. The reason we need this is that the default `user-agent` header name could be blocked by different platforms/configurations which causes us to lose usage data.

This is currently delivered as an internal implementation detail to address issues with the shopify oxygen sdk not sending usage data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Server SDK clients can now send SDK usage metadata under a **configurable HTTP header** instead of always using `user-agent`. `LDClientImpl` passes an internal `userAgentHeaderName` into `defaultHeaders` on both FDv1 and FDv2 construction paths (events, polling, and related outbound traffic that uses those base headers).
> 
> The **Shopify Oxygen** SDK sets `userAgentHeaderName` to `x-launchdarkly-user-agent` so usage data is not dropped when platforms block the standard `user-agent` header. When no override is supplied, behavior stays the same (`user-agent`).
> 
> New tests cover the override on the events and polling paths, the Oxygen integration expectation on event processor headers, and the default header name when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6abaeafd4d9944c7aeec50efc44521f9b0691fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->