### PR TITLE
test(openfeature-cloudflare-sdk): fix breaking unit test

### DIFF
--- a/packages/sdk/openfeature-cloudflare-server/__tests__/LaunchDarklyProvider.test.ts
+++ b/packages/sdk/openfeature-cloudflare-server/__tests__/LaunchDarklyProvider.test.ts
@@ -91,7 +91,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: true,
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -144,7 +144,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 'good',
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -197,7 +197,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: 17,
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -250,7 +250,7 @@ describe('given a mock LaunchDarkly client', () => {
     expect(res).toMatchObject({
       flagKey: testFlagKey,
       value: { some: 'value' },
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 
@@ -307,7 +307,7 @@ describe('given a mock LaunchDarkly client', () => {
       flagKey: testFlagKey,
       value: { yes: 'no' },
       variant: '22',
-      reason: 'OFF',
+      reason: 'DISABLED',
     });
   });
 

--- a/packages/sdk/openfeature-cloudflare-server/package.json
+++ b/packages/sdk/openfeature-cloudflare-server/package.json
@@ -48,7 +48,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cloudflare/workers-types": "^4.20230321.0",
-    "@launchdarkly/openfeature-js-server-common": "1.0.1"
+    "@launchdarkly/openfeature-js-server-common": "1.1.0"
   },
   "peerDependencies": {
     "@launchdarkly/cloudflare-server-sdk": "^2.7.0",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/1983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Bumps `@launchdarkly/openfeature-js-server-common` from **1.0.1** to **1.1.0** in `openfeature-cloudflare-server`, pulling in updated OpenFeature evaluation-reason mapping (LaunchDarkly `OFF` is now surfaced as **`DISABLED`** instead of **`OFF`**).
> 
> Unit tests in `LaunchDarklyProvider.test.ts` are updated so boolean, string, number, and object detail expectations use `reason: 'DISABLED'` when mocks return `reason.kind: 'OFF'`, including the variant case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f7e7d9592f948aa6e536ee6d4d0452ac909a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->