### PR TITLE
fix(persistent-store): add error logs for upsert

### DIFF
--- a/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
+++ b/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
@@ -9,6 +9,7 @@ import AsyncStoreFacade from '../../src/store/AsyncStoreFacade';
 import PersistentDataStoreWrapper from '../../src/store/PersistentDataStoreWrapper';
 import { persistentStoreKinds } from '../../src/store/persistentStoreKinds';
 import VersionedDataKinds from '../../src/store/VersionedDataKinds';
+import TestLogger, { LogLevel } from '../Logger';
 
 /**
  * Conditionally skip tests. Allows conditional tests within an describe.each.
@@ -446,6 +447,73 @@ describe.each(['caching', 'non-caching'])(
       // There are no exceptions or anything.
       const value = await asyncWrapper.get(VersionedDataKinds.Features, 'key1');
       expect(value).toBeNull();
+    });
+
+    it('logs at error level when an upsert reports an error', async () => {
+      const logger = new TestLogger();
+      const loggingWrapper = new PersistentDataStoreWrapper(
+        mockPersistentStore,
+        isCaching ? 60 : 0,
+        logger,
+      );
+
+      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
+        cb(new Error('bad news'), undefined);
+      });
+
+      await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
+        key: 'key1',
+        version: 1,
+      });
+
+      logger.expectMessages([
+        {
+          level: LogLevel.Error,
+          matches: /Persistent store returned error: bad news/,
+        },
+      ]);
+      loggingWrapper.close();
+    });
+
+    it('logs at error level when a delete reports an error', async () => {
+      const logger = new TestLogger();
+      const loggingWrapper = new PersistentDataStoreWrapper(
+        mockPersistentStore,
+        isCaching ? 60 : 0,
+        logger,
+      );
+
+      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
+        cb(new Error('bad news'), undefined);
+      });
+
+      await new AsyncStoreFacade(loggingWrapper).delete(VersionedDataKinds.Features, 'key1', 2);
+
+      logger.expectMessages([
+        {
+          level: LogLevel.Error,
+          matches: /Persistent store returned error: bad news/,
+        },
+      ]);
+      loggingWrapper.close();
+    });
+
+    it('does not log an error when an upsert succeeds', async () => {
+      const logger = new TestLogger();
+      const loggingWrapper = new PersistentDataStoreWrapper(
+        mockPersistentStore,
+        isCaching ? 60 : 0,
+        logger,
+      );
+
+      await new AsyncStoreFacade(loggingWrapper).init({});
+      await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
+        key: 'key1',
+        version: 1,
+      });
+
+      expect(logger.getCount(LogLevel.Error)).toEqual(0);
+      loggingWrapper.close();
     });
 
     it('if there is an error during an upsert, then that item remains in the cache as it was', async () => {

--- a/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
+++ b/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
@@ -457,45 +457,25 @@ describe.each(['caching', 'non-caching'])(
         logger,
       );
 
-      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
-        cb(new Error('bad news'), undefined);
-      });
+      try {
+        jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
+          cb(new Error('bad news'), undefined);
+        });
 
-      await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
-        key: 'key1',
-        version: 1,
-      });
+        await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
+          key: 'key1',
+          version: 1,
+        });
 
-      logger.expectMessages([
-        {
-          level: LogLevel.Error,
-          matches: /Persistent store returned error: bad news/,
-        },
-      ]);
-      loggingWrapper.close();
-    });
-
-    it('logs at error level when a delete reports an error', async () => {
-      const logger = new TestLogger();
-      const loggingWrapper = new PersistentDataStoreWrapper(
-        mockPersistentStore,
-        isCaching ? 60 : 0,
-        logger,
-      );
-
-      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
-        cb(new Error('bad news'), undefined);
-      });
-
-      await new AsyncStoreFacade(loggingWrapper).delete(VersionedDataKinds.Features, 'key1', 2);
-
-      logger.expectMessages([
-        {
-          level: LogLevel.Error,
-          matches: /Persistent store returned error: bad news/,
-        },
-      ]);
-      loggingWrapper.close();
+        logger.expectMessages([
+          {
+            level: LogLevel.Error,
+            matches: /Persistent store returned error: bad news/,
+          },
+        ]);
+      } finally {
+        loggingWrapper.close();
+      }
     });
 
     it('does not log an error when an upsert succeeds', async () => {
@@ -506,14 +486,17 @@ describe.each(['caching', 'non-caching'])(
         logger,
       );
 
-      await new AsyncStoreFacade(loggingWrapper).init({});
-      await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
-        key: 'key1',
-        version: 1,
-      });
+      try {
+        await new AsyncStoreFacade(loggingWrapper).init({});
+        await new AsyncStoreFacade(loggingWrapper).upsert(VersionedDataKinds.Features, {
+          key: 'key1',
+          version: 1,
+        });
 
-      expect(logger.getCount(LogLevel.Error)).toEqual(0);
-      loggingWrapper.close();
+        expect(logger.getCount(LogLevel.Error)).toEqual(0);
+      } finally {
+        loggingWrapper.close();
+      }
     });
 
     it('if there is an error during an upsert, then that item remains in the cache as it was', async () => {

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -1,3 +1,5 @@
+import { LDLogger } from '@launchdarkly/js-sdk-common';
+
 import {
   DataKind,
   PersistentDataStore,
@@ -108,6 +110,7 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
   constructor(
     private readonly _core: PersistentDataStore,
     ttl: number,
+    private readonly _logger?: LDLogger,
   ) {
     if (ttl) {
       this._itemCache = new TtlCache({
@@ -229,6 +232,9 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
         data.key,
         persistKind.serialize(data),
         (err, updatedDescriptor) => {
+          if (err) {
+            this._logger?.error(`Persistent store returned error: ${err.message}`);
+          }
           if (!err && updatedDescriptor) {
             if (updatedDescriptor.serializedItem) {
               const value = deserialize(persistKind, updatedDescriptor);

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -233,13 +233,9 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
         persistKind.serialize(data),
         (err, updatedDescriptor) => {
           if (err) {
-            try {
-              this._logger?.error(
-                `Persistent store returned error: ${err instanceof Error ? err.message : err}`,
-              );
-            } catch {
-              // A logger failure must not stop the update queue.
-            }
+            this._logger?.error(
+              `Persistent store returned error: ${err instanceof Error ? err.message : err}`,
+            );
           }
           if (!err && updatedDescriptor) {
             if (updatedDescriptor.serializedItem) {

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -233,7 +233,13 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
         persistKind.serialize(data),
         (err, updatedDescriptor) => {
           if (err) {
-            this._logger?.error(`Persistent store returned error: ${err.message}`);
+            try {
+              this._logger?.error(
+                `Persistent store returned error: ${err instanceof Error ? err.message : err}`,
+              );
+            } catch {
+              // A logger failure must not stop the update queue.
+            }
           }
           if (!err && updatedDescriptor) {
             if (updatedDescriptor.serializedItem) {

--- a/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
@@ -1,3 +1,5 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+
 import { interfaces, LDLogger, PersistentDataStoreWrapper } from '@launchdarkly/node-server-sdk';
 
 import DynamoDBCore from '../src/DynamoDBCore';
@@ -29,7 +31,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-it('logs at error level when getAll fails', (done) => {
+it('logs at error level when getAll fails', async () => {
   const logger = makeLogger();
   const state = {
     prefixedKey: (key: string) => key,
@@ -38,30 +40,73 @@ it('logs at error level when getAll fails', (done) => {
   // @ts-ignore Partial state mock for testing.
   const core = new DynamoDBCore('test-table', state, logger);
 
-  core.getAll(featuresKind, (descriptors) => {
-    expect(descriptors).toBeUndefined();
-    expect(logger.error).toHaveBeenCalledWith('Error reading features: Error: query failed');
+  const descriptors = await new Promise((resolve) => {
+    core.getAll(featuresKind, resolve);
+  });
+
+  expect(descriptors).toBeUndefined();
+  expect(logger.error).toHaveBeenCalledWith('Error reading features: Error: query failed');
+});
+
+it('logs through the wrapper when a real upsert fails', (done) => {
+  const { PersistentDataStoreWrapper: RealWrapper } = jest.requireActual(
+    '@launchdarkly/node-server-sdk',
+  );
+  const logger = makeLogger();
+  const state = {
+    prefixedKey: (key: string) => key,
+    put: jest.fn().mockRejectedValue(new Error('write throttled')),
+    close: jest.fn(),
+  };
+  // @ts-ignore Partial state mock for testing.
+  const core = new DynamoDBCore('test-table', state, logger);
+  const wrapper = new RealWrapper(core, 0, logger);
+
+  wrapper.upsert(featuresKind, { key: 'flagA', version: 1 }, () => {
+    expect(logger.error).toHaveBeenCalledWith('Persistent store returned error: write throttled');
+    wrapper.close();
     done();
   });
 });
 
+// A stub client keeps the plumbing tests hermetic. No real AWS client is
+// constructed, so no region or credential lookup happens.
+function makeFakeDynamoDBClient() {
+  // @ts-ignore Partial client mock for testing.
+  return { send: jest.fn(), destroy: jest.fn() } as DynamoDBClient;
+}
+
 it('passes the SDK logger to the persistent store wrapper', () => {
   const logger = makeLogger();
-  const store = new DynamoDBFeatureStore('test-table', undefined, logger);
+  const store = new DynamoDBFeatureStore(
+    'test-table',
+    { dynamoDBClient: makeFakeDynamoDBClient() },
+    logger,
+  );
 
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
-  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
+  // The store wraps the logger, so verify the wrapper logger forwards to it.
+  const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
+  wrapperLogger.error('probe');
+  expect(logger.error).toHaveBeenCalledWith('probe');
 });
 
 it('prefers the logger from the store options over the SDK logger', () => {
   const optionsLogger = makeLogger();
   const sdkLogger = makeLogger();
-  const store = new DynamoDBFeatureStore('test-table', { logger: optionsLogger }, sdkLogger);
+  const store = new DynamoDBFeatureStore(
+    'test-table',
+    { dynamoDBClient: makeFakeDynamoDBClient(), logger: optionsLogger },
+    sdkLogger,
+  );
 
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
-  expect(wrapperMock.mock.calls[0][2]).toBe(optionsLogger);
+  const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
+  wrapperLogger.error('probe');
+  expect(optionsLogger.error).toHaveBeenCalledWith('probe');
+  expect(sdkLogger.error).not.toHaveBeenCalled();
 });

--- a/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
@@ -1,0 +1,67 @@
+import { interfaces, LDLogger, PersistentDataStoreWrapper } from '@launchdarkly/node-server-sdk';
+
+import DynamoDBCore from '../src/DynamoDBCore';
+import DynamoDBFeatureStore from '../src/DynamoDBFeatureStore';
+
+jest.mock('@launchdarkly/node-server-sdk', () => {
+  const actual = jest.requireActual('@launchdarkly/node-server-sdk');
+  return {
+    ...actual,
+    PersistentDataStoreWrapper: jest.fn(),
+  };
+});
+
+const featuresKind: interfaces.PersistentStoreDataKind = {
+  namespace: 'features',
+  deserialize: (data: string) => JSON.parse(data),
+};
+
+function makeLogger(): LDLogger {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('logs at error level when getAll fails', (done) => {
+  const logger = makeLogger();
+  const state = {
+    prefixedKey: (key: string) => key,
+    query: jest.fn().mockRejectedValue(new Error('query failed')),
+  };
+  // @ts-ignore Partial state mock for testing.
+  const core = new DynamoDBCore('test-table', state, logger);
+
+  core.getAll(featuresKind, (descriptors) => {
+    expect(descriptors).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith('Error reading features: Error: query failed');
+    done();
+  });
+});
+
+it('passes the SDK logger to the persistent store wrapper', () => {
+  const logger = makeLogger();
+  const store = new DynamoDBFeatureStore('test-table', undefined, logger);
+
+  expect(store).toBeDefined();
+  const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
+  expect(wrapperMock).toHaveBeenCalledTimes(1);
+  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
+});
+
+it('prefers the logger from the store options over the SDK logger', () => {
+  const optionsLogger = makeLogger();
+  const sdkLogger = makeLogger();
+  const store = new DynamoDBFeatureStore('test-table', { logger: optionsLogger }, sdkLogger);
+
+  expect(store).toBeDefined();
+  const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
+  expect(wrapperMock).toHaveBeenCalledTimes(1);
+  expect(wrapperMock.mock.calls[0][2]).toBe(optionsLogger);
+});

--- a/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-dynamodb/__tests__/DynamoDBErrorLogging.test.ts
@@ -87,10 +87,8 @@ it('passes the SDK logger to the persistent store wrapper', () => {
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
-  // The store wraps the logger, so verify the wrapper logger forwards to it.
-  const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
-  wrapperLogger.error('probe');
-  expect(logger.error).toHaveBeenCalledWith('probe');
+  // The SDK logger is already safe and passes through unwrapped.
+  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
 });
 
 it('prefers the logger from the store options over the SDK logger', () => {
@@ -105,6 +103,7 @@ it('prefers the logger from the store options over the SDK logger', () => {
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
+  // The raw options logger is wrapped at entry, so verify it forwards.
   const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
   wrapperLogger.error('probe');
   expect(optionsLogger.error).toHaveBeenCalledWith('probe');

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBCore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBCore.ts
@@ -126,7 +126,14 @@ export default class DynamoDBCore implements interfaces.PersistentDataStore {
     allData: interfaces.KindKeyedStore<interfaces.PersistentStoreDataKind>,
     callback: () => void,
   ) {
-    const items = await this._readExistingItems(allData);
+    let items: Record<string, AttributeValue>[];
+    try {
+      items = await this._readExistingItems(allData);
+    } catch (error) {
+      this._logger?.error(`Error reading existing items from DynamoDB: ${error}`);
+      callback();
+      return;
+    }
 
     // Make a key from an existing DB item.
     function makeNamespaceKey(item: Record<string, AttributeValue>) {
@@ -180,20 +187,20 @@ export default class DynamoDBCore implements interfaces.PersistentDataStore {
     key: string,
     callback: (descriptor: interfaces.SerializedItemDescriptor | undefined) => void,
   ) {
+    let descriptor: interfaces.SerializedItemDescriptor | undefined;
     try {
       const read = await this._state.get(this._tableName, {
         namespace: stringValue(this._state.prefixedKey(kind.namespace)),
         key: stringValue(key),
       });
       if (read) {
-        callback(this._unmarshalItem(read));
-      } else {
-        callback(undefined);
+        descriptor = this._unmarshalItem(read);
       }
     } catch (error) {
       this._logger?.error(`Error reading ${kind.namespace}:${key}: ${error}`);
-      callback(undefined);
     }
+    // Callback outside the try. In case it raised an exception.
+    callback(descriptor);
   }
 
   async getAll(
@@ -203,15 +210,20 @@ export default class DynamoDBCore implements interfaces.PersistentDataStore {
     ) => void,
   ) {
     const params = this._queryParamsForNamespace(kind.namespace);
+    let descriptors:
+      | interfaces.KeyedItem<string, interfaces.SerializedItemDescriptor>[]
+      | undefined;
     try {
       const results = await this._state.query(params);
-      callback(
-        results.map((record) => ({ key: record!.key!.S!, item: this._unmarshalItem(record) })),
-      );
+      descriptors = results.map((record) => ({
+        key: record!.key!.S!,
+        item: this._unmarshalItem(record),
+      }));
     } catch (error) {
       this._logger?.error(`Error reading ${kind.namespace}: ${error}`);
-      callback(undefined);
     }
+    // Callback outside the try. In case it raised an exception.
+    callback(descriptors);
   }
 
   async upsert(

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBCore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBCore.ts
@@ -203,10 +203,15 @@ export default class DynamoDBCore implements interfaces.PersistentDataStore {
     ) => void,
   ) {
     const params = this._queryParamsForNamespace(kind.namespace);
-    const results = await this._state.query(params);
-    callback(
-      results.map((record) => ({ key: record!.key!.S!, item: this._unmarshalItem(record) })),
-    );
+    try {
+      const results = await this._state.query(params);
+      callback(
+        results.map((record) => ({ key: record!.key!.S!, item: this._unmarshalItem(record) })),
+      );
+    } catch (error) {
+      this._logger?.error(`Error reading ${kind.namespace}: ${error}`);
+      callback(undefined);
+    }
   }
 
   async upsert(

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
@@ -1,4 +1,5 @@
 import {
+  createSafeLogger,
   interfaces,
   LDFeatureStore,
   LDFeatureStoreDataStorage,
@@ -22,7 +23,9 @@ export default class DynamoDBFeatureStore implements LDFeatureStore {
 
   constructor(tableName: string, options?: LDDynamoDBOptions, logger?: LDLogger) {
     // Prefer the logger configured on the store options, then the SDK logger.
-    const actualLogger = options?.logger ?? logger;
+    // Wrap it so a failing logger cannot break store operations.
+    const configuredLogger = options?.logger ?? logger;
+    const actualLogger = configuredLogger ? createSafeLogger(configuredLogger) : undefined;
     this._wrapper = new PersistentDataStoreWrapper(
       new DynamoDBCore(tableName, new DynamoDBClientState(options), actualLogger),
       TtlFromOptions(options),

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
@@ -23,9 +23,8 @@ export default class DynamoDBFeatureStore implements LDFeatureStore {
 
   constructor(tableName: string, options?: LDDynamoDBOptions, logger?: LDLogger) {
     // Prefer the logger configured on the store options, then the SDK logger.
-    // Wrap it so a failing logger cannot break store operations.
-    const configuredLogger = options?.logger ?? logger;
-    const actualLogger = configuredLogger ? createSafeLogger(configuredLogger) : undefined;
+    // The SDK logger is already safe. Wrap the raw options logger at its entry.
+    const actualLogger = options?.logger ? createSafeLogger(options.logger) : logger;
     this._wrapper = new PersistentDataStoreWrapper(
       new DynamoDBCore(tableName, new DynamoDBClientState(options), actualLogger),
       TtlFromOptions(options),

--- a/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/DynamoDBFeatureStore.ts
@@ -21,9 +21,12 @@ export default class DynamoDBFeatureStore implements LDFeatureStore {
   private _wrapper: PersistentDataStoreWrapper;
 
   constructor(tableName: string, options?: LDDynamoDBOptions, logger?: LDLogger) {
+    // Prefer the logger configured on the store options, then the SDK logger.
+    const actualLogger = options?.logger ?? logger;
     this._wrapper = new PersistentDataStoreWrapper(
-      new DynamoDBCore(tableName, new DynamoDBClientState(options), logger),
+      new DynamoDBCore(tableName, new DynamoDBClientState(options), actualLogger),
       TtlFromOptions(options),
+      actualLogger,
     );
   }
 

--- a/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
@@ -97,8 +97,5 @@ it('passes the SDK logger to the persistent store wrapper', () => {
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
-  // The store wraps the logger, so verify the wrapper logger forwards to it.
-  const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
-  wrapperLogger.error('probe');
-  expect(logger.error).toHaveBeenCalledWith('probe');
+  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
 });

--- a/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
@@ -1,0 +1,63 @@
+import { LDLogger, PersistentDataStoreWrapper } from '@launchdarkly/node-server-sdk';
+
+import RedisCore from '../src/RedisCore';
+import RedisFeatureStore from '../src/RedisFeatureStore';
+
+jest.mock('@launchdarkly/node-server-sdk', () => {
+  const actual = jest.requireActual('@launchdarkly/node-server-sdk');
+  return {
+    ...actual,
+    PersistentDataStoreWrapper: jest.fn(),
+  };
+});
+
+function makeLogger(): LDLogger {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('logs at error level when the initialized check fails', (done) => {
+  const logger = makeLogger();
+  const state = {
+    prefixedKey: (key: string) => key,
+    getClient: () => ({
+      exists: (_key: string, cb: (err: Error | null, count: number) => void) => {
+        cb(new Error('connection refused'), 0);
+      },
+    }),
+  };
+  // @ts-ignore Partial state mock for testing.
+  const core = new RedisCore(state, logger);
+
+  core.initialized((isInitialized) => {
+    expect(isInitialized).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error reading initialized state from Redis Error: connection refused',
+    );
+    done();
+  });
+});
+
+it('passes the SDK logger to the persistent store wrapper', () => {
+  const logger = makeLogger();
+  // Provide a fake client so no real Redis connection is made.
+  const fakeClient = { on: jest.fn() };
+  const store = new RedisFeatureStore(
+    // @ts-ignore Partial client mock for testing.
+    { client: fakeClient },
+    logger,
+  );
+
+  expect(store).toBeDefined();
+  const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
+  expect(wrapperMock).toHaveBeenCalledTimes(1);
+  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
+});

--- a/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
+++ b/packages/store/node-server-sdk-redis/__tests__/RedisErrorLogging.test.ts
@@ -40,8 +40,46 @@ it('logs at error level when the initialized check fails', (done) => {
   core.initialized((isInitialized) => {
     expect(isInitialized).toBe(false);
     expect(logger.error).toHaveBeenCalledWith(
-      'Error reading initialized state from Redis Error: connection refused',
+      'Error reading initialized state from Redis: Error: connection refused',
     );
+    done();
+  });
+});
+
+it('logs through the wrapper when a write fails', (done) => {
+  const { PersistentDataStoreWrapper: RealWrapper } = jest.requireActual(
+    '@launchdarkly/node-server-sdk',
+  );
+  const logger = makeLogger();
+  const fakeClient = {
+    watch: jest.fn(),
+    hget: (_ns: string, _key: string, cb: (err: Error | null, val: string | null) => void) => {
+      cb(null, null);
+    },
+    multi: () => ({
+      hset: jest.fn(),
+      discard: jest.fn(),
+      exec: (cb: (err: Error | null, replies: unknown) => void) => {
+        cb(new Error('Connection is closed.'), undefined);
+      },
+    }),
+  };
+  const state = {
+    prefixedKey: (key: string) => key,
+    isConnected: () => true,
+    isInitialConnection: () => false,
+    getClient: () => fakeClient,
+    close: jest.fn(),
+  };
+  // @ts-ignore Partial state mock for testing.
+  const core = new RedisCore(state, logger);
+  const wrapper = new RealWrapper(core, 0, logger);
+
+  wrapper.upsert({ namespace: 'features' }, { key: 'flagA', version: 5 }, () => {
+    expect(logger.error).toHaveBeenCalledWith(
+      'Persistent store returned error: Connection is closed.',
+    );
+    wrapper.close();
     done();
   });
 });
@@ -59,5 +97,8 @@ it('passes the SDK logger to the persistent store wrapper', () => {
   expect(store).toBeDefined();
   const wrapperMock = PersistentDataStoreWrapper as unknown as jest.Mock;
   expect(wrapperMock).toHaveBeenCalledTimes(1);
-  expect(wrapperMock.mock.calls[0][2]).toBe(logger);
+  // The store wraps the logger, so verify the wrapper logger forwards to it.
+  const wrapperLogger: LDLogger = wrapperMock.mock.calls[0][2];
+  wrapperLogger.error('probe');
+  expect(logger.error).toHaveBeenCalledWith('probe');
 });

--- a/packages/store/node-server-sdk-redis/src/RedisCore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisCore.ts
@@ -191,7 +191,7 @@ export default class RedisCore implements interfaces.PersistentDataStore {
   initialized(callback: (isInitialized: boolean) => void): void {
     this._state.getClient().exists(this._initedKey, (err, count) => {
       if (err) {
-        this._logger?.error(`Error reading initialized state from Redis ${err}`);
+        this._logger?.error(`Error reading initialized state from Redis: ${err}`);
       }
       // Initialized if there is not an error and the key does exists.
       // (A count >= 1)

--- a/packages/store/node-server-sdk-redis/src/RedisCore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisCore.ts
@@ -190,6 +190,9 @@ export default class RedisCore implements interfaces.PersistentDataStore {
 
   initialized(callback: (isInitialized: boolean) => void): void {
     this._state.getClient().exists(this._initedKey, (err, count) => {
+      if (err) {
+        this._logger?.error(`Error reading initialized state from Redis ${err}`);
+      }
       // Initialized if there is not an error and the key does exists.
       // (A count >= 1)
       callback(!!(!err && count));

--- a/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
@@ -24,6 +24,7 @@ export default class RedisFeatureStore implements LDFeatureStore {
     this._wrapper = new PersistentDataStoreWrapper(
       new RedisCore(new RedisClientState(options, logger), logger),
       TtlFromOptions(options),
+      logger,
     );
   }
 

--- a/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
@@ -1,4 +1,5 @@
 import {
+  createSafeLogger,
   interfaces,
   LDFeatureStore,
   LDFeatureStoreDataStorage,
@@ -21,10 +22,12 @@ export default class RedisFeatureStore implements LDFeatureStore {
   private _wrapper: PersistentDataStoreWrapper;
 
   constructor(options?: LDRedisOptions, logger?: LDLogger) {
+    // Wrap the logger so a failing logger cannot break store operations.
+    const actualLogger = logger ? createSafeLogger(logger) : undefined;
     this._wrapper = new PersistentDataStoreWrapper(
-      new RedisCore(new RedisClientState(options, logger), logger),
+      new RedisCore(new RedisClientState(options, actualLogger), actualLogger),
       TtlFromOptions(options),
-      logger,
+      actualLogger,
     );
   }
 

--- a/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
+++ b/packages/store/node-server-sdk-redis/src/RedisFeatureStore.ts
@@ -1,5 +1,4 @@
 import {
-  createSafeLogger,
   interfaces,
   LDFeatureStore,
   LDFeatureStoreDataStorage,
@@ -22,12 +21,10 @@ export default class RedisFeatureStore implements LDFeatureStore {
   private _wrapper: PersistentDataStoreWrapper;
 
   constructor(options?: LDRedisOptions, logger?: LDLogger) {
-    // Wrap the logger so a failing logger cannot break store operations.
-    const actualLogger = logger ? createSafeLogger(logger) : undefined;
     this._wrapper = new PersistentDataStoreWrapper(
-      new RedisCore(new RedisClientState(options, actualLogger), actualLogger),
+      new RedisCore(new RedisClientState(options, logger), logger),
       TtlFromOptions(options),
-      actualLogger,
+      logger,
     );
   }
 


### PR DESCRIPTION
This PR will add an error log whenever the store throws during upsert.
The purpose of this change is to make the javascript sdk behavior
consistent with go server sdk behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **error-level logging** when persistent feature-store operations fail, aligning Node.js SDK behavior with the Go server SDK.
> 
> **`PersistentDataStoreWrapper`** now accepts an optional `LDLogger` and logs `Persistent store returned error: …` when an upsert callback reports an error (without changing cache behavior on failure). **Redis** and **DynamoDB** feature stores pass the SDK logger into the wrapper; DynamoDB also prefers `options.logger` (via `createSafeLogger`) over the SDK logger for both the core and wrapper.
> 
> **DynamoDBCore** wraps `init`, `get`, and `getAll` in try/catch with error logs and invokes callbacks outside the try block. **RedisCore** logs when the initialized-state `exists` check fails. New unit tests cover wrapper upsert logging and store-specific error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191c2e837ca0092710c4cd26c42eb8151ffa19a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->