### PR TITLE
fix!: Map LaunchDarkly evaluation reasons to OpenFeature reasons

### DIFF
--- a/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
+++ b/packages/sdk/openfeature-node-server/__tests__/LaunchDarklyProvider.test.ts
@@ -123,7 +123,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: true,
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -176,7 +176,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 'good',
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -229,7 +229,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 17,
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -282,7 +282,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: { some: 'value' },
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -339,7 +339,7 @@ describe('given a mock LaunchDarkly client', () => {
       flagKey: testFlagKey,
       value: { yes: 'no' },
       variant: '22',
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 

--- a/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/BaseOpenFeatureProvider.test.ts
@@ -86,7 +86,7 @@ it('resolveBooleanEvaluation returns the translated result for boolean flags', a
   expect(result).toEqual({
     value: true,
     variant: '1',
-    reason: 'OFF',
+    reason: 'DISABLED',
     flagMetadata: { variationIndex: 1 },
   });
 });
@@ -124,7 +124,7 @@ it('resolveNumberEvaluation returns the translated result for number flags', asy
   expect(result).toEqual({
     value: 42,
     variant: '2',
-    reason: 'TARGET_MATCH',
+    reason: 'TARGETING_MATCH',
     flagMetadata: { variationIndex: 2 },
   });
 });
@@ -351,8 +351,7 @@ it('wraps a host logger that throws so flag evaluation does not crash', async ()
   ).resolves.toEqual({
     value: true,
     variant: '0',
-    reason: 'OFF',
+    reason: 'DISABLED',
     flagMetadata: { variationIndex: 0 },
   });
 });
-

--- a/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
@@ -1,3 +1,5 @@
+import { StandardResolutionReasons } from '@openfeature/server-sdk';
+
 import { translateResult } from '../src/translateResult';
 
 it.each([true, 'potato', 42, { yes: 'no' }])('puts the value into the result.', (value) => {
@@ -23,9 +25,13 @@ it('converts the variationIndex into a string variant', () => {
   ).toEqual('9');
 });
 
-it.each(['OFF', 'FALLTHROUGH', 'TARGET_MATCH', 'PREREQUISITE_FAILED', 'ERROR'])(
-  'populates the resolution reason',
-  (reason) => {
+it.each([
+  ['OFF', StandardResolutionReasons.DISABLED],
+  ['FALLTHROUGH', 'FALLTHROUGH'],
+  ['TARGET_MATCH', StandardResolutionReasons.TARGETING_MATCH],
+  ['PREREQUISITE_FAILED', 'PREREQUISITE_FAILED'],
+  ['ERROR', StandardResolutionReasons.ERROR],
+])('populates the resolution reason', (reason, expectedReason) => {
     expect(
       translateResult<boolean>({
         value: true,
@@ -34,9 +40,8 @@ it.each(['OFF', 'FALLTHROUGH', 'TARGET_MATCH', 'PREREQUISITE_FAILED', 'ERROR'])(
           kind: reason,
         },
       }).reason,
-    ).toEqual(reason);
-  },
-);
+    ).toEqual(expectedReason);
+});
 
 it('does not populate the errorCode when there is not an error', () => {
   const translated = translateResult<boolean>({

--- a/packages/shared/openfeature-server-common/src/translateResult.ts
+++ b/packages/shared/openfeature-server-common/src/translateResult.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from '@openfeature/server-sdk';
+import { ErrorCode, StandardResolutionReasons } from '@openfeature/server-sdk';
 import type { FlagMetadata, ResolutionDetails } from '@openfeature/server-sdk';
 
 import type { LDEvaluationDetail } from '@launchdarkly/js-sdk-common';
@@ -18,6 +18,19 @@ function translateErrorKind(errorKind: string | undefined): ErrorCode {
       return ErrorCode.TARGETING_KEY_MISSING;
     default:
       return ErrorCode.GENERAL;
+  }
+}
+
+function translateReason(reason: string): string {
+  switch (reason) {
+    case 'OFF':
+      return StandardResolutionReasons.DISABLED;
+    case 'TARGET_MATCH':
+      return StandardResolutionReasons.TARGETING_MATCH;
+    case 'ERROR':
+      return StandardResolutionReasons.ERROR;
+    default:
+      return reason;
   }
 }
 
@@ -87,7 +100,7 @@ export function translateResult<T>(result: LDEvaluationDetail): ResolutionDetail
   const resolution: ResolutionDetails<T> = {
     value: result.value,
     variant: result.variationIndex?.toString(),
-    reason: result.reason.kind,
+    reason: translateReason(result.reason.kind),
     flagMetadata: translateFlagMetadata(result),
   };
 


### PR DESCRIPTION
`translateResult` now maps LaunchDarkly evaluation reason kinds onto the OpenFeature standard reasons.

- `OFF` becomes `DISABLED`, `TARGET_MATCH` becomes `TARGETING_MATCH`, `ERROR` stays `ERROR`
- All other kinds (`FALLTHROUGH`, `RULE_MATCH`, `PREREQUISITE_FAILED`, ...) pass through unchanged as LaunchDarkly-specific reasons
- Affects both the Node and Cloudflare providers, which share this package

<details>
<summary>Implementation details</summary>

Found during the weekly OpenFeature provider audit against `launchdarkly/sdk-specs` (`OFP`), which prescribes this mapping. The Java, .NET, Python and Ruby providers already implement it; the JS providers reported the raw LaunchDarkly kind, so an application checking `StandardResolutionReasons.DISABLED` or `TARGETING_MATCH` never matched.

This is a behavior change in the reason string returned for flags that are off or matched by an individual target.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe alternatives you've considered**

Leaving the raw kinds and documenting them: that keeps the providers inconsistent with the other LaunchDarkly OpenFeature providers and with the spec.

**Testing**

`yarn workspace @launchdarkly/openfeature-js-server-common test|lint`, `yarn workspace @launchdarkly/openfeature-node-server test|lint`, `yarn workspace @launchdarkly/openfeature-cloudflare-server test|lint`

</details>

Link to Devin session: https://app.devin.ai/sessions/38a6eaf69fcf41109e136a1d0fe5e899
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Breaking behavior change:** OpenFeature evaluation details no longer expose raw LaunchDarkly `reason.kind` values for the mapped cases. `translateResult` now runs LaunchDarkly reasons through a new `translateReason` helper so results align with OpenFeature `StandardResolutionReasons` and the LaunchDarkly OpenFeature provider spec.
> 
> **Mapped reasons:** `OFF` → `DISABLED`, `TARGET_MATCH` → `TARGETING_MATCH`, and `ERROR` → the standard error reason. Other kinds (e.g. `FALLTHROUGH`, `RULE_MATCH`, `PREREQUISITE_FAILED`) are unchanged.
> 
> Because this lives in `@launchdarkly/openfeature-js-server-common` and is used by `BaseOpenFeatureProvider`, **Node and Cloudflare** server providers pick up the change automatically. Tests were updated to expect the new reason strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6686aa7a20caf7b57e4a83625dc9d785bbaa078e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->