### PR TITLE
chore: Register AI SDK identifiers and correct AI feature list

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -236,18 +236,17 @@
       "type": "ai",
       "path": "packages/sdk/server-ai",
       "languages": ["JavaScript", "TypeScript"],
+      "aiSdkNames": ["@launchdarkly/server-sdk-ai"],
       "releases": {
         "tag-prefix": "server-sdk-ai-"
       },
       "userAgents": ["NodeJSAIClient"],
       "features": {
         "aiAgentConfig": { "introduced": "0.11" },
+        "aiAgentGraph": { "introduced": "0.17" },
         "aiCompletionConfig": { "introduced": "0.1" },
         "aiJudgeConfig": { "introduced": "0.14" },
-        "aiTrackMetrics": { "introduced": "0.1" },
-        "contexts": { "introduced": "0.1" },
-        "experimentation": { "introduced": "0.1" },
-        "privateAttrs": { "introduced": "0.1" }
+        "aiTrackMetrics": { "introduced": "0.1" }
       }
     },
     "shopify-oxygen": {


### PR DESCRIPTION
## Why

The `server-ai` entry in `.sdk_metadata.json` is out of date in three ways. sdk-meta builds the SDK catalog from this file, so the errors show up in the SDK feature matrix and in SDK Connections.

## 1. Add `aiSdkNames`

```json
"aiSdkNames": ["@launchdarkly/server-sdk-ai"]
```

AI SDKs have no user agent of their own — they wrap a caller-supplied client and report themselves in a `$ld:ai:sdk:info` custom event instead. sdk-meta is gaining a registry for that channel (launchdarkly/sdk-meta#607) so those reported values can be resolved back to an SDK id.

The value is the `aiSdkName` from `packages/sdk/server-ai/src/sdkInfo.ts`. The language is not repeated here — sdk-meta pairs each name with the SDK's declared `languages` at generation time.

Until #607 merges the ingest tool ignores unknown fields, so this is inert.

## 2. Add the missing `aiAgentGraph` feature

The entry never declared it, though the capability has shipped since 0.17 — `LDGraphTrackerImpl.ts`, `LDAgentGraphFlagValue`, and `agentGraph()` are all present.

Verified by walking the tags: `git grep -il AgentGraph -- packages/sdk/server-ai` returns **0 files at `server-sdk-ai-v0.16.8`** and **9 files at `server-sdk-ai-v0.17.0`**.

## 3. Remove the non-`ai` features

Dropping `contexts`, `experimentation`, and `privateAttrs`.

The rule being applied across all AI SDK entries is **only `ai`-prefixed features**. Everything else in sdk-meta's vocabulary is a base-SDK capability, already recorded against `node-server`. Declaring it again double-counts, and since every AI SDK would claim the same three, it makes them indistinguishable in the feature comparison matrix.

`privateAttrs` is also not accurate for this layer. sdk-meta defines it as "use context attribute values for targeting, but do not send them to LaunchDarkly," but `LDAIClientImpl._applyInterpolation` does:

```ts
const allVariables = { ...variables, ldctx: context };
```

The whole context goes into template interpolation with no private-attribute filtering, so a template referencing `{{ldctx.email}}` interpolates a private attribute into prompt text. The entry claims a guarantee the code does not make.

## Result

```json
"server-ai": {
  "name": "Node.js Server AI SDK",
  "type": "ai",
  "path": "packages/sdk/server-ai",
  "languages": ["JavaScript", "TypeScript"],
  "aiSdkNames": ["@launchdarkly/server-sdk-ai"],
  "releases": { "tag-prefix": "server-sdk-ai-" },
  "userAgents": ["NodeJSAIClient"],
  "features": {
    "aiAgentConfig":      { "introduced": "0.11" },
    "aiAgentGraph":       { "introduced": "0.17" },
    "aiCompletionConfig": { "introduced": "0.1" },
    "aiJudgeConfig":      { "introduced": "0.14" },
    "aiTrackMetrics":     { "introduced": "0.1" }
  }
}
```

`userAgents` is left as-is. Unlike the other AI SDKs this one has a registered user agent, and removing it is out of scope here.

No source, build, or release changes — one metadata file.

## Related

Sibling PRs adding the same field to the other AI SDKs: launchdarkly/ruby-server-sdk-ai#38, launchdarkly/go-server-sdk-ai#19, launchdarkly/python-server-sdk-ai#215.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **`server-ai`** block in **`.sdk_metadata.json`** so sdk-meta’s catalog and feature matrix match how the Node.js Server AI SDK actually reports itself and what it ships.
> 
> Adds **`aiSdkNames`: `["@launchdarkly/server-sdk-ai"]`** (aligned with `packages/sdk/server-ai/src/sdkInfo.ts`) so ingest can resolve AI SDK identity from `$ld:ai:sdk:info` events once sdk-meta’s registry lands. Declares **`aiAgentGraph`** at **0.17**, which was missing despite the capability existing in the package.
> 
> Removes **`contexts`**, **`experimentation`**, and **`privateAttrs`** from this entry so only **`ai*`** features are listed—avoiding double-counting base Node server capabilities and dropping an inaccurate **`privateAttrs`** claim for the AI layer. No runtime or package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40171aa53bf1ef5f5a76f6ef1b226cbfa47b0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->