### PR TITLE
chore(deps): fixing dependency breaking build

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
   },
   "packageManager": "yarn@4.15.0",
   "resolutions": {
-    "@types/node": "24.1.0"
+    "@types/node": "24.1.0",
+    "@bytecodealliance/jco/typescript": "5.9.3",
+    "@bytecodealliance/jco/typescript-compiler-api": "npm:typescript@5.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "packageManager": "yarn@4.15.0",
   "resolutions": {
     "@types/node": "24.1.0",
-    "@bytecodealliance/jco/typescript": "5.9.3",
+    "@bytecodealliance/jco/typescript": "5.1.6",
     "@bytecodealliance/jco/typescript-compiler-api": "npm:typescript@5.1.6"
   }
 }


### PR DESCRIPTION
`@bytecodealliance/jco` pulls in typscript 7 which breaks root level
install. This change will scope the typescript version back to 5.x.x

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **Yarn `resolutions`** so `@bytecodealliance/jco` no longer pulls **TypeScript 7** during install, which was breaking the monorepo root install.
> 
> `@bytecodealliance/jco/typescript` is forced to **5.1.6** (same as the root `typescript` devDependency), and `typescript-compiler-api` is aliased to **`npm:typescript@5.1.6`** so the whole jco toolchain stays on **5.x**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbcf1ec18ed534487f5cc70aee736ebdd3b410b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->