### PR TITLE
feat: Wire CI and release-please for openfeature-cloudflare-server (prerelease)

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-sdk-openfeature-cloudflare-server--bug_report.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-openfeature-cloudflare-server--bug_report.md
@@ -1,0 +1,36 @@
+---
+name: '@launchdarkly/openfeature-cloudflare-server Bug Report'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/openfeature-cloudflare-server, bug'
+assignees: ''
+---
+
+**Is this a support request?**
+This issue tracker is maintained by LaunchDarkly SDK developers and is intended for feedback on the code in this library. If you're not sure whether the problem you are having is specifically related to this library, or to the LaunchDarkly service overall, it may be more appropriate to contact the LaunchDarkly support team; they can help to investigate the problem and will consult the SDK team if necessary. You can submit a support request by going [here](https://support.launchdarkly.com/) and clicking "submit a request", or by emailing support@launchdarkly.com.
+
+Note that issues filed on this issue tracker are publicly accessible. Do not provide any private account information on your issues. If your problem is specific to your account, you should submit a support request as described above.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add any log output related to your problem.
+
+**SDK version**
+The version of this SDK that you are using.
+
+**Language version, developer tools**
+For instance, Go 1.11 or Ruby 2.5.3. If you are using a language that requires a separate compiler, such as C, please include the name and version of the compiler too.
+
+**OS/platform**
+For instance, Ubuntu 16.04, Windows 10, or Android 4.0.3. If your code is running in a browser, please also include the browser type and version.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/package-sdk-openfeature-cloudflare-server--feature_request.md
+++ b/.github/ISSUE_TEMPLATE/package-sdk-openfeature-cloudflare-server--feature_request.md
@@ -1,0 +1,19 @@
+---
+name: '@launchdarkly/openfeature-cloudflare-server Feature Request'
+about: Create a report to help us improve
+title: ''
+labels: 'package: sdk/openfeature-cloudflare-server, feature'
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I would love to see the SDK [...does something new...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/workflows/openfeature-cloudflare-server.yaml
+++ b/.github/workflows/openfeature-cloudflare-server.yaml
@@ -1,0 +1,33 @@
+name: sdk/openfeature-cloudflare-server
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-openfeature-cloudflare-server:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Node versions to run on. Matches this package's own "engines" field (>=22).
+        version: [22]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./actions/setup-yarn
+        with:
+          node-version: ${{ matrix.version }}
+          registry-url: 'https://registry.npmjs.org'
+      - id: shared
+        name: Shared CI Steps
+        uses: ./actions/ci
+        with:
+          workspace_name: '@launchdarkly/openfeature-cloudflare-server'
+          workspace_path: packages/sdk/openfeature-cloudflare-server

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,6 +65,7 @@ on:
           - packages/sdk/node-client
           - packages/sdk/react
           - packages/shared/openfeature-server-common
+          - packages/sdk/openfeature-cloudflare-server
           - packages/sdk/openfeature-node-server
           - packages/sdk/vue
       prerelease:
@@ -112,6 +113,7 @@ jobs:
       package-sdk-react-released: ${{ steps.release.outputs['packages/sdk/react--release_created'] }}
       package-shared-openfeature-server-common-released: ${{ steps.release.outputs['packages/shared/openfeature-server-common--release_created'] }}
       package-sdk-openfeature-node-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-node-server--release_created'] }}
+      package-sdk-openfeature-cloudflare-server-released: ${{ steps.release.outputs['packages/sdk/openfeature-cloudflare-server--release_created'] }}
       package-tooling-client-testing-plugin-released: ${{ steps.release.outputs['packages/tooling/client-testing-plugin--release_created'] }}
       package-sdk-vue-released: ${{ steps.release.outputs['packages/sdk/vue--release_created'] }}
       package-node-client-released: ${{ steps.release.outputs['packages/sdk/node-client--release_created'] }}
@@ -591,6 +593,22 @@ jobs:
         uses: ./actions/full-release
         with:
           workspace_path: packages/sdk/openfeature-node-server
+          aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+
+  release-openfeature-cloudflare-server:
+    runs-on: ubuntu-latest
+    needs: ['release-please', 'release-cloudflare', 'release-openfeature-server-common']
+    permissions:
+      id-token: write
+      contents: write
+    if: ${{ always() && !failure() && !cancelled() && needs.release-please.outputs.package-sdk-openfeature-cloudflare-server-released == 'true'}}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: release-openfeature-cloudflare-server
+        name: Full release of packages/sdk/openfeature-cloudflare-server
+        uses: ./actions/full-release
+        with:
+          workspace_path: packages/sdk/openfeature-cloudflare-server
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
 
   release-vue:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -610,6 +610,8 @@ jobs:
         with:
           workspace_path: packages/sdk/openfeature-cloudflare-server
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
+          # openfeature-cloudflare-server is publishing as a prerelease; remove this once it reaches GA so npm's `latest` tag starts tracking it.
+          prerelease: true
 
   release-vue:
     runs-on: ubuntu-latest

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -27,5 +27,6 @@
   "packages/sdk/shopify-oxygen": "0.1.20",
   "packages/sdk/react": "4.1.14",
   "packages/sdk/openfeature-node-server": "1.4.0",
-  "packages/sdk/vue": "0.2.2"
+  "packages/sdk/vue": "0.2.2",
+  "packages/sdk/openfeature-cloudflare-server": "0.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This includes shared libraries, used by SDKs and other tools, as well as SDKs.
 | [@launchdarkly/react-sdk](packages/sdk/react/README.md)                       | [![NPM][sdk-react-npm-badge]][sdk-react-npm-link]                   | [React][package-sdk-react-issues]                   | [![Actions Status][sdk-react-ci-badge]][sdk-react-ci]                   |
 | [@launchdarkly/vue-client-sdk](packages/sdk/vue/README.md)                     | [![NPM][sdk-vue-npm-badge]][sdk-vue-npm-link]                       | [Vue][package-sdk-vue-issues]                       | [![Actions Status][sdk-vue-ci-badge]][sdk-vue-ci]                       |
 | [@launchdarkly/openfeature-node-server](packages/sdk/openfeature-node-server/README.md) | [![NPM][sdk-openfeature-node-server-npm-badge]][sdk-openfeature-node-server-npm-link] | [OpenFeature Node Server][package-sdk-openfeature-node-server-issues] | [![Actions Status][sdk-openfeature-node-server-ci-badge]][sdk-openfeature-node-server-ci] |
+| [@launchdarkly/openfeature-cloudflare-server](packages/sdk/openfeature-cloudflare-server/README.md) | [![NPM][sdk-openfeature-cloudflare-server-npm-badge]][sdk-openfeature-cloudflare-server-npm-link] | [OpenFeature Cloudflare Server][package-sdk-openfeature-cloudflare-server-issues] | [![Actions Status][sdk-openfeature-cloudflare-server-ci-badge]][sdk-openfeature-cloudflare-server-ci] |
 <!--| [@launchdarkly/browser](packages/sdk/combined-browser/README.md)                  | [![NPM][sdk-combined-browser-npm-badge]][sdk-browser-npm-link]             | [Combined Browser][package-sdk-combined-browser-issues]             | [![Actions Status][sdk-combined-browser-ci-badge]][sdk-combined-browser-ci]             |-->
 
 | Shared packages                                                                      | npm                                                                       | issues                                                      | tests                                                                           |
@@ -272,3 +273,9 @@ We encourage pull requests and other contributions from the community. Check out
 [sdk-openfeature-node-server-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-node-server.svg?style=flat-square
 [sdk-openfeature-node-server-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-node-server
 [package-sdk-openfeature-node-server-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fopenfeature-node-server%22+
+[//]: # 'sdk/openfeature-cloudflare-server'
+[sdk-openfeature-cloudflare-server-ci-badge]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-cloudflare-server.yaml/badge.svg
+[sdk-openfeature-cloudflare-server-ci]: https://github.com/launchdarkly/js-core/actions/workflows/openfeature-cloudflare-server.yaml
+[sdk-openfeature-cloudflare-server-npm-badge]: https://img.shields.io/npm/v/@launchdarkly/openfeature-cloudflare-server.svg?style=flat-square
+[sdk-openfeature-cloudflare-server-npm-link]: https://www.npmjs.com/package/@launchdarkly/openfeature-cloudflare-server
+[package-sdk-openfeature-cloudflare-server-issues]: https://github.com/launchdarkly/js-core/issues?q=is%3Aissue+is%3Aopen+label%3A%22package%3A+sdk%2Fopenfeature-cloudflare-server%22+

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -129,7 +129,17 @@
           "path": "example/package.json",
           "jsonpath": "$.dependencies['@launchdarkly/cloudflare-server-sdk']"
         },
-        "src/createPlatformInfo.ts"
+        "src/createPlatformInfo.ts",
+        {
+          "type": "json",
+          "path": "/packages/sdk/openfeature-cloudflare-server/package.json",
+          "jsonpath": "$.peerDependencies['@launchdarkly/cloudflare-server-sdk']"
+        },
+        {
+          "type": "json",
+          "path": "/packages/sdk/openfeature-cloudflare-server/package.json",
+          "jsonpath": "$.devDependencies['@launchdarkly/cloudflare-server-sdk']"
+        }
       ]
     },
     "packages/sdk/fastly": {
@@ -409,7 +419,15 @@
         }
       ]
     },
