### PR TITLE
ci: fixing the CI build issue

### DIFF
--- a/packages/sdk/fastly/example/src/index.ts
+++ b/packages/sdk/fastly/example/src/index.ts
@@ -58,7 +58,7 @@ async function handleRequest(event: FetchEvent) {
       key: 'test-user',
     },
     'fastly-request': {
-      key: env('FASTLY_TRACE_ID'),
+      key: env('FASTLY_TRACE_ID') ?? 'unknown',
       fastly_service_version: env('FASTLY_SERVICE_VERSION'),
       fastly_cache_generation: env('FASTLY_CACHE_GENERATION'),
       fastly_hostname: env('FASTLY_HOSTNAME'),

--- a/packages/shared/common/src/internal/fdv2/index.ts
+++ b/packages/shared/common/src/internal/fdv2/index.ts
@@ -1,6 +1,6 @@
-import { fdv1PayloadAdaptor as FDv1PayloadAdaptor } from './FDv1PayloadAdaptor';
 import { readFallbackDirective, readGoodbyeFallbackDirective } from './fallbackDirective';
 import type { FallbackDirective } from './fallbackDirective';
+import { fdv1PayloadAdaptor as FDv1PayloadAdaptor } from './FDv1PayloadAdaptor';
 import { PayloadProcessor } from './payloadProcessor';
 import { PayloadStreamReader } from './payloadStreamReader';
 import type { FDv2Event, FDv2EventsCollection } from './proto';

--- a/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/PollingBase.ts
@@ -1,7 +1,6 @@
 import { internal, isHttpRecoverable, LDLogger } from '@launchdarkly/js-sdk-common';
 
 import { processFlagEval } from '../flagEvalMapper';
-import { FallbackDirective, readFallbackDirective } from './fallbackDirective';
 import { FDv2Requestor } from './FDv2Requestor';
 import {
   changeSet,

--- a/packages/shared/sdk-client/src/datasource/fdv2/StreamingFDv2Base.ts
+++ b/packages/shared/sdk-client/src/datasource/fdv2/StreamingFDv2Base.ts
@@ -14,11 +14,6 @@ import {
 import { processFlagEval } from '../flagEvalMapper';
 import { createAsyncQueue } from './AsyncQueue';
 import {
-  FallbackDirective,
-  readFallbackDirective,
-  readGoodbyeFallbackDirective,
-} from './fallbackDirective';
-import {
   changeSet,
   errorInfoFromHttpError,
   errorInfoFromInvalidData,


### PR DESCRIPTION
Also addressing SDK-3088

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/2007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes CI build failures (SDK-3088) by cleaning up **FDv2 datasource imports** and hardening the **Fastly SDK example** context.
> 
> The Fastly example now sets the `fastly-request` context **key** to `'unknown'` when `FASTLY_TRACE_ID` is unset, so multi-kind evaluation does not rely on an undefined key in environments like CI.
> 
> In **sdk-client** FDv2 polling/streaming bases, unused imports from local `./fallbackDirective` are removed; those modules already use **`internal.readFallbackDirective`** / **`internal.readGoodbyeFallbackDirective`** from shared common. The **common** `fdv2` barrel file only reorders imports (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d8a98f332535d3d12b0c9e34d23c52891e2b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->