### PR TITLE
chore: Exclude typescript from Dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "typescript"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,10 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        group-by: dependency-name
     ignore:
       - dependency-name: "typescript"


### PR DESCRIPTION
TypeScript is a dev toolchain dependency managed deliberately alongside the SDK's own TypeScript version. Routine Dependabot bumps for typescript in examples and contract tests would create noise (e.g. jumping from 4.5 to 7.0) without adding value. Security updates for typescript still come through since Dependabot bypasses `ignore` rules for security alerts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adjusts the **npm** Dependabot config for SDK examples, contract tests, and related paths so routine updates are less noisy and easier to review.
> 
> Adds an **`ignore`** rule for the **`typescript`** package so Dependabot no longer opens version bumps there; TypeScript stays aligned with the SDK’s chosen toolchain instead of drifting via example/test `package.json` files. **Security advisories** for TypeScript can still surface separately (Dependabot does not apply `ignore` to those).
> 
> Also adds **`groups.npm-dependencies`** with **`group-by: dependency-name`**, so non-TypeScript npm updates are grouped per dependency rather than as many one-off PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75610e7473e6ae85bda4e6ddc7aaa20c0daf41ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->