### PR TITLE
docs: Add OpenFeature feature matrices to the provider READMEs

### DIFF
--- a/packages/sdk/openfeature-cloudflare-server/README.md
+++ b/packages/sdk/openfeature-cloudflare-server/README.md
@@ -16,6 +16,28 @@ This package provides an [OpenFeature](https://openfeature.dev/) provider that w
 
 This provider is designed primarily for use in multi-user Cloudflare Workers. It follows the server-side LaunchDarkly model for multi-user contexts. It is not intended for use in desktop and embedded systems applications.
 
+## Feature matrix
+
+This matrix mirrors the [feature matrix of the OpenFeature SDK for JavaScript](https://github.com/open-feature/js-sdk/blob/main/packages/server/README.md#-features) and describes what this provider supports. Rows which are not supported state whether the limitation comes from the OpenFeature JavaScript SDK or from the provider.
+
+| Status | Feature                         | Notes                                                                                                                                                                                                                     |
+|--------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | Providers                       | Evaluates boolean, string, number, and object flags through the LaunchDarkly Cloudflare SDK.                                                                                                                              |
+| ✅      | Targeting                       | The `EvaluationContext` is converted to a LaunchDarkly single or multi-context. See [OpenFeature Specific Considerations](#openfeature-specific-considerations).                                                           |
+| ✅      | Hooks                           | Hooks are registered on the OpenFeature API and client; the provider requires no additional support and its results are visible to hooks, including [flag metadata](#flag-metadata).                                       |
+| ✅      | Logging                         | The provider logs through the logging configuration of the `LDOptions` it is given.                                                                                                                                       |
+| ✅      | Domains                         | Domains bind clients to providers in the OpenFeature SDK; a separate provider instance may be registered per domain.                                                                                                       |
+| ❌      | Eventing                        | This provider does not emit `ConfigurationChanged`, `Error`, or `Stale` events because the Cloudflare SDK reads flag data from a KV namespace on each evaluation and has no connection to LaunchDarkly to provide an underlying event to translate. This is a Cloudflare platform limitation, not an OpenFeature SDK or provider gap. See [ConfigurationChanged is not supported on this platform](#configurationchanged-is-not-supported-on-this-platform) and [#1886](https://github.com/launchdarkly/js-core/issues/1886). |
+| ✅      | Transaction Context Propagation | Provided by the OpenFeature SDK, which merges the transaction context into the evaluation context before the provider is called; no provider support is required.                                                          |
+| ✅      | Tracking                        | The common provider implementation translates tracking details and sends them through the Cloudflare LaunchDarkly client.                                                                                                 |
+| ✅      | Initialization                  | `initialize` waits for the Cloudflare LaunchDarkly client with the common provider's default 10-second timeout; the Cloudflare provider passes no initialization-timeout override.                                      |
+| ✅      | Shutdown                        | The common provider implementation flushes and closes the Cloudflare LaunchDarkly client. A closed client cannot be restarted, so a new provider instance is required afterward.                                         |
+| ✅      | Extending                       | The underlying LaunchDarkly client is available through `getClient()` for functionality with no OpenFeature equivalent.                                                                                                    |
+| ✅      | Multi-Provider                 | Provided by the OpenFeature SDK; no provider support is required.                                                                                                                                                          |
+| ✅      | Flag metadata                   | LaunchDarkly evaluation reason details are returned as OpenFeature flag metadata. See [Flag Metadata](#flag-metadata).                                                                                                     |
+
+<sub>Supported: ✅ | Partially supported: ⚠️ | Not supported: ❌</sub>
+
 ## Installation
 
 ```bash

--- a/packages/sdk/openfeature-node-server/README.md
+++ b/packages/sdk/openfeature-node-server/README.md
@@ -14,6 +14,28 @@ This provider is designed primarily for use in multi-user systems such as web se
 
 This version of the LaunchDarkly OpenFeature provider is compatible with Node.js versions 20 and above.
 
+## Feature matrix
+
+This matrix mirrors the [feature matrix of the OpenFeature SDK for JavaScript](https://github.com/open-feature/js-sdk/blob/main/packages/server/README.md#-features) and describes what this provider supports. Rows which are not supported state whether the limitation comes from the OpenFeature JavaScript SDK or from the provider.
+
+| Status | Feature                         | Notes                                                                                                                                                                                                                     |
+|--------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | Providers                       | Evaluates boolean, string, number, and object flags through the LaunchDarkly Node.js SDK.                                                                                                                                 |
+| ✅      | Targeting                       | The `EvaluationContext` is converted to a LaunchDarkly single or multi-context. See [OpenFeature Specific Considerations](#openfeature-specific-considerations).                                                           |
+| ✅      | Hooks                           | Hooks are registered on the OpenFeature API and client; the provider requires no additional support and its results are visible to hooks, including [flag metadata](#flag-metadata).                                       |
+| ✅      | Logging                         | The provider logs through the logging configuration of the `LDOptions` it is given.                                                                                                                                       |
+| ✅      | Domains                         | Domains bind clients to providers in the OpenFeature SDK; a separate provider instance may be registered per domain.                                                                                                       |
+| ⚠️      | Eventing                        | Only `ConfigurationChanged` is emitted; this provider never emits `Error` or `Stale` because the underlying LaunchDarkly Node.js SDK has no data source status API. This is a limitation of the provider's underlying SDK, not the OpenFeature SDK: [#1886](https://github.com/launchdarkly/js-core/issues/1886). |
+| ✅      | Transaction Context Propagation | Provided by the OpenFeature SDK, which merges the transaction context into the evaluation context before the provider is called; no provider support is required.                                                          |
+| ✅      | Tracking                        | `track` sends a LaunchDarkly custom event for the evaluation context, with the tracking event value and remaining details attached.                                                                                        |
+| ✅      | Initialization                  | `initialize` waits for the LaunchDarkly client with the `initTimeoutSeconds` constructor parameter, which defaults to 10 seconds.                                                                                          |
+| ✅      | Shutdown                        | `onClose` flushes and closes the LaunchDarkly client. A closed client cannot be restarted, so a new provider instance is required afterward.                                                                              |
+| ✅      | Extending                       | The underlying LaunchDarkly client is available through `getClient()` for functionality with no OpenFeature equivalent.                                                                                                    |
+| ✅      | Multi-Provider                 | Provided by the OpenFeature SDK; no provider support is required.                                                                                                                                                          |
+| ✅      | Flag metadata                   | LaunchDarkly evaluation reason details are returned as OpenFeature flag metadata. See [Flag Metadata](#flag-metadata).                                                                                                     |
+
+<sub>Supported: ✅ | Partially supported: ⚠️ | Not supported: ❌</sub>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Adds a feature matrix to the Node and Cloudflare OpenFeature provider READMEs, mirroring the OpenFeature JavaScript server SDK's own feature table.

- Same rows and order as the [OpenFeature JS server SDK matrix](https://github.com/open-feature/js-sdk/blob/main/packages/server/README.md#-features), plus `Initialization` and `Flag metadata`
- Node marks `Eventing` partial: only `ConfigurationChanged` is emitted, because the LaunchDarkly Node.js SDK has no data source status API ([#1886](https://github.com/launchdarkly/js-core/issues/1886))
- Cloudflare marks `Eventing` unsupported, as a platform limitation — flag data is read from KV per evaluation, so there is no underlying event to translate
- The matrices live in the provider package READMEs, and use the same format as the Java, Python, .NET and Ruby providers so they can be compared side by side

<details>
<summary>Implementation details</summary>

Written during the weekly OpenFeature provider audit. Each row was checked against the provider source and the shared `openfeature-server-common` base class rather than assumed; the wording follows the matrix already present in the Ruby provider README. Every row that is not fully supported states whether the limitation is in the OpenFeature SDK, in the platform, or in the provider, so a reader never has to guess.

Documentation only; no packages change.

**Requirements**

- [x] I have added test coverage for new or changed functionality (documentation only)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

[#1886](https://github.com/launchdarkly/js-core/issues/1886)

</details>

Link to Devin session: https://app.devin.ai/sessions/38a6eaf69fcf41109e136a1d0fe5e899
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds a **Feature matrix** section to the OpenFeature provider READMEs for **Node.js** and **Cloudflare**, aligned with the [OpenFeature JavaScript server SDK feature table](https://github.com/open-feature/js-sdk/blob/main/packages/server/README.md#-features) and extended with **Initialization** and **Flag metadata** rows.
> 
> Each row documents support (✅/⚠️/❌) and notes where gaps come from the OpenFeature SDK, the provider, or the platform. **Eventing** is the main divergence: Node is **partial** (only `ConfigurationChanged`; no `Error`/`Stale` per [#1886](https://github.com/launchdarkly/js-core/issues/1886)), while Cloudflare is **unsupported** because flags are read from KV per evaluation with no streamable change events.
> 
> **Documentation only**—no runtime or package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78dcdfd550b8b07b1d642774cfad27c578f45c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->