### PR TITLE
fix: Export BasicLogger, LDContext, and LDOptions from the Fastly SDK

### DIFF
--- a/packages/sdk/fastly/__tests__/exports.test.ts
+++ b/packages/sdk/fastly/__tests__/exports.test.ts
@@ -1,0 +1,28 @@
+/// <reference types="@fastly/js-compute" />
+import { BasicLogger, init, LDContext, LDLogger, LDOptions } from '../src/index';
+
+// The index module imports the KV store type from the Fastly runtime.
+jest.mock('fastly:kv-store');
+
+describe('package exports', () => {
+  it('exports BasicLogger as a runtime value', () => {
+    expect(typeof BasicLogger).toBe('function');
+    const logger: LDLogger = new BasicLogger({ level: 'debug' });
+    expect(typeof logger.debug).toBe('function');
+  });
+
+  it('exports init as a runtime value', () => {
+    expect(typeof init).toBe('function');
+  });
+
+  it('exports the LDContext and LDOptions types', () => {
+    // These assignments only compile when the types are exported.
+    const context: LDContext = { kind: 'user', key: 'example-user-key', anonymous: true };
+    const options: LDOptions = {
+      logger: new BasicLogger({ level: 'debug' }),
+      eventsBackendName: 'launchdarkly',
+    };
+    expect(context.key).toBe('example-user-key');
+    expect(options.eventsBackendName).toBe('launchdarkly');
+  });
+});

--- a/packages/sdk/fastly/__tests__/exports.test.ts
+++ b/packages/sdk/fastly/__tests__/exports.test.ts
@@ -1,14 +1,17 @@
 /// <reference types="@fastly/js-compute" />
