### PR TITLE
fix(perf): reduce Akamai CryptoJS bundle size

### DIFF
--- a/packages/shared/akamai-edgeworker-sdk/__tests__/platform/crypto/crypto.test.ts
+++ b/packages/shared/akamai-edgeworker-sdk/__tests__/platform/crypto/crypto.test.ts
@@ -1,0 +1,46 @@
+import CryptoJSHasher from '../../../src/platform/crypto/cryptoJSHasher';
+import CryptoJSHmac from '../../../src/platform/crypto/cryptoJSHmac';
+import { SupportedHashAlgorithm } from '../../../src/platform/crypto/types';
+
+const vectors = [
+  {
+    algorithm: 'sha1',
+    hashHex: 'aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d',
+    hashBase64: 'qvTGHdzF6KLavt4PO0gs2a6pQ00=',
+    hmacHex: 'b34ceac4516ff23a143e61d79d0fa7a4fbe5f266',
+    hmacBase64: 's0zqxFFv8joUPmHXnQ+npPvl8mY=',
+  },
+  {
+    algorithm: 'sha256',
+    hashHex: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    hashBase64: 'LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=',
+    hmacHex: '9307b3b915efb5171ff14d8cb55fbcc798c6c0ef1456d66ded1a6aa723a58b7b',
+    hmacBase64: 'kwezuRXvtRcf8U2MtV+8x5jGwO8UVtZt7RpqpyOli3s=',
+  },
+] as const;
+
+describe.each(vectors)('given the $algorithm algorithm', (vector) => {
+  const algorithm = vector.algorithm as SupportedHashAlgorithm;
+
+  it('hashes using hex encoding', () => {
+    expect(new CryptoJSHasher(algorithm).update('hello').digest('hex')).toEqual(vector.hashHex);
+  });
+
+  it('hashes using base64 encoding', () => {
+    expect(new CryptoJSHasher(algorithm).update('hello').digest('base64')).toEqual(
+      vector.hashBase64,
+    );
+  });
+
+  it('creates an HMAC using hex encoding', () => {
+    expect(new CryptoJSHmac(algorithm, 'key').update('hello').digest('hex')).toEqual(
+      vector.hmacHex,
+    );
+  });
+
+  it('creates an HMAC using base64 encoding', () => {
+    expect(new CryptoJSHmac(algorithm, 'key').update('hello').digest('base64')).toEqual(
+      vector.hmacBase64,
+    );
+  });
+});

--- a/packages/shared/akamai-edgeworker-sdk/src/platform/crypto/cryptoJSHasher.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/platform/crypto/cryptoJSHasher.ts
@@ -1,6 +1,7 @@
-import { algo as CryptoAlgo } from 'crypto-js';
-import Base64 from 'crypto-js/enc-base64';
-import Hex from 'crypto-js/enc-hex';
+import CryptoJS from 'crypto-js/core';
+import 'crypto-js/sha1';
+import 'crypto-js/sha256';
+import 'crypto-js/enc-base64';
 
 import { Hasher as LDHasher } from '@launchdarkly/js-server-sdk-common';
 
