### PR TITLE
feat: Move FDv1 fallback directive parsing to the shared package

### DIFF
--- a/packages/shared/common/__tests__/internal/fdv2/fallbackDirective.test.ts
+++ b/packages/shared/common/__tests__/internal/fdv2/fallbackDirective.test.ts
@@ -1,7 +1,7 @@
 import {
   readFallbackDirective,
   readGoodbyeFallbackDirective,
-} from '../../../src/datasource/fdv2/fallbackDirective';
+} from '../../../src/internal/fdv2/fallbackDirective';
 
 function makeHeaders(map: Record<string, string>): { get(name: string): string | null } {
   const lower: Record<string, string> = {};

--- a/packages/shared/common/src/internal/fdv2/fallbackDirective.ts
+++ b/packages/shared/common/src/internal/fdv2/fallbackDirective.ts
@@ -9,7 +9,7 @@
  * - `> 0`: milliseconds to wait before attempting FDv2 recovery.
  *
  * This is the single place that interprets `x-ld-fd-fallback` and
- * `x-ld-fd-fallback-ttl`, shared by the streaming and polling sources.
+ * `x-ld-fd-fallback-ttl`.
  */
 export interface FallbackDirective {
   fdv1Fallback: boolean;
@@ -21,8 +21,8 @@ export interface FallbackDirective {
  * `{ fdv1Fallback: false }` when `x-ld-fd-fallback` is absent or not `"true"`.
  *
  * @param headers Header accessor. The `get` method must accept header names
- *   in any casing; both streaming and polling callers normalize to lowercase
- *   before calling this function.
+ *   in any casing; callers normalize to lowercase before calling this
+ *   function.
  */
 export function readFallbackDirective(headers: {
   get(name: string): string | null;

--- a/packages/shared/common/src/internal/fdv2/index.ts
+++ b/packages/shared/common/src/internal/fdv2/index.ts
@@ -1,4 +1,6 @@
 import { fdv1PayloadAdaptor as FDv1PayloadAdaptor } from './FDv1PayloadAdaptor';
+import { readFallbackDirective, readGoodbyeFallbackDirective } from './fallbackDirective';
+import type { FallbackDirective } from './fallbackDirective';
 import { PayloadProcessor } from './payloadProcessor';
 import { PayloadStreamReader } from './payloadStreamReader';
 import type { FDv2Event, FDv2EventsCollection } from './proto';
@@ -15,9 +17,17 @@ import type {
   Update,
 } from './protocolHandler';
 
-export { createProtocolHandler, FDv1PayloadAdaptor, PayloadProcessor, PayloadStreamReader };
+export {
+  createProtocolHandler,
+  FDv1PayloadAdaptor,
+  PayloadProcessor,
+  PayloadStreamReader,
+  readFallbackDirective,
+  readGoodbyeFallbackDirective,
+};
 
 export type {
+  FallbackDirective,
   FDv2Event,
   FDv2EventsCollection,
   ObjProcessors,

--- a/packages/shared/sdk-client/src/datasource/fdv2/FDv2SourceResult.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/FDv2SourceResult.ts
@@ -1,7 +1,6 @@
 import { DataSourceErrorKind, internal } from '@launchdarkly/js-sdk-common';
 
 import DataSourceStatusErrorInfo from '../DataSourceStatusErrorInfo';
-import { FallbackDirective } from './fallbackDirective';
 
 /**
  * Possible states for a status result from an FDv2 data source.
@@ -64,7 +63,7 @@ export type FDv2SourceResult = ChangeSetResult | StatusResult;
  */
 export function changeSet(
   payload: internal.Payload,
-  fallback: FallbackDirective,
+  fallback: internal.FallbackDirective,
   environmentId?: string,
   freshness?: number,
 ): FDv2SourceResult {
@@ -84,7 +83,7 @@ export function changeSet(
  */
 export function interrupted(
   errorInfo: DataSourceStatusErrorInfo,
-  fallback: FallbackDirective,
+  fallback: internal.FallbackDirective,
 ): FDv2SourceResult {
   return {
     type: 'status',
@@ -108,7 +107,7 @@ export function shutdown(): FDv2SourceResult {
  */
 export function terminalError(
   errorInfo: DataSourceStatusErrorInfo,
-  fallback: FallbackDirective,
+  fallback: internal.FallbackDirective,
 ): FDv2SourceResult {
   return {
     type: 'status',
@@ -130,7 +129,7 @@ export function terminalError(
  *   caller's default; `0` for indefinite). Same semantics as
  *   {@link StatusResult.fdv1FallbackTtlMs}.
  */
-export function goodbye(reason: string, fallback: FallbackDirective): FDv2SourceResult {
+export function goodbye(reason: string, fallback: internal.FallbackDirective): FDv2SourceResult {
   return {
     type: 'status',
     state: 'goodbye',

--- a/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
@@ -13,7 +13,6 @@ import {
   interrupted,
   terminalError,
 } from './FDv2SourceResult';
-import { FallbackDirective, readFallbackDirective } from './fallbackDirective';
 
 function getEnvironmentId(headers: { get(name: string): string | null }): string | undefined {
   return headers.get('x-ld-envid') ?? undefined;
@@ -29,7 +28,7 @@ function getEnvironmentId(headers: { get(name: string): string | null }): string
  */
 function processEvents(
   events: internal.FDv2Event[],
-  fallback: FallbackDirective,
+  fallback: internal.FallbackDirective,
   environmentId: string | undefined,
   logger?: LDLogger,
 ): FDv2SourceResult {
@@ -108,12 +107,12 @@ export async function poll(
   basis: string | undefined,
   logger?: LDLogger,
 ): Promise<FDv2SourceResult> {
-  let directive: FallbackDirective = { fdv1Fallback: false };
+  let directive: internal.FallbackDirective = { fdv1Fallback: false };
   let environmentId: string | undefined;
 
   try {
     const response = await requestor.poll(basis);
-    directive = readFallbackDirective(response.headers);
+    directive = internal.readFallbackDirective(response.headers);
     environmentId = getEnvironmentId(response.headers);
 
     // 304 Not Modified: no payload has changed since the last poll.

--- a/packages/shared/sdk-client/src/datasource/fdv2/StreamingFDv2Base.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/StreamingFDv2Base.ts
@@ -25,11 +25,6 @@ import {
   shutdown,
   terminalError,
 } from './FDv2SourceResult';
-import {
-  FallbackDirective,
-  readFallbackDirective,
-  readGoodbyeFallbackDirective,
-} from './fallbackDirective';
 
 /**
  * Handler invoked when a legacy `"ping"` event is received on the stream.
@@ -150,7 +145,7 @@ export function createStreamingBase(config: {
    * the pending pair is cleared. Safe to call with neither; it just returns the
    * current committed state unchanged.
    */
-  function resolveFallback(incoming?: FallbackDirective): FallbackDirective {
+  function resolveFallback(incoming?: internal.FallbackDirective): internal.FallbackDirective {
     if (incoming?.fdv1Fallback) {
       fdv1Fallback = true;
       fdv1FallbackTtlMs = incoming.fdv1FallbackTtlMs;
@@ -176,8 +171,8 @@ export function createStreamingBase(config: {
    * so it still enqueues directly.
    */
   function putWithFallback(
-    build: (fallback: FallbackDirective) => FDv2SourceResult,
-    incoming?: FallbackDirective,
+    build: (fallback: internal.FallbackDirective) => FDv2SourceResult,
+    incoming?: internal.FallbackDirective,
   ): void {
     resultQueue.put(build(resolveFallback(incoming)));
   }
@@ -193,7 +188,7 @@ export function createStreamingBase(config: {
         // An in-band fallback signal in the goodbye data (its own TTL) takes
         // precedence over a directive deferred at onopen; putWithFallback()
         // passes it through to resolveFallback() as the incoming override.
-        const goodbyeDirective = readGoodbyeFallbackDirective(rawData);
+        const goodbyeDirective = internal.readGoodbyeFallbackDirective(rawData);
         putWithFallback(
           (fallback) => (fallback.fdv1Fallback
             ? terminalError(errorInfoFromUnknown(action.reason), fallback)
@@ -224,7 +219,7 @@ export function createStreamingBase(config: {
   function handleError(err: HttpErrorResponse): boolean {
     // Check for FDv1 fallback header (with optional TTL).
     const errHeaders = err.headers ?? {};
-    const directive = readFallbackDirective({
+    const directive = internal.readFallbackDirective({
       get: (name: string) => errHeaders[name.toLowerCase()] ?? null,
     });
     if (directive.fdv1Fallback) {
@@ -406,7 +401,7 @@ export function createStreamingBase(config: {
         // in flight is delivered first.
         const openHeaders = e?.headers;
         if (openHeaders) {
-          const directive = readFallbackDirective({
+          const directive = internal.readFallbackDirective({
             get: (name: string) => openHeaders[name.toLowerCase()] ?? null,
           });
           pendingFallback = directive.fdv1Fallback;


### PR DESCRIPTION
## Summary

Moves the FDv1 fallback directive parsing (`FallbackDirective`, `readFallbackDirective`, `readGoodbyeFallbackDirective`) out of `packages/shared/sdk-client` and into `packages/shared/common`'s `internal/fdv2` namespace, since `packages/shared/sdk-server`'s `CompositeDataSource` will eventually need the same TTL-directive parsing and both packages already depend on `@launchdarkly/js-sdk-common` at the same version. Behavior-preserving move; the three sdk-client call sites (`PollingBase.ts`, `StreamingFDv2Base.ts`, `FDv2SourceResult.ts`) now reference the shared package's `internal` namespace instead of a local file. Sets up the shared location the next PR in this stack builds on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Moves** FDv1 fallback directive types and parsers (`FallbackDirective`, `readFallbackDirective`, `readGoodbyeFallbackDirective`) into `@launchdarkly/js-sdk-common` under `internal/fdv2`, and **re-exports** them from that module’s public `internal` barrel.
> 
> **sdk-client** FDv2 polling/streaming and `FDv2SourceResult` helpers **stop importing** a local `fallbackDirective` module and instead use `internal.FallbackDirective` and the shared readers. Unit tests **import** the implementation from the new `internal/fdv2` path. Comments in `fallbackDirective.ts` are **tweaked** to describe generic callers rather than streaming/polling only.
> 
> No intended behavior change—this **deduplicates** parsing so **sdk-server** (e.g. `CompositeDataSource`) can share the same logic in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222b04eef2ce97d8c143ddf8a9c91bbd889e5e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->