### PR TITLE
ci(vue-sdk): remove scaffolding and add sdk-meta entry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -610,8 +610,6 @@ jobs:
         with:
           workspace_path: packages/sdk/vue
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          # Vue SDK is publishing as a prerelease; remove this once it reaches GA so npm's `latest` tag starts tracking it.
-          prerelease: true
 
   manual-publish:
     runs-on: ubuntu-latest

--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -292,6 +292,35 @@
         "secureMode": { "introduced": "1.0" },
         "track": { "introduced": "1.2" }
       }
+    },
+    "vue": {
+      "name": "Vue SDK",
+      "type": "client-side",
+      "path": "packages/sdk/vue",
+      "languages": ["JavaScript", "TypeScript"],
+      "releases": {
+        "tag-prefix": "vue-client-sdk-"
+      },
+      "wrapperNames": ["vue-client-sdk"],
+      "features": {
+        "allFlags": { "introduced": "1.0" },
+        "appMetadata": { "introduced": "1.0" },
+        "bigSegments": { "introduced": "1.0" },
+        "bootstrapping": { "introduced": "1.0" },
+        "contexts": { "introduced": "2.0" },
+        "experimentation": { "introduced": "1.0" },
+        "fdv2": { "introduced": "3.0" },
+        "flagChanges": { "introduced": "1.0" },
+        "hooks": { "introduced": "2.4" },
+        "inlineContextCustomEvents": { "introduced": "2.4" },
+        "perContextSummaryEvents": { "introduced": "2.4" },
+        "pluginSupport": { "introduced": "2.4" },
+        "privateAttrs": { "introduced": "1.0" },
+        "relayProxyProxy": { "introduced": "1.0" },
+        "secureMode": { "introduced": "1.0" },
+        "track": { "introduced": "1.0" },
+        "variationDetail": { "introduced": "1.0" }
+      }
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -434,7 +434,6 @@
       "prerelease-type": "beta"
     },
     "packages/sdk/vue": {
-      "release-as": "3.0.0",
       "extra-files": [
         "src/client/LDVueClient.ts",
         {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> Treats the **Vue SDK** as a normal GA package in release automation instead of prerelease scaffolding.
> 
> **CI:** The `release-vue` job no longer passes `prerelease: true` to `full-release`, so published versions can update npm’s **`latest`** tag (same pattern as other client SDKs).
> 
> **Release Please:** Drops the pinned **`release-as": "3.0.0"`** for `packages/sdk/vue`, so future versions follow conventional commits rather than a one-off forced major.
> 
> **Metadata:** Adds a **`vue`** entry to `.sdk_metadata.json` (client-side SDK, `vue-client-sdk-` tag prefix, wrapper name, and feature introduction versions) so the Vue package is represented alongside other SDKs in repo metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aae75a092b18af09a06e81e062105d1b15ff496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/js-core/pull/2008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->