-import { BasicLogger, init, LDContext, LDLogger, LDOptions } from '../src/index';
+import { basicLogger, init, LDContext, LDLogger, LDOptions } from '../src/index';
 
 // The index module imports the KV store type from the Fastly runtime.
 jest.mock('fastly:kv-store');
 
 describe('package exports', () => {
-  it('exports BasicLogger as a runtime value', () => {
-    expect(typeof BasicLogger).toBe('function');
-    const logger: LDLogger = new BasicLogger({ level: 'debug' });
+  it('exports a basicLogger factory that returns an LDLogger', () => {
+    expect(typeof basicLogger).toBe('function');
+    const logger: LDLogger = basicLogger({ level: 'debug' });
     expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
   });
 
   it('exports init as a runtime value', () => {
@@ -19,7 +22,7 @@ describe('package exports', () => {
     // These assignments only compile when the types are exported.
     const context: LDContext = { kind: 'user', key: 'example-user-key', anonymous: true };
     const options: LDOptions = {
-      logger: new BasicLogger({ level: 'debug' }),
+      logger: basicLogger({ level: 'debug' }),
       eventsBackendName: 'launchdarkly',
     };
     expect(context.key).toBe('example-user-key');

--- a/packages/sdk/fastly/src/api/LDClient.ts
+++ b/packages/sdk/fastly/src/api/LDClient.ts
@@ -1,7 +1,7 @@
 import { Info, LDClientImpl, ServerInternalOptions } from '@launchdarkly/js-server-sdk-common';
 
 import EdgePlatform from '../platform';
-import { FastlySDKOptions } from '../utils/validateOptions';
+import { LDOptions } from '../utils/validateOptions';
 import createCallbacks from './createCallbacks';
 import createOptions from './createOptions';
 
@@ -12,7 +12,7 @@ export const DEFAULT_EVENTS_BACKEND_NAME = 'launchdarkly';
  */
 export default class LDClient extends LDClientImpl {
   // clientSideID is only used to query the edge key-value store and send analytics, not to initialize with LD servers
-  constructor(clientSideID: string, platformInfo: Info, options: FastlySDKOptions) {
+  constructor(clientSideID: string, platformInfo: Info, options: LDOptions) {
     const { eventsBackendName, ...ldOptions } = options;
     const platform = new EdgePlatform(
       platformInfo,

--- a/packages/sdk/fastly/src/index.ts
+++ b/packages/sdk/fastly/src/index.ts
@@ -20,7 +20,11 @@ import {
 import { EdgeFeatureStore, EdgeProvider, LDClient } from './api';
 import { DEFAULT_EVENTS_BACKEND_NAME } from './api/LDClient';
 import createPlatformInfo from './createPlatformInfo';
-import validateOptions, { FastlySDKOptions, LDOptionsCommon } from './utils/validateOptions';
+import validateOptions, {
+  FastlySDKOptions,
+  LDOptions,
+  LDOptionsCommon,
+} from './utils/validateOptions';
 
 export type {
   BasicLoggerOptions,
@@ -44,14 +48,7 @@ export type {
 // create a logger.
 export type { BasicLogger };
 
-export type { EdgeProvider, FastlySDKOptions, KVStore, LDClient, LDOptionsCommon };
-
-/**
- * The LaunchDarkly Fastly Compute SDK configuration options. This is the
- * name the other LaunchDarkly edge SDKs use for their options type.
- * It is the same type as {@link FastlySDKOptions}.
- */
-export type LDOptions = FastlySDKOptions;
+export type { EdgeProvider, FastlySDKOptions, KVStore, LDClient, LDOptions, LDOptionsCommon };
 
 /**
  * Provides a simple {@link LDLogger} implementation.
@@ -96,14 +93,14 @@ export function basicLogger(options: BasicLoggerOptions): LDLogger {
  * @param kvStore
  *  The Fastly KV store configured for LaunchDarkly.
  * @param options
- *  Optional {@link FastlySDKOptions | configuration settings}.
+ *  Optional {@link LDOptions | configuration settings}.
  * @return
  *  The new {@link LDClient} instance.
  */
 export const init = (
   clientSideId: string,
   kvStore: KVStore,
-  options: FastlySDKOptions = { eventsBackendName: DEFAULT_EVENTS_BACKEND_NAME },
+  options: LDOptions = { eventsBackendName: DEFAULT_EVENTS_BACKEND_NAME },
 ) => {
   const logger = options.logger ?? BasicLogger.get();
 

--- a/packages/sdk/fastly/src/index.ts
+++ b/packages/sdk/fastly/src/index.ts
@@ -11,21 +11,39 @@
 /// <reference types="@fastly/js-compute" />
 import { KVStore } from 'fastly:kv-store';
 
-import { BasicLogger, LDEvaluationReason } from '@launchdarkly/js-server-sdk-common';
+import { BasicLogger } from '@launchdarkly/js-server-sdk-common';
 
 import { EdgeFeatureStore, EdgeProvider, LDClient } from './api';
 import { DEFAULT_EVENTS_BACKEND_NAME } from './api/LDClient';
 import createPlatformInfo from './createPlatformInfo';
 import validateOptions, { FastlySDKOptions, LDOptionsCommon } from './utils/validateOptions';
 
-export type {
+export {
   BasicLogger,
-  FastlySDKOptions,
-  KVStore,
-  LDClient,
-  LDEvaluationReason,
-  LDOptionsCommon,
-};
+  type BasicLoggerOptions,
+  type LDClientContext,
+  type LDContext,
+  type LDEvaluationDetail,
+  type LDEvaluationDetailTyped,
+  type LDEvaluationReason,
+  type LDFlagValue,
+  type LDFlagsState,
+  type LDFlagsStateOptions,
+  type LDLogger,
+  type LDLogLevel,
+  type LDMultiKindContext,
+  type LDSingleKindContext,
+  type LDWaitForInitializationOptions,
+} from '@launchdarkly/js-server-sdk-common';
+
+export type { EdgeProvider, FastlySDKOptions, KVStore, LDClient, LDOptionsCommon };
+
+/**
+ * The LaunchDarkly Fastly Compute SDK configuration options. This is the
+ * name the other LaunchDarkly edge SDKs use for their options type.
+ * It is the same type as {@link FastlySDKOptions}.
+ */
+export type LDOptions = FastlySDKOptions;
 
 /**
  * Creates an instance of the Fastly LaunchDarkly client.

--- a/packages/sdk/fastly/src/index.ts
+++ b/packages/sdk/fastly/src/index.ts
@@ -11,30 +11,38 @@
 /// <reference types="@fastly/js-compute" />
 import { KVStore } from 'fastly:kv-store';
 
-import { BasicLogger } from '@launchdarkly/js-server-sdk-common';
+import {
+  BasicLogger,
+  type BasicLoggerOptions,
+  type LDLogger,
+} from '@launchdarkly/js-server-sdk-common';
 
 import { EdgeFeatureStore, EdgeProvider, LDClient } from './api';
 import { DEFAULT_EVENTS_BACKEND_NAME } from './api/LDClient';
 import createPlatformInfo from './createPlatformInfo';
 import validateOptions, { FastlySDKOptions, LDOptionsCommon } from './utils/validateOptions';
 
-export {
-  BasicLogger,
-  type BasicLoggerOptions,
-  type LDClientContext,
-  type LDContext,
-  type LDEvaluationDetail,
-  type LDEvaluationDetailTyped,
-  type LDEvaluationReason,
-  type LDFlagValue,
-  type LDFlagsState,
-  type LDFlagsStateOptions,
-  type LDLogger,
-  type LDLogLevel,
-  type LDMultiKindContext,
-  type LDSingleKindContext,
-  type LDWaitForInitializationOptions,
+export type {
+  BasicLoggerOptions,
+  LDClientContext,
+  LDContext,
+  LDEvaluationDetail,
+  LDEvaluationDetailTyped,
+  LDEvaluationReason,
+  LDFlagValue,
+  LDFlagsState,
+  LDFlagsStateOptions,
+  LDLogger,
+  LDLogLevel,
+  LDMultiKindContext,
+  LDSingleKindContext,
+  LDWaitForInitializationOptions,
 } from '@launchdarkly/js-server-sdk-common';
+
+// BasicLogger stays available as a type so existing code keeps compiling.
+// The next major version removes it from the exports. Use basicLogger() to
+// create a logger.
+export type { BasicLogger };
 
 export type { EdgeProvider, FastlySDKOptions, KVStore, LDClient, LDOptionsCommon };
 
@@ -44,6 +52,32 @@ export type { EdgeProvider, FastlySDKOptions, KVStore, LDClient, LDOptionsCommon
  * It is the same type as {@link FastlySDKOptions}.
  */
 export type LDOptions = FastlySDKOptions;
+
+/**
+ * Provides a simple {@link LDLogger} implementation.
+ *
+ * This logging implementation uses a simple format that includes only the log level
+ * and the message text. Output is written to the standard error stream (`console.error`).
+ * You can filter by log level as described in {@link BasicLoggerOptions.level}.
+ *
+ * To use the logger created by this function, put it into {@link LDOptions.logger}. If
+ * you do not set {@link LDOptions.logger} to anything, the SDK uses a default logger
+ * that is equivalent to `basicLogger({ level: 'info' })`.
+ *
+ * @param options Configuration for the logger.
+ *
+ * @example
+ * This example shows how to use `basicLogger` in your SDK options to enable console
+ * logging only at `warn` and `error` levels.
+ * ```javascript
+ *   const ldOptions = {
+ *     logger: basicLogger({ level: 'warn' }),
+ *   };
+ * ```
+ */
+export function basicLogger(options: BasicLoggerOptions): LDLogger {
+  return new BasicLogger(options);
+}
 
 /**
  * Creates an instance of the Fastly LaunchDarkly client.

--- a/packages/sdk/fastly/src/utils/validateOptions.ts
+++ b/packages/sdk/fastly/src/utils/validateOptions.ts
@@ -4,7 +4,7 @@ export type { LDOptionsCommon };
 /**
  * The Launchdarkly Fastly Compute SDK configuration options. See {@link LDOptionsCommon} for more information on the 'logger', 'sendEvents', and 'eventsUri' options.
  */
-export type FastlySDKOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents' | 'eventsUri'> & {
+export type LDOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents' | 'eventsUri'> & {
   /**
    * The Fastly Backend name to send LaunchDarkly events. Backends are configured using the Fastly service backend configuration. This option can be ignored if the `sendEvents` option is set to `false`. See [Fastly's Backend documentation](https://developer.fastly.com/reference/api/services/backend/) for more information. The default value is `launchdarkly`.
    */
@@ -12,10 +12,17 @@ export type FastlySDKOptions = Pick<LDOptionsCommon, 'logger' | 'sendEvents' | '
 };
 
 /**
+ * The Launchdarkly Fastly Compute SDK configuration options.
+ *
+ * @deprecated Use {@link LDOptions} instead. FastlySDKOptions will be removed in a future version.
+ */
+export type FastlySDKOptions = LDOptions;
+
+/**
  * The internal options include featureStore because that's how the LDClient
  * implementation expects it.
  */
-export type LDOptionsInternal = FastlySDKOptions & Pick<LDOptionsCommon, 'featureStore'>;
+export type LDOptionsInternal = LDOptions & Pick<LDOptionsCommon, 'featureStore'>;
 
 const validators = {
   clientSideId: TypeValidators.String,


### PR DESCRIPTION
## Summary

The published Fastly SDK exports only `init` at runtime. `BasicLogger` was exported as a type only, so `new BasicLogger(...)` is `undefined` when the package is used, and `LDContext` and `LDOptions` were not exported at all. The Fastly reference docs import all three from `@launchdarkly/fastly-server-sdk`.

- Add a `basicLogger(options)` factory that returns an `LDLogger`, matching the Node server SDK. `BasicLogger` stays exported as a type only so existing code keeps compiling; a comment notes that the next major version removes it from the exports.
- Rename the options type to `LDOptions`. `FastlySDKOptions` stays exported as a deprecated alias that points users to `LDOptions` and will be removed in a future version.
- Re-export the common evaluation and context types (`LDContext`, `LDEvaluationDetail`, `LDLogger`, ...) the same way the Cloudflare SDK does.
- Add an export-surface test covering the factory and the types.

The Fastly logging doc snippet moves to `basicLogger({ level: 'debug' })` in launchdarkly/sdk-meta#626.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> The Fastly SDK **public export surface** is expanded so it matches reference docs and the Node/Cloudflare SDK patterns.
> 
> A runtime **`basicLogger(options)`** factory is added (replacing the unusable `new BasicLogger(...)` pattern when only the type was exported). **`BasicLogger`** remains a **type-only** export for backward compatibility, with a note that it will be removed in a future major version.
> 
> Configuration typing is **renamed to `LDOptions`**; **`FastlySDKOptions`** is kept as a **deprecated alias**. **`init`** and **`LDClient`** now take **`LDOptions`** in docs and signatures.
> 
> The package **re-exports** common evaluation/context types from `@launchdarkly/js-server-sdk-common` (e.g. **`LDContext`**, **`LDLogger`**, **`LDEvaluationDetail`**). An **`exports.test.ts`** suite locks in the factory, **`init`**, and type exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209bc12341915ab2d7973137d3b410b7761d4e90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->