### PR TITLE
fix(vue-sdk): re-export `LDPlugin` from base impl

### DIFF
--- a/packages/sdk/vue/src/index.ts
+++ b/packages/sdk/vue/src/index.ts
@@ -22,6 +22,7 @@ export type {
   LDFlagValue,
   LDInspection,
   LDLogger,
+  LDPlugin,
   Hook,
   LDIdentifyOptions,
   LDIdentifyResult,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> The Vue SDK’s public entry now **re-exports the `LDPlugin` type** from `@launchdarkly/js-client-sdk`, alongside the other commonly used client types.
> 
> This aligns the Vue package surface with the base client SDK so TypeScript consumers can type custom plugins without importing directly from the base package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ca5d06fd515e9f39720ca85d88014dd3668c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->