### PR TITLE
fix: Validate privateAttributes in OpenFeature context conversion

### DIFF
--- a/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
+++ b/packages/shared/openfeature-server-common/__tests__/translateContext.test.ts
@@ -172,6 +172,48 @@ it('can handle privateAttributes in a single context', () => {
   expect(logger.logs.length).toEqual(0);
 });
 
+it('logs an error when privateAttributes is not an array', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      targetingKey: 'my-key',
+      myCustomAttribute: 'myCustomValue',
+      privateAttributes: 'myCustomAttribute' as unknown as string[],
+    }),
+  ).toEqual({
+    kind: 'user',
+    key: 'my-key',
+    myCustomAttribute: 'myCustomValue',
+  });
+  expect(logger.logs).toEqual(["The attribute 'privateAttributes' must be an array"]);
+});
+
+it('omits non-string privateAttributes entries and logs an error', () => {
+  const logger = new TestLogger();
+  expect(
+    translateContext(logger, {
+      targetingKey: 'my-key',
+      privateAttributes: ['myCustomAttribute', 17 as unknown as string],
+    }),
+  ).toEqual({
+    kind: 'user',
+    key: 'my-key',
+    _meta: {
+      privateAttributes: ['myCustomAttribute'],
+    },
+  });
+  expect(logger.logs).toEqual(["'privateAttributes' must be an array of only string values"]);
+});
+
+it('does not set metadata when privateAttributes is empty', () => {
+  const logger = new TestLogger();
+  expect(translateContext(logger, { targetingKey: 'my-key', privateAttributes: [] })).toEqual({
+    kind: 'user',
+    key: 'my-key',
+  });
+  expect(logger.logs.length).toEqual(0);
+});
+
 it('detects a cycle and logs an error', () => {
   const a: any = {
     b: { c: {} },

--- a/packages/shared/openfeature-server-common/src/translateContext.ts
+++ b/packages/shared/openfeature-server-common/src/translateContext.ts
@@ -84,10 +84,20 @@ function translateContextCommon(
       return;
     }
     if (key === 'privateAttributes') {
-      // eslint-disable-next-line no-underscore-dangle
-      convertedContext._meta = {
-        privateAttributes: value as string[],
-      };
+      if (!Array.isArray(value)) {
+        logger.error("The attribute 'privateAttributes' must be an array");
+        return;
+      }
+
+      const privateAttributes = value.filter((item): item is string => typeof item === 'string');
+      if (privateAttributes.length !== value.length) {
+        logger.error("'privateAttributes' must be an array of only string values");
+      }
+
+      if (privateAttributes.length) {
+        // eslint-disable-next-line no-underscore-dangle
+        convertedContext._meta = { privateAttributes };
+      }
     } else if (key in LDContextBuiltIns) {
       if (typeof value === LDContextBuiltIns[key]) {
         (convertedContext as any)[key] = value;


### PR DESCRIPTION
The JavaScript OpenFeature providers now validate the `privateAttributes` evaluation context attribute instead of forwarding it unchecked.

- A `privateAttributes` value which is not an array is dropped and an error is logged
- Non-string entries within the array are dropped and an error is logged
- `_meta` is only added to the converted context when at least one private attribute survives

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

None.

**Describe the solution you've provided**

`translateContext` assigned `_meta.privateAttributes` with a `value as string[]` cast, so an application which set `privateAttributes` to a string (or to an array containing non-strings) produced a context whose private attribute list was not a list of strings. The behavior spec (OFP 2.4.4, 2.4.5, 2.4.5.1) requires the attribute to be dropped with an error in that case, which is what the Java, Python, Ruby and PHP providers already do.

Dropping the bad value is the safer of the two options here, since a malformed private attribute list can otherwise be silently ignored further down and result in attributes being sent to LaunchDarkly which the application intended to keep private.

**Describe alternatives you've considered**

Coercing entries to strings was rejected: private attribute names are references into the context, so a coerced name would not match any attribute and would give a false sense of privacy.

**Additional context**

Found during the weekly OpenFeature provider audit. The `key`/`targetingKey` validation gap in the same function is handled in a separate PR.


Link to Devin session: https://app.devin.ai/sessions/9f0be899af7842e0b6a7bfc6229084f6
Open in Devin Desktop: https://app.devin.ai/desktop/session/9f0be899af7842e0b6a7bfc6229084f6?variant=devin
Requested by: @kinyoklion