### PR TITLE
ci: Update CI to run oxlint/oxfmt instead of ESLint/Prettier

### DIFF
--- a/actions/ci/action.yml
+++ b/actions/ci/action.yml
@@ -31,6 +31,14 @@ runs:
       shell: bash
       run: yarn workspace ${{ inputs.workspace_name }} lint
 
+    - name: Format Check
+      shell: bash
+      # TODO: Most packages aren't reformatted to the new oxfmt style yet.
+      # continue-on-error keeps this step visible in CI without blocking merges
+      # until the repo-wide reformat lands incrementally. Remove once that's done.
+      continue-on-error: true
+      run: yarn workspace ${{ inputs.workspace_name }} format:check
+
     - name: Test
       shell: bash
       # Run just the tests for the targeted package.

--- a/packages/tooling/contract-test-utils/src/adapter/startAdapter.ts
+++ b/packages/tooling/contract-test-utils/src/adapter/startAdapter.ts
@@ -1,9 +1,14 @@
+// import/extensions appears to misfire on bare package specifiers here; revisit the rule config.
+// oxlint-disable-next-line import/extensions
 import bodyParser from 'body-parser';
+// oxlint-disable-next-line import/extensions
 import cors from 'cors';
 import { randomUUID } from 'crypto';
+// oxlint-disable-next-line import/extensions
 import express from 'express';
 import http from 'node:http';
 import util from 'node:util';
+// oxlint-disable-next-line import/extensions
 import { WebSocketServer } from 'ws';
 
 export interface AdapterOptions {

--- a/packages/tooling/contract-test-utils/src/client-side/TestHook.ts
+++ b/packages/tooling/contract-test-utils/src/client-side/TestHook.ts
@@ -1,3 +1,5 @@
+// import/extensions appears to misfire on this bare package specifier; revisit the rule config.
+// oxlint-disable-next-line import/extensions
 import {
   EvaluationSeriesContext,
   EvaluationSeriesData,

--- a/packages/tooling/contract-test-utils/src/server-side/TestHook.ts
+++ b/packages/tooling/contract-test-utils/src/server-side/TestHook.ts
@@ -1,3 +1,5 @@
+// import/extensions appears to misfire on this bare package specifier; revisit the rule config.
+// oxlint-disable-next-line import/extensions
 import { integrations, LDEvaluationDetail } from '@launchdarkly/js-server-sdk-common';
 
 import { BaseTestHook } from '../shared/BaseTestHook.js';


### PR DESCRIPTION
This PR will enable oxfmt in the CI and convert some eslint ignore comments to oxlint format - currently, we are not failing the build due to formatting errors (we will run the formatter in a later PR)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds an **oxfmt** format check to the shared composite CI workflow (`actions/ci/action.yml`), running `yarn workspace … format:check` after lint and before tests. The step uses **`continue-on-error: true`** so formatting drift is visible in CI but does not block merges until a repo-wide oxfmt reformat is finished (with a TODO to remove that once complete).
> 
> In **`contract-test-utils`**, adds **`oxlint-disable-next-line import/extensions`** (with short notes about false positives on bare package specifiers) on several imports in `startAdapter.ts` and the client/server `TestHook.ts` files so oxlint passes under the new toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf405b27b22d61f20c443a0c2dbb06be0463f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->