-    "packages/shared/openfeature-server-common": {},
+    "packages/shared/openfeature-server-common": {
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "/packages/sdk/openfeature-cloudflare-server/package.json",
+          "jsonpath": "$.dependencies['@launchdarkly/openfeature-js-server-common']"
+        }
+      ]
+    },
     "packages/sdk/openfeature-node-server": {
       "extra-files": [
         "src/LaunchDarklyProvider.ts",
@@ -419,6 +437,10 @@
           "jsonpath": "$.dependencies['@launchdarkly/openfeature-node-server']"
         }
       ]
+    },
+    "packages/sdk/openfeature-cloudflare-server": {
+      "bump-minor-pre-major": true,
+      "prerelease": true
     },
     "packages/sdk/vue": {
       "bump-minor-pre-major": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -133,11 +133,6 @@
         {
           "type": "json",
           "path": "/packages/sdk/openfeature-cloudflare-server/package.json",
-          "jsonpath": "$.peerDependencies['@launchdarkly/cloudflare-server-sdk']"
-        },
-        {
-          "type": "json",
-          "path": "/packages/sdk/openfeature-cloudflare-server/package.json",
           "jsonpath": "$.devDependencies['@launchdarkly/cloudflare-server-sdk']"
         }
       ]
@@ -440,7 +435,8 @@
     },
     "packages/sdk/openfeature-cloudflare-server": {
       "bump-minor-pre-major": true,
-      "prerelease": true
+      "prerelease": true,
+      "prerelease-type": "beta"
     },
     "packages/sdk/vue": {
       "bump-minor-pre-major": true,


### PR DESCRIPTION
This PR will publish `@launchdarkly/openfeature-cloudflare-server` as a pre-release module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds monorepo plumbing so **`@launchdarkly/openfeature-cloudflare-server`** can be built in CI and published to npm as a **beta prerelease** (starting at **0.1.0**).
> 
> A dedicated GitHub Actions workflow runs shared build/test for that workspace on Node 22. **release-please** is extended with manifest/config entries (`prerelease-type: beta`), cross-package version bumps when **`@launchdarkly/cloudflare-server-sdk`** or **`@launchdarkly/openfeature-js-server-common`** release, a **`release-openfeature-cloudflare-server`** job (after cloudflare + openfeature-server-common) with **`prerelease: true`** so npm `latest` is not updated, and manual publish support. README and package-scoped issue templates are added for discoverability and support routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c38cdd248934e91f3f55beabc7858c67f4325880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->