### PR TITLE
feat(store): add support for infinite TTL

### DIFF
--- a/packages/shared/sdk-server/__tests__/cache/TtlCache.test.ts
+++ b/packages/shared/sdk-server/__tests__/cache/TtlCache.test.ts
@@ -94,6 +94,47 @@ describe('given a ttl cache', () => {
   });
 });
 
+describe.each([-1, Infinity])('given a ttl cache with an infinite ttl (%p)', (ttl) => {
+  let ttlCache: TtlCache;
+
+  beforeEach(() => {
+    ttlCache = new TtlCache({ ttl, checkInterval: 600 });
+  });
+
+  afterEach(() => {
+    ttlCache.close();
+    jest.restoreAllMocks();
+  });
+
+  it('items in the cache do not expire.', () => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 0);
+
+    ttlCache.set('0', 0);
+
+    jest.spyOn(Date, 'now').mockImplementation(() => Number.MAX_SAFE_INTEGER);
+
+    expect(ttlCache.get('0')).toEqual(0);
+  });
+
+  it('items can be deleted.', () => {
+    ttlCache.set('0', 0);
+    ttlCache.set('1', 1);
+
+    ttlCache.delete('0');
+
+    expect(ttlCache.get('0')).toBeUndefined();
+    expect(ttlCache.get('1')).toEqual(1);
+  });
+
+  it('the cache can be cleared.', () => {
+    ttlCache.set('0', 0);
+
+    ttlCache.clear();
+
+    expect(ttlCache.get('0')).toBeUndefined();
+  });
+});
+
 describe('given a ttl cache with short check period and TTL', () => {
   let ttlCache: TtlCache;
 

--- a/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
+++ b/packages/shared/sdk-server/__tests__/store/PersistentStoreWrapper.test.ts
@@ -551,3 +551,129 @@ describe.each(['caching', 'non-caching'])(
     });
   },
 );
