### PR TITLE
fix: Ignore non-string and empty keys in OpenFeature context conversion

### DIFF
--- a/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
@@ -271,6 +271,52 @@ it('preserves null values inside nested structure attributes', () => {
   expect(logger.logs.length).toEqual(0);
 });
 
+it('ignores a non-string key and logs a warning and an error', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { key: 42 as unknown as string })).toEqual({
+    key: undefined,
+    kind: 'user',
+  });
+  expect(logger.logs).toEqual([
+    "A non-string 'key' attribute was provided.",
+    "The EvaluationContext must contain either a 'targetingKey' or a 'key' and the type must be a string.",
+  ]);
+});
+
+it('uses the key attribute when the targetingKey is empty', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: '', key: 'the-key' })).toEqual({
+    key: 'the-key',
+    kind: 'user',
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
+it('logs an error when the only key is empty', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: '' })).toEqual({
+    key: undefined,
+    kind: 'user',
+  });
+  expect(logger.logs).toEqual([
+    "The EvaluationContext must contain either a 'targetingKey' or a 'key' and the type must be a string.",
+  ]);
+});
+
+it('ignores a non-string targetingKey within a multi-context', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      kind: 'multi',
+      user: { targetingKey: 42 as unknown as string, key: 'user-key' },
+    }),
+  ).toEqual({
+    kind: 'multi',
+    user: { key: 'user-key' },
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
 it('logs an error and skips null sub-contexts in a multi-context without crashing', () => {
   const logger = new TestLogger();
   expect(

--- a/packages/shared/openfeature-server-common/src/translateContext.ts
+++ b/packages/shared/openfeature-server-common/src/translateContext.ts
@@ -13,6 +13,15 @@ const LDContextBuiltIns: Record<string, string> = {
 };
 
 /**
+ * Get the value as a string, or undefined if it is not a non-empty string.
+ * @param value The value to check.
+ * @returns The value as a string, or undefined.
+ */
+function nonEmptyString(value: EvaluationContextValue | undefined): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+/**
  * Convert attributes, potentially recursively, into appropriate types.
  * @param logger Logger to use if issues are encountered.
  * @param key The key for the attribute.
@@ -61,10 +70,17 @@ function translateContextCommon(
   inCommon: Record<string, EvaluationContextValue>,
   inTargetingKey: string | undefined,
 ): LDContextCommon {
-  const keyAttr = inCommon.key as string;
-  const finalKey = inTargetingKey ?? keyAttr;
+  const keyAttr = inCommon.key;
+  // An empty key is treated the same as an absent one.
+  const targetingKey = nonEmptyString(inTargetingKey);
+  const keyFromAttr = nonEmptyString(keyAttr);
+  const finalKey = targetingKey ?? keyFromAttr;
 
-  if (keyAttr != null && inTargetingKey != null) {
+  if (keyAttr != null && typeof keyAttr !== 'string') {
+    logger.warn("A non-string 'key' attribute was provided.");
+  }
+
+  if (keyFromAttr != null && targetingKey != null) {
     logger.warn(
       "The EvaluationContext contained both a 'targetingKey' and a 'key' attribute. The" +
         " 'key' attribute will be discarded.",
@@ -78,7 +94,7 @@ function translateContextCommon(
     );
   }
 
-  const convertedContext: LDContextCommon = { key: finalKey };
+  const convertedContext: LDContextCommon = { key: finalKey as string };
   Object.entries(inCommon).forEach(([key, value]) => {
     if (key === 'targetingKey' || key === 'key' || key === 'kind') {
       return;


### PR DESCRIPTION
The JavaScript OpenFeature providers now handle a non-string or empty `key`/`targetingKey` the way the provider behavior spec and the other LaunchDarkly providers do.

- A non-string `key` attribute is no longer used as the context key, and a warning is logged (OFP 2.3.4 / 2.3.4.1)
- An empty `targetingKey` is treated as absent, so a string `key` attribute is used instead
- The "both a targetingKey and a key" warning now only fires when the `key` attribute is actually usable

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe the solution you've provided**

`translateContext` previously did `inTargetingKey ?? inCommon.key`, so a non-string `key` (for example a number) became the LaunchDarkly context key unchanged, and an empty `targetingKey` won over a perfectly good `key` attribute. Both diverge from `OFP-openfeature-provider-behavior` and from the Java, Python, Ruby and PHP providers, which validate the type and treat an empty targeting key as absent.

A small `nonEmptyString` helper is now used for both candidates, so only non-empty strings are eligible, and the non-string case logs a warning before the existing "must contain either a 'targetingKey' or a 'key'" error.

**Describe alternatives you've considered**

Coercing a non-string key with `String(value)` was rejected: it would silently target a context the application did not ask for, and the spec requires the attribute to be ignored.

**Additional context**

Found during the weekly OpenFeature provider audit. `privateAttributes` type validation is a separate gap and is handled in its own PR.


Link to Devin session: https://app.devin.ai/sessions/9f0be899af7842e0b6a7bfc6229084f6
Open in Devin Desktop: https://app.devin.ai/desktop/session/9f0be899af7842e0b6a7bfc6229084f6?variant=devin
Requested by: @kinyoklion