@@ -14,10 +15,10 @@ export default class CryptoJSHasher implements LDHasher {
 
     switch (algorithm) {
       case 'sha1':
-        algo = CryptoAlgo.SHA1;
+        algo = CryptoJS.algo.SHA1;
         break;
       case 'sha256':
-        algo = CryptoAlgo.SHA256;
+        algo = CryptoJS.algo.SHA256;
         break;
       default:
         throw new Error('unsupported hash algorithm. Only sha1 and sha256 are supported.');
@@ -32,10 +33,10 @@ export default class CryptoJSHasher implements LDHasher {
     let enc;
     switch (encoding) {
       case 'base64':
-        enc = Base64;
+        enc = CryptoJS.enc.Base64;
         break;
       case 'hex':
-        enc = Hex;
+        enc = CryptoJS.enc.Hex;
         break;
       default:
         throw new Error('unsupported output encoding. Only base64 and hex are supported.');

--- a/packages/shared/akamai-edgeworker-sdk/src/platform/crypto/cryptoJSHmac.ts
+++ b/packages/shared/akamai-edgeworker-sdk/src/platform/crypto/cryptoJSHmac.ts
@@ -1,4 +1,8 @@
-import { algo as CryptoAlgo } from 'crypto-js';
+import CryptoJS from 'crypto-js/core';
+import 'crypto-js/sha1';
+import 'crypto-js/sha256';
+import 'crypto-js/hmac';
+import 'crypto-js/enc-base64';
 
 import { Hmac as LDHmac } from '@launchdarkly/js-server-sdk-common';
 
@@ -12,16 +16,16 @@ export default class CryptoJSHmac implements LDHmac {
 
     switch (algorithm) {
       case 'sha1':
-        algo = CryptoAlgo.SHA1;
+        algo = CryptoJS.algo.SHA1;
         break;
       case 'sha256':
-        algo = CryptoAlgo.SHA256;
+        algo = CryptoJS.algo.SHA256;
         break;
       default:
         throw new Error('unsupported hash algorithm. Only sha1 and sha256 are supported.');
     }
 
-    this._cryptoJSHmac = CryptoAlgo.HMAC.create(algo, key);
+    this._cryptoJSHmac = CryptoJS.algo.HMAC.create(algo, key);
   }
 
   digest(encoding: SupportedOutputEncoding): string {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Raised from a [customer report](https://launchdarklysupport.zendesk.com/requests/129493) that Akamai SDK initialization consumes approximately 45 ms of a 60 ms initialization CPU budget.

**Describe the solution you've provided**

Replace the `crypto-js` root import with targeted imports for core, SHA-1, SHA-256, HMAC, and Base64. This avoids bundling unused ciphers, hash algorithms, modes, and padding implementations while preserving the existing synchronous crypto API.

The HMAC implementation now also accesses Base64 and Hex through the imported CryptoJS namespace instead of the undeclared `CryptoJS` global. Direct test vectors cover SHA-1 and SHA-256 hashes and HMACs in both Hex and Base64.

**Describe alternatives you've considered**

Targeted `semver` imports and publishing an unbundled ESM entry point could provide additional savings, but they affect shared SDK behavior or the public package layout. They are intentionally excluded so this PR remains a low-risk import-graph optimization matching the approach already accepted for the Fastly SDK in #1795.

**Additional context**

Measured after building with:

```shell
yarn workspaces foreach -pR --topological-dev --from '@launchdarkly/akamai-server-edgekv-sdk' run build
```

| EdgeKV artifact | Raw | Gzip | Brotli |
| --- | ---: | ---: | ---: |
| ESM | 272,844 -> 213,975 bytes (-21.58%) | 81,316 -> 58,334 bytes (-28.26%) | 67,973 -> 50,037 bytes (-26.39%) |
| CJS | 272,462 -> 213,593 bytes (-21.61%) | 81,114 -> 58,130 bytes (-28.34%) | 67,797 -> 49,904 bytes (-26.39%) |

Validated with the common Akamai SDK and EdgeKV SDK unit tests and lint checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Shrinks the Akamai EdgeKV SDK bundle** by replacing the full `crypto-js` entry import with `crypto-js/core` plus side-effect imports for SHA-1, SHA-256, HMAC, and Base64 only, so unused ciphers and algorithms are not pulled into the build (reported ~21% smaller raw artifacts and ~28% smaller gzip).
> 
> `CryptoJSHasher` and `CryptoJSHmac` now resolve algorithms and encodings through the imported `CryptoJS` namespace (`CryptoJS.algo.*`, `CryptoJS.enc.*`) instead of separate `crypto-js` subpath default imports. HMAC digest encoding follows the same pattern, removing reliance on an implicit global `CryptoJS` for Base64/Hex.
> 
> Adds **`crypto.test.ts`** with fixed vectors for SHA-1 and SHA-256 hashes and HMACs in hex and base64 to lock behavior after the import change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b98a650d6c3da32de65d8f9e271b75653f13e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->