### PR TITLE
fix: Log the cached-data evaluation warning only once per client

### DIFF
--- a/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
+++ b/packages/shared/sdk-server/__tests__/LDClient.evaluation.test.ts
@@ -359,8 +359,10 @@ describe('given a client and store that are uninitialized', () => {
 describe('given a client that is un-initialized and store that is initialized', () => {
   let store: LDFeatureStore;
   let client: LDClientImpl;
+  let logger: TestLogger;
 
   beforeEach(async () => {
+    logger = new TestLogger();
     store = new InMemoryFeatureStore();
     const asyncStore = new AsyncStoreFacade(store);
     // Put something in the store, but don't initialize it.
@@ -380,6 +382,7 @@ describe('given a client that is un-initialized and store that is initialized', 
       'sdk-key-initialized-store',
       createBasicPlatform(),
       {
+        logger,
         sendEvents: false,
         featureStore: store,
         updateProcessor: () => ({
@@ -406,5 +409,26 @@ describe('given a client that is un-initialized and store that is initialized', 
       variationIndex: 0,
       reason: { kind: 'OFF' },
     });
+  });
+
+  it('logs the last known values warning once for repeated evaluations', async () => {
+    await client.variation('flagkey', defaultUser, 'default');
+    await client.variation('flagkey', defaultUser, 'default');
+    await client.variationDetail('flagkey', defaultUser, 'default');
+
+    expect(logger.getCount(LogLevel.Warn)).toEqual(1);
+    logger.expectMessages([
+      { level: LogLevel.Warn, matches: /using last known values from feature store/ },
+    ]);
+  });
+
+  it('logs the allFlagsState last known values warning once for repeated calls', async () => {
+    await client.allFlagsState(defaultUser);
+    await client.allFlagsState(defaultUser);
+
+    expect(logger.getCount(LogLevel.Warn)).toEqual(1);
+    logger.expectMessages([
+      { level: LogLevel.Warn, matches: /using last known values from data store/ },
+    ]);
   });
 });

--- a/packages/shared/sdk-server/src/LDClientImpl.ts
+++ b/packages/shared/sdk-server/src/LDClientImpl.ts
@@ -584,6 +584,12 @@ function constructFDv2(
 export default class LDClientImpl implements LDClient {
   private _initState: InitState = InitState.Initializing;
 
+  // The last-known-values warning is logged once per client.
+  private _lastKnownValuesWarningLogged = false;
+
+  // The allFlagsState last-known-values warning is logged once per client.
+  private _allFlagsStateLastKnownValuesWarningLogged = false;
+
   private _featureStore: LDFeatureStore | LDTransactionalFeatureStore;
 
   private _updateProcessor?: subsystem.LDStreamProcessor;
@@ -1187,10 +1193,13 @@ export default class LDClientImpl implements LDClient {
         this._featureStore.initialized((storeInitialized) => {
           let valid = true;
           if (storeInitialized) {
-            this._logger?.warn(
-              'Called allFlagsState before client initialization; using last known' +
-                ' values from data store',
-            );
+            if (!this._allFlagsStateLastKnownValuesWarningLogged) {
+              this._allFlagsStateLastKnownValuesWarningLogged = true;
+              this._logger?.warn(
+                'Called allFlagsState before client initialization; using last known' +
+                  ' values from data store. This message is logged once.',
+              );
+            }
           } else {
             this._logger?.warn(
               'Called allFlagsState before client initialization. Data store not available; ' +
@@ -1380,10 +1389,14 @@ export default class LDClientImpl implements LDClient {
     if (!this.initialized()) {
       this._featureStore.initialized((storeInitialized) => {
         if (storeInitialized) {
-          this._logger?.warn(
-            'Variation called before LaunchDarkly client initialization completed' +
-              " (did you wait for the 'ready' event?) - using last known values from feature store",
-          );
+          if (!this._lastKnownValuesWarningLogged) {
+            this._lastKnownValuesWarningLogged = true;
+            this._logger?.warn(
+              'Variation called before LaunchDarkly client initialization completed' +
+                " (did you wait for the 'ready' event?) - using last known values from feature store." +
+                ' This message is logged once.',
+            );
+          }
           this._variationInternal(flagKey, context, defaultValue, eventFactory, cb, typeChecker);
           return;
         }


### PR DESCRIPTION
## Summary

When a variation or allFlagsState call arrives before the client has finished initializing and the feature store already holds data, the server client evaluates against that data and logs a warning. The warning is logged on every such call, so a client that is waiting on its data source while serving from a populated store (for example, a persistent store or an initializer snapshot) floods the log at the evaluation rate.

Both warnings are now logged once per client instance. A private boolean per message records that it was logged. The check and the write happen only inside the branch where the store reports initialized, so a normal evaluation does not touch them. JavaScript is single-threaded, so no synchronization is needed. Each message ends with a note that it is logged once.

The sibling messages for an uninitialized store, which return the default value or an empty state, are unchanged.

This package is shared by the Node server SDK and the edge SDKs, so all of them pick up the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Pre-init evaluations against an **already-initialized feature store** no longer spam logs: `LDClientImpl` tracks two per-client flags so the **variation** path and **`allFlagsState`** each emit their “using last known values” warning **at most once**, with copy noting the message is logged once.
> 
> Behavior is unchanged—still evaluates from cached store data when the client is not ready but the store has data. Warnings for an **uninitialized** store (defaults / empty state) are untouched. Tests in `LDClient.evaluation.test.ts` assert a single warn after repeated `variation`, `variationDetail`, and `allFlagsState` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433c9209332fb829d7350c70c7cf1490f48cdc02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->