### PR TITLE
feat: Test vulnerability alert ordering with explicit config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,10 @@
       "matchPackageNames": ["reactivecircus/android-emulator-runner"],
       "enabled": false
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["* * * * *"]
+  },
+  "osvVulnerabilityAlerts": true
 }

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -103,7 +103,7 @@ jobs:
           sleep 5  # Give the browser time to initialize and connect via WebSocket
 
       - name: Run contract tests (FDv1)
-        uses: launchdarkly/gh-actions/actions/contract-tests@a848aec9c87c29470093b22154107b83a7696374
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
           extra_params: '--skip-from=${{ github.workspace }}/packages/sdk/browser/contract-tests/suppressions.txt'
 
       - name: Run contract tests (FDv2)
-        uses: launchdarkly/gh-actions/actions/contract-tests@a848aec9c87c29470093b22154107b83a7696374
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -24,7 +24,7 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
 
       - name: Generate SBOM
-        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@54a4d773fe4ff458c0dc93bab1714fefcd77a526 # main
+        uses: launchdarkly/gh-actions/actions/dependency-scan/generate-sbom@main
         with:
           types: 'nodejs'
           ensure-non-empty: 'true'
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Evaluate SBOM Policy
-        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@54a4d773fe4ff458c0dc93bab1714fefcd77a526 # main
+        uses: launchdarkly/gh-actions/actions/dependency-scan/evaluate-policy@main
         with:
           artifacts-pattern: bom-*

--- a/.github/workflows/electron.yaml
+++ b/.github/workflows/electron.yaml
@@ -69,7 +69,7 @@ jobs:
           done
 
       - name: Run contract tests
-        uses: launchdarkly/gh-actions/actions/contract-tests@a848aec9c87c29470093b22154107b83a7696374
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-client.yml
+++ b/.github/workflows/node-client.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Launch the test service in the background
         run: yarn workspace @launchdarkly/node-client-sdk-contract-tests start 2>&1 &
       - name: Run contract tests (FDv1)
-        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-native-detox.yml
+++ b/.github/workflows/react-native-detox.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/react-native-example' run build
 
-      - uses: launchdarkly/gh-actions/actions/release-secrets@a848aec9c87c29470093b22154107b83a7696374
+      - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1
         name: 'Get mobile key'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN_EXAMPLES }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -71,7 +71,7 @@ jobs:
           done
           sleep 5
       - name: Run contract tests
-        uses: launchdarkly/gh-actions/actions/contract-tests@a848aec9c87c29470093b22154107b83a7696374
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-node.yml
+++ b/.github/workflows/server-node.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Launch the test service in the background
         run: yarn workspace @launchdarkly/node-server-sdk-contract-tests start 2>&1 &
       - name: Run contract tests (v2)
-        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}
           stop_service: 'false'
           extra_params: '--skip-from=./packages/sdk/server-node/contract-tests/testharness-suppressions.txt'
       - name: Run contract tests (v3)
-        uses: launchdarkly/gh-actions/actions/contract-tests@5adb11fd6953e1bc35d9cf1fc1b4374c464e3a8b # contract-tests-v1.3.0
+        uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shopify-oxygen.yml
+++ b/.github/workflows/shopify-oxygen.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn workspace @launchdarkly/shopify-oxygen-contract-tests build
       - name: Launch the test service in the background
         run: yarn workspace @launchdarkly/shopify-oxygen-contract-tests start &> /dev/null &
-      - uses: launchdarkly/gh-actions/actions/contract-tests@a848aec9c87c29470093b22154107b83a7696374
+      - uses: launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1
         with:
           test_service_port: 8000
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds explicit `vulnerabilityAlerts` and `osvVulnerabilityAlerts` config at the repo level, after the preset's `enabled: false` packageRule
- Testing whether this ordering causes Renovate to create security update PRs for packages like `electron`, `vite`, and `postcss` that are currently being marked as disabled

## Context

The `sdk-javascript` preset sets `enabled: false` for all npm packages to suppress routine dependency PRs. However, Renovate's vulnerability alert system should bypass `enabled: false` via a `force` mechanism. The last Renovate run showed that `electron`, `vite`, and `postcss` (all with known CVEs) were logged as "is disabled" rather than generating PRs.

This PR tests whether explicitly re-declaring `vulnerabilityAlerts.enabled: true` at the repo level (after the preset extends) changes the behavior.