### PR TITLE
fix!: Map the WRONG_TYPE error kind to TYPE_MISMATCH

### DIFF
--- a/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateResult.test.ts
@@ -61,6 +61,18 @@ it('does populate the errorCode when there is an error', () => {
   expect(translated.errorCode).toEqual('GENERAL');
 });
 
+it('maps the WRONG_TYPE error kind to TYPE_MISMATCH', () => {
+  const translated = translateResult<boolean>({
+    value: true,
+    variationIndex: 9,
+    reason: {
+      kind: 'ERROR',
+      errorKind: 'WRONG_TYPE',
+    },
+  });
+  expect(translated.errorCode).toEqual('TYPE_MISMATCH');
+});
+
 it('includes the variation index in the flag metadata', () => {
   expect(
     translateResult<boolean>({

--- a/packages/shared/openfeature-server-common/src/translateResult.ts
+++ b/packages/shared/openfeature-server-common/src/translateResult.ts
@@ -16,6 +16,8 @@ function translateErrorKind(errorKind: string | undefined): ErrorCode {
       return ErrorCode.FLAG_NOT_FOUND;
     case 'USER_NOT_SPECIFIED':
       return ErrorCode.TARGETING_KEY_MISSING;
+    case 'WRONG_TYPE':
+      return ErrorCode.TYPE_MISMATCH;
     default:
       return ErrorCode.GENERAL;
   }


### PR DESCRIPTION
The `WRONG_TYPE` evaluation error kind is now reported as `ErrorCode.TYPE_MISMATCH` instead of falling through to `GENERAL`.

- Required by the OFP spec's error kind mapping; the Ruby and .NET providers already do this
- The JS server SDK does produce `WRONG_TYPE` (see `LDClientImpl`), so this is reachable for both the Node and Cloudflare providers

<details>
<summary>Implementation details</summary>

Found during the weekly OpenFeature provider audit against `launchdarkly/sdk-specs` (`OFP`).

`translateErrorKind` handled `CLIENT_NOT_READY`, `MALFORMED_FLAG`, `FLAG_NOT_FOUND` and `USER_NOT_SPECIFIED`; everything else became `GENERAL`, so an application could not distinguish a type mismatch from an arbitrary failure.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe alternatives you've considered**

None; the mapping is prescribed by the spec.

**Testing**

`yarn workspace @launchdarkly/openfeature-js-server-common test|lint`

</details>

Link to Devin session: https://app.devin.ai/sessions/38a6eaf69fcf41109e136a1d0fe5e899
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> OpenFeature evaluation results now map LaunchDarkly’s **`WRONG_TYPE`** error kind to **`ErrorCode.TYPE_MISMATCH`** instead of **`GENERAL`**, aligning the shared server provider translation with the OpenFeature provider spec (and other LaunchDarkly providers).
> 
> A unit test asserts that **`translateErrorKind`** returns **`TYPE_MISMATCH`** when the evaluation reason is **`ERROR`** with **`errorKind: 'WRONG_TYPE'`**. Apps that relied on **`GENERAL`** for type mismatches will see a different **`errorCode`** when the JS server SDK returns **`WRONG_TYPE`** (e.g. wrong flag type for the requested evaluation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 170d17032edc69ce65e86eca09b645314070f602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->