+
+describe.each([-1, Infinity])(
+  'given a persistent store implementation and a wrapper with an infinite TTL (%p)',
+  (ttl) => {
+    let mockPersistentStore: MockPersistentStore;
+    let wrapper: PersistentDataStoreWrapper;
+    let asyncWrapper: AsyncStoreFacade;
+
+    beforeEach(async () => {
+      mockPersistentStore = new MockPersistentStore();
+      wrapper = new PersistentDataStoreWrapper(mockPersistentStore, ttl);
+      asyncWrapper = new AsyncStoreFacade(wrapper);
+
+      await asyncWrapper.init({
+        features: {
+          key1: {
+            deleted: false,
+            version: 1,
+          },
+        },
+        segments: {
+          key2: {
+            deleted: false,
+            version: 2,
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      wrapper.close();
+      jest.restoreAllMocks();
+    });
+
+    it('cached items do not expire', async () => {
+      const spy = jest.spyOn(mockPersistentStore, 'get');
+      jest.spyOn(Date, 'now').mockImplementation(() => Number.MAX_SAFE_INTEGER);
+
+      const value = await asyncWrapper.get(VersionedDataKinds.Features, 'key1');
+      expect(value).toEqual({
+        deleted: false,
+        version: 1,
+      });
+      expect(spy).toBeCalledTimes(0);
+    });
+
+    it('after a successful upsert, the all-items cache is updated in place', async () => {
+      const spy = jest.spyOn(mockPersistentStore, 'getAll');
+
+      await asyncWrapper.upsert(VersionedDataKinds.Features, {
+        key: 'key3',
+        version: 5,
+      });
+
+      const allFlags = await asyncWrapper.all(VersionedDataKinds.Features);
+      expect(allFlags).toEqual({
+        key1: {
+          deleted: false,
+          version: 1,
+        },
+        key3: {
+          key: 'key3',
+          version: 5,
+        },
+      });
+      // The all-items cache was updated in place, so the store is not read.
+      expect(spy).toBeCalledTimes(0);
+    });
+
+    it('after a successful delete, the item is removed from the all-items cache', async () => {
+      const spy = jest.spyOn(mockPersistentStore, 'getAll');
+
+      await asyncWrapper.delete(VersionedDataKinds.Features, 'key1', 7);
+
+      const value = await asyncWrapper.get(VersionedDataKinds.Features, 'key1');
+      expect(value).toBeNull();
+
+      const allFlags = await asyncWrapper.all(VersionedDataKinds.Features);
+      expect(allFlags).toEqual({});
+      expect(spy).toBeCalledTimes(0);
+    });
+
+    it('when an upsert fails, the caches are still updated with the new item', async () => {
+      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
+        cb(new Error('bad news'), undefined);
+      });
+      const getSpy = jest.spyOn(mockPersistentStore, 'get');
+      const getAllSpy = jest.spyOn(mockPersistentStore, 'getAll');
+
+      await asyncWrapper.upsert(VersionedDataKinds.Features, {
+        key: 'key1',
+        version: 2,
+      });
+
+      const value = await asyncWrapper.get(VersionedDataKinds.Features, 'key1');
+      expect(value).toEqual({
+        key: 'key1',
+        version: 2,
+      });
+
+      const allFlags = await asyncWrapper.all(VersionedDataKinds.Features);
+      expect(allFlags).toEqual({
+        key1: {
+          key: 'key1',
+          version: 2,
+        },
+      });
+      expect(getSpy).toBeCalledTimes(0);
+      expect(getAllSpy).toBeCalledTimes(0);
+    });
+
+    it('when a delete fails, the caches still remove the item', async () => {
+      jest.spyOn(mockPersistentStore, 'upsert').mockImplementation((_kind, _key, _data, cb) => {
+        cb(new Error('bad news'), undefined);
+      });
+
+      await asyncWrapper.delete(VersionedDataKinds.Features, 'key1', 2);
+
+      const value = await asyncWrapper.get(VersionedDataKinds.Features, 'key1');
+      expect(value).toBeNull();
+
+      const allFlags = await asyncWrapper.all(VersionedDataKinds.Features);
+      expect(allFlags).toEqual({});
+    });
+  },
+);

--- a/packages/shared/sdk-server/src/cache/TtlCache.ts
+++ b/packages/shared/sdk-server/src/cache/TtlCache.ts
@@ -3,11 +3,23 @@ function isStale(record: CacheRecord): boolean {
 }
 
 /**
+ * Check if a TTL value represents an infinite TTL.
+ *
+ * A negative TTL, or Infinity, means that cached items never expire.
+ * @param ttl The TTL, in seconds, to check.
+ * @returns True if the TTL is infinite.
+ */
+export function isInfiniteTtl(ttl: number): boolean {
+  return ttl < 0 || ttl === Infinity;
+}
+
+/**
  * Options for the TTL cache.
  */
 export interface TtlCacheOptions {
   /**
-   * The TTL for all items in seconds.
+   * The TTL for all items in seconds. A negative value, or Infinity, means
+   * that items never expire.
    */
   ttl: number;
 
@@ -30,10 +42,16 @@ export default class TtlCache {
 
   private _checkIntervalHandle: any;
 
+  private _neverExpire: boolean;
+
   constructor(private readonly _options: TtlCacheOptions) {
-    this._checkIntervalHandle = setInterval(() => {
-      this._purgeStale();
-    }, _options.checkInterval * 1000);
+    this._neverExpire = isInfiniteTtl(_options.ttl);
+    // When items never expire there is nothing to purge.
+    if (!this._neverExpire) {
+      this._checkIntervalHandle = setInterval(() => {
+        this._purgeStale();
+      }, _options.checkInterval * 1000);
+    }
   }
 
   /**
@@ -53,14 +71,15 @@ export default class TtlCache {
 
   /**
    * Set an item in the cache. It will expire after the TTL specified
-   * in the cache configuration.
+   * in the cache configuration. If the TTL is infinite, then the item
+   * will not expire.
    * @param key The key for the value.
    * @param value The value to set.
    */
   public set(key: string, value: any) {
     this._storage.set(key, {
       value,
-      expiration: Date.now() + this._options.ttl * 1000,
+      expiration: this._neverExpire ? Infinity : Date.now() + this._options.ttl * 1000,
     });
   }
 

--- a/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
+++ b/packages/shared/sdk-server/src/store/PersistentDataStoreWrapper.ts
@@ -14,7 +14,7 @@ import {
   LDFeatureStoreKindData,
   LDKeyedFeatureStoreItem,
 } from '../api/subsystems';
-import TtlCache from '../cache/TtlCache';
+import TtlCache, { isInfiniteTtl } from '../cache/TtlCache';
 import { persistentStoreKinds } from './persistentStoreKinds';
 import sortDataSet from './sortDataSet';
 import UpdateQueue from './UpdateQueue';
@@ -107,11 +107,19 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
    */
   private _queue: UpdateQueue = new UpdateQueue();
 
+  /**
+   * True when the cache TTL is infinite. In this mode cached items never
+   * expire, and the caches update even when a store write fails. This keeps
+   * the cached data current when the store has an outage.
+   */
+  private _isInfiniteTtl: boolean;
+
   constructor(
     private readonly _core: PersistentDataStore,
     ttl: number,
     private readonly _logger?: LDLogger,
   ) {
+    this._isInfiniteTtl = isInfiniteTtl(ttl);
     if (ttl) {
       this._itemCache = new TtlCache({
         ttl,
@@ -221,8 +229,11 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
 
   upsert(kind: DataKind, data: LDKeyedFeatureStoreItem, callback: () => void): void {
     this._queue.enqueue((cb) => {
-      // Clear the caches which contain all the values of a specific kind.
-      if (this._allItemsCache) {
+      // With a finite TTL, clear the caches which contain all the values of
+      // a specific kind. They will re-populate from the store on the next
+      // read. With an infinite TTL, the caches instead update in place after
+      // the write completes.
+      if (this._allItemsCache && !this._isInfiniteTtl) {
         this._allItemsCache.clear();
       }
 
@@ -241,19 +252,49 @@ export default class PersistentDataStoreWrapper implements LDFeatureStore {
             if (updatedDescriptor.serializedItem) {
               const value = deserialize(persistKind, updatedDescriptor);
               this._itemCache?.set(cacheKey(kind, data.key), value);
+              this._updateAllItemsCacheInPlace(kind, data.key, value);
             } else if (updatedDescriptor.deleted) {
               // Deleted and there was not a serialized representation.
-              this._itemCache?.set(data.key, {
-                key: data.key,
-                version: updatedDescriptor.version,
-                deleted: true,
-              });
+              const value = deletedDescriptor(updatedDescriptor.version);
+              this._itemCache?.set(cacheKey(kind, data.key), value);
+              this._updateAllItemsCacheInPlace(kind, data.key, value);
             }
+          } else if (err && this._isInfiniteTtl) {
+            // The write failed, but the cached items never expire. Update the
+            // caches with the new item, so the SDK continues to serve current
+            // data. Without this update the process would serve the old value
+            // until it restarts.
+            const value: ItemDescriptor = { version: data.version, item: data };
+            this._itemCache?.set(cacheKey(kind, data.key), value);
+            this._updateAllItemsCacheInPlace(kind, data.key, value);
           }
           cb();
         },
       );
     }, callback);
+  }
+
+  /**
+   * Update a single item in the cached all-items data for a kind. This only
+   * applies to the infinite TTL mode. With a finite TTL, the all-items cache
+   * is cleared instead, and it re-populates from the store on the next read.
+   */
+  private _updateAllItemsCacheInPlace(kind: DataKind, key: string, item: ItemDescriptor): void {
+    if (!this._isInfiniteTtl || !this._allItemsCache) {
+      return;
+    }
+    const cached = this._allItemsCache.get(allForKindCacheKey(kind));
+    if (!cached) {
+      return;
+    }
+    const updated: LDFeatureStoreKindData = { ...cached };
+    const value = itemIfNotDeleted(item);
+    if (value) {
+      updated[key] = value;
+    } else {
+      delete updated[key];
+    }
+    this._allItemsCache.set(allForKindCacheKey(kind), updated);
   }
 
   delete(kind: DataKind, key: string, version: number, callback: () => void): void {

--- a/packages/store/node-server-sdk-dynamodb/src/LDDynamoDBOptions.ts
+++ b/packages/store/node-server-sdk-dynamodb/src/LDDynamoDBOptions.ts
@@ -29,6 +29,11 @@ export default interface LDDynamoDBOptions {
    * The amount of time, in seconds, that recently read or updated items should remain in an
    * in-memory cache. If it is zero, there will be no in-memory caching.
    *
+   * A negative value, or `Infinity`, means infinite caching: cached items never expire, and the
+   * cache is updated even when a write to DynamoDB fails. Use this mode when DynamoDB is only a
+   * source of data at startup. After the cache is populated, the SDK serves all reads from the
+   * cache, and a DynamoDB outage cannot make the served data stale.
+   *
    * This parameter applies only to {@link DynamoDBFeatureStore}. It is ignored for {@link DynamoDBBigSegmentStore}.
    * Caching for {@link DynamoDBBigSegmentStore} is configured separately, in the SDK's
    * `LDBigSegmentsOptions` type, since it is independent of what database implementation is used.

--- a/packages/store/node-server-sdk-redis/src/LDRedisOptions.ts
+++ b/packages/store/node-server-sdk-redis/src/LDRedisOptions.ts
@@ -31,6 +31,11 @@ export default interface LDRedisOptions {
    * in-memory cache. If it is zero, there will be no in-memory caching. The default TTL will be
    * 30 seconds if one is not set.
    *
+   * A negative value, or `Infinity`, means infinite caching: cached items never expire, and the
+   * cache is updated even when a write to Redis fails. Use this mode when Redis is only a source
+   * of data at startup. After the cache is populated, the SDK serves all reads from the cache,
+   * and a Redis outage cannot make the served data stale.
+   *
    * This parameter applies only to RedisFeatureStore. It is ignored for RedisBigSegmentStore.
    * Caching for RedisBigSegmentStore is configured separately, in the SDK's
    * `LDBigSegmentsOptions` type, since it is independent of what database implementation is used.


### PR DESCRIPTION
This PR will add support for infinite TTL on persistent store caches. We
initially chose to designate values >=0 as inifinite to be consistent
with Go.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/2001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **infinite TTL** support for in-memory persistent-store caches by treating a **negative** `cacheTTL` or **`Infinity`** as “never expire” (via new `isInfiniteTtl` in `TtlCache`).
> 
> `TtlCache` skips expiry purging and stores entries with infinite expiration. **`PersistentDataStoreWrapper`** changes behavior in infinite mode: the per-kind “all items” cache is **updated in place** on upsert/delete instead of being cleared, and **failed backend writes still refresh the caches** so flag data stays current when DynamoDB/Redis is down. Redis and DynamoDB option docs now describe this startup-cache / outage-resilience use case.
> 
> New tests cover infinite TTL for both `TtlCache` and the wrapper (including failed write paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d59d3a447497b76cdffe8716175a9d87ffeaae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->