### PR TITLE
chore: dependabot to ignore major type updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,5 @@ updates:
         group-by: dependency-name
     ignore:
       - dependency-name: "typescript"
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR will make dependabot ignore major type updates which could break builds.

This should be safe as `@types` scoped packages should always be dev dependencies.

ref: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#ignore--

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **npm** Dependabot config so **`@types/*`** packages no longer get automatic **semver-major** bump PRs, alongside the existing **`typescript`** ignore.
> 
> Major `@types` releases often introduce breaking type changes that can fail CI without a deliberate upgrade; limiting Dependabot to minor/patch for those scoped packages reduces noisy or risky major update PRs while still allowing smaller updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d830d297bb47589c5c05b90280d4f9740f7a091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->