### PR TITLE
ci(client-common): remove comments during rollup

### DIFF
--- a/packages/shared/sdk-client/rollup.config.js
+++ b/packages/shared/sdk-client/rollup.config.js
@@ -27,6 +27,7 @@ export default [
         module: 'esnext',
         tsconfig: './tsconfig.json',
         outputToFilesystem: true,
+        removeComments: true,
       }),
       common({
         transformMixedEsModules: true,
@@ -39,7 +40,7 @@ export default [
   {
     ...getSharedConfig('cjs', 'dist/cjs/index.cjs'),
     plugins: [
-      typescript({ tsconfig: './tsconfig.json', outputToFilesystem: true }),
+      typescript({ tsconfig: './tsconfig.json', outputToFilesystem: true, removeComments: true }),
       common(),
       resolve(),
       json(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> **Rollup builds for `@launchdarkly` shared sdk-client now drop comments from compiled output** for both ESM (`dist/esm/index.mjs`) and CJS (`dist/cjs/index.cjs`) targets by setting `removeComments: true` on `@rollup/plugin-typescript` in each bundle config.
> 
> This affects emitted JavaScript only (not source); it aligns intermediate dist artifacts with leaner bundles before downstream SDK packages apply their own minification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db3865ce18db221a2cc7c09d01228ac882b